### PR TITLE
feat: Improve script portability and MCP instructions

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -18,9 +18,9 @@ cd "$PROJECT_ROOT" || exit 1
 
 # Auto-initialize project if preprocessing artifacts are missing (Issue #12)
 if [ ! -f "01_manuscript/contents/wordcounts/figure_count.txt" ]; then
-    if [ -x "scripts/installation/init_project.sh" ]; then
+    if [ -x "$PROJECT_ROOT/scripts/installation/init_project.sh" ]; then
         echo "Initializing project (missing preprocessing artifacts)..."
-        ./scripts/installation/init_project.sh >/dev/null 2>&1 || true
+        "$PROJECT_ROOT/scripts/installation/init_project.sh" >/dev/null 2>&1 || true
     fi
 fi
 
@@ -123,21 +123,21 @@ show_help_recursive() {
     echo -e "${BOLD_CYAN}━━━ compile.sh manuscript ━━━${NC}"
     echo -e "${GRAY}./scripts/shell/compile_manuscript.sh${NC}"
     echo ""
-    ./scripts/shell/compile_manuscript.sh --help 2>/dev/null || echo "(No help available)"
+    "$PROJECT_ROOT/scripts/shell/compile_manuscript.sh" --help 2>/dev/null || echo "(No help available)"
     echo ""
     echo -e "${CYAN}────────────────────────────────────────────────────────────────────${NC}"
     echo ""
     echo -e "${BOLD_CYAN}━━━ compile.sh supplementary ━━━${NC}"
     echo -e "${GRAY}./scripts/shell/compile_supplementary.sh${NC}"
     echo ""
-    ./scripts/shell/compile_supplementary.sh --help 2>/dev/null || echo "(No help available)"
+    "$PROJECT_ROOT/scripts/shell/compile_supplementary.sh" --help 2>/dev/null || echo "(No help available)"
     echo ""
     echo -e "${CYAN}────────────────────────────────────────────────────────────────────${NC}"
     echo ""
     echo -e "${BOLD_CYAN}━━━ compile.sh revision ━━━${NC}"
     echo -e "${GRAY}./scripts/shell/compile_revision.sh${NC}"
     echo ""
-    ./scripts/shell/compile_revision.sh --help 2>/dev/null || echo "(No help available)"
+    "$PROJECT_ROOT/scripts/shell/compile_revision.sh" --help 2>/dev/null || echo "(No help available)"
     echo ""
 }
 
@@ -221,7 +221,7 @@ echo ""
 # Handle watch mode
 if [ "$WATCH_MODE" = true ]; then
     # Run watch script for manuscript
-    ./scripts/shell/watch_compile.sh "$REMAINING_ARGS"
+    "$PROJECT_ROOT/scripts/shell/watch_compile.sh" "$REMAINING_ARGS"
     exit $?
 fi
 
@@ -229,13 +229,13 @@ fi
 # Note: Use ${VAR:+$VAR} to only pass args when non-empty (avoid passing "" as an argument)
 case $DOC_TYPE in
 manuscript)
-    ./scripts/shell/compile_manuscript.sh ${REMAINING_ARGS:+$REMAINING_ARGS}
+    "$PROJECT_ROOT/scripts/shell/compile_manuscript.sh" ${REMAINING_ARGS:+$REMAINING_ARGS}
     ;;
 supplementary)
-    ./scripts/shell/compile_supplementary.sh ${REMAINING_ARGS:+$REMAINING_ARGS}
+    "$PROJECT_ROOT/scripts/shell/compile_supplementary.sh" ${REMAINING_ARGS:+$REMAINING_ARGS}
     ;;
 revision)
-    ./scripts/shell/compile_revision.sh ${REMAINING_ARGS:+$REMAINING_ARGS}
+    "$PROJECT_ROOT/scripts/shell/compile_revision.sh" ${REMAINING_ARGS:+$REMAINING_ARGS}
     ;;
 *)
     echo "Error: Unknown document type: $DOC_TYPE"

--- a/scripts/shell/compile_manuscript.sh
+++ b/scripts/shell/compile_manuscript.sh
@@ -64,7 +64,7 @@ echo_header() { log_stage_start "$1"; }
 
 # Configurations
 export SCITEX_WRITER_DOC_TYPE="manuscript"
-source ./config/load_config.sh "$SCITEX_WRITER_DOC_TYPE"
+source "$PROJECT_ROOT/config/load_config.sh" "$SCITEX_WRITER_DOC_TYPE"
 echo
 
 # Log
@@ -253,17 +253,17 @@ main() {
 
     # Check dependencies
     log_stage_start "Dependency Check"
-    ./scripts/shell/modules/check_dependancy_commands.sh
+    "$PROJECT_ROOT/scripts/shell/modules/check_dependancy_commands.sh"
     log_stage_end "Dependency Check"
 
     # Merge bibliography files if multiple exist
     log_stage_start "Bibliography Merge"
-    ./scripts/shell/modules/merge_bibliographies.sh
+    "$PROJECT_ROOT/scripts/shell/modules/merge_bibliographies.sh"
     log_stage_end "Bibliography Merge"
 
     # Apply citation style from config
     log_stage_start "Citation Style"
-    ./scripts/shell/modules/apply_citation_style.sh
+    "$PROJECT_ROOT/scripts/shell/modules/apply_citation_style.sh"
     log_stage_end "Citation Style"
 
     # Run independent processing in parallel for speed
@@ -278,19 +278,19 @@ main() {
 
     # Run all three in parallel
     (
-        ./scripts/shell/modules/process_figures.sh "$no_figs" "$do_p2t" "$do_verbose" "$do_crop_tif" >"$fig_log" 2>&1
+        "$PROJECT_ROOT/scripts/shell/modules/process_figures.sh" "$no_figs" "$do_p2t" "$do_verbose" "$do_crop_tif" >"$fig_log" 2>&1
         echo $? >"$temp_dir/fig_exit"
     ) &
     local fig_pid=$!
 
     (
-        ./scripts/shell/modules/process_tables.sh "$no_tables" >"$tbl_log" 2>&1
+        "$PROJECT_ROOT/scripts/shell/modules/process_tables.sh" "$no_tables" >"$tbl_log" 2>&1
         echo $? >"$temp_dir/tbl_exit"
     ) &
     local tbl_pid=$!
 
     (
-        ./scripts/shell/modules/count_words.sh >"$wrd_log" 2>&1
+        "$PROJECT_ROOT/scripts/shell/modules/count_words.sh" >"$wrd_log" 2>&1
         echo $? >"$temp_dir/wrd_exit"
     ) &
     local wrd_pid=$!
@@ -336,12 +336,12 @@ main() {
 
     # Compile documents
     log_stage_start "TeX Compilation (Structure)"
-    ./scripts/shell/modules/compilation_structure_tex_to_compiled_tex.sh
+    "$PROJECT_ROOT/scripts/shell/modules/compilation_structure_tex_to_compiled_tex.sh"
     log_stage_end "TeX Compilation (Structure)"
 
     # Engine Selection
     log_stage_start "Engine Selection"
-    source ./scripts/shell/modules/select_compilation_engine.sh
+    source "$PROJECT_ROOT/scripts/shell/modules/select_compilation_engine.sh"
 
     # Get engine from config or default to auto
     SELECTED_ENGINE="${SCITEX_WRITER_ENGINE:-auto}"
@@ -369,13 +369,13 @@ main() {
 
     # TeX to PDF
     log_stage_start "PDF Generation"
-    ./scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
+    "$PROJECT_ROOT/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh"
     log_stage_end "PDF Generation"
 
     # Diff (skip if --no_diff specified)
     if [ "$no_diff" = false ]; then
         log_stage_start "Diff Generation"
-        ./scripts/shell/modules/process_diff.sh
+        "$PROJECT_ROOT/scripts/shell/modules/process_diff.sh"
         log_stage_end "Diff Generation"
     else
         echo_info "Skipping diff generation (--no_diff specified)"
@@ -383,17 +383,17 @@ main() {
 
     # Versioning
     log_stage_start "Archive/Versioning"
-    ./scripts/shell/modules/process_archive.sh
+    "$PROJECT_ROOT/scripts/shell/modules/process_archive.sh"
     log_stage_end "Archive/Versioning"
 
     # Cleanup
     log_stage_start "Cleanup"
-    ./scripts/shell/modules/cleanup.sh
+    "$PROJECT_ROOT/scripts/shell/modules/cleanup.sh"
     log_stage_end "Cleanup"
 
     # Final steps
     log_stage_start "Directory Tree"
-    ./scripts/shell/modules/custom_tree.sh
+    "$PROJECT_ROOT/scripts/shell/modules/custom_tree.sh"
     log_stage_end "Directory Tree"
 
     # Final summary

--- a/src/scitex_writer/_mcp.py
+++ b/src/scitex_writer/_mcp.py
@@ -22,28 +22,49 @@ Project Structure:
   02_supplementary/    - Supplementary materials
   03_revision/         - Revision responses
 
-Quick Start:
-  ./compile.sh manuscript       # Compile manuscript
-  ./compile.sh supplementary    # Compile supplementary
-  ./compile.sh revision         # Compile revision
-  ./compile.sh --help-recursive # Full documentation
+Compilation (IMPORTANT for AI Agents):
+  ALWAYS use absolute path to avoid working directory issues:
+    /path/to/project/compile.sh manuscript --draft --quiet
 
-Editable Files (manuscript):
+  If BASH_ENV causes issues (e.g., in Claude Code), use:
+    env -u BASH_ENV /bin/bash -c '/path/to/project/compile.sh manuscript --draft'
+
+  Fast compilation (recommended for iterative editing):
+    /path/to/project/compile.sh manuscript --draft --no_diff --quiet
+
+  Full compilation with diff:
+    /path/to/project/compile.sh manuscript
+
+Editable Files (IMRAD structure):
   01_manuscript/contents/abstract.tex
   01_manuscript/contents/introduction.tex
   01_manuscript/contents/methods.tex
   01_manuscript/contents/results.tex
   01_manuscript/contents/discussion.tex
-  01_manuscript/contents/figures/caption_and_media/
-  01_manuscript/contents/tables/caption_and_media/
 
-Figure Naming:
-  01_my_figure.png + 01_my_figure.tex (caption)
-  Cite: \\ref{fig:my_figure_01}
+Figures:
+  Location: 01_manuscript/contents/figures/caption_and_media/
+  Naming:   01_my_figure.png + 01_my_figure.tex (caption)
+  Caption file format:
+    %% Figure caption
+    \\caption{Your caption here.}
+    \\label{fig:my_figure_01}
+  Cite: \\ref{fig:my_figure_01} or Figure~\\ref{fig:my_figure_01}
 
-Table Naming:
-  01_my_table.csv + 01_my_table.tex (caption)
-  Cite: \\ref{tab:my_table_01}
+Tables:
+  Location: 01_manuscript/contents/tables/caption_and_media/
+  Naming:   01_my_table.csv + 01_my_table.tex (caption)
+  Caption file format:
+    %% Table caption
+    \\caption{Your caption here.}
+    \\label{tab:my_table_01}
+  Cite: \\ref{tab:my_table_01} or Table~\\ref{tab:my_table_01}
+
+Bibliography:
+  Location: 00_shared/bib_files/
+  Single file: Name it bibliography.bib to skip merge step
+  Multiple files: Requires bibtexparser (pip install bibtexparser)
+  Cite: \\cite{AuthorYear} e.g., \\cite{Lamport1994}
 
 Compile Options:
   --draft      Single-pass compilation (~5s faster)
@@ -54,9 +75,14 @@ Compile Options:
   --quiet      Minimal output
 
 Output:
-  01_manuscript/manuscript.pdf
+  01_manuscript/manuscript.pdf        - Main document
+  01_manuscript/manuscript_diff.pdf   - Changes from last commit (red=deleted, blue=added)
   02_supplementary/supplementary.pdf
   03_revision/revision.pdf
+
+Version Control:
+  Git commit before compiling to enable diff generation
+  Diff compares: last commit -> current (uncommitted) changes
 """
 
 mcp = FastMCP(


### PR DESCRIPTION
## Summary
- Use `$PROJECT_ROOT` instead of relative paths in shell scripts
- Enhance MCP instructions for AI agents

## Changes
- `compile.sh` - Use absolute paths for subscript calls
- `scripts/shell/compile_manuscript.sh` - Same path fixes
- `src/scitex_writer/_mcp.py` - Enhanced instructions:
  - Absolute path guidance
  - BASH_ENV workaround for Claude Code
  - Figure/table caption format examples
  - Bibliography tips
  - Output PDF explanations
  - Version control guidance

From demo session handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)