### PR TITLE
Track 00_shared/bibliography.bib symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,6 @@
 **/contents/figures/compiled/
 **/contents/tables/compiled/
 
-# Auto-generated symlinks and merged files
-00_shared/bibliography.bib
-
 # Revision working files
 **/contents/editor/*_revision.tex
 **/contents/reviewer*/*_revision.tex

--- a/00_shared/bibliography.bib
+++ b/00_shared/bibliography.bib
@@ -1,0 +1,1 @@
+bib_files/bibliography.bib


### PR DESCRIPTION
## Summary
- Remove gitignore rule that was excluding the bibliography symlink
- Ensures the symlink is available when cloning the template

🤖 Generated with [Claude Code](https://claude.com/claude-code)