### PR TITLE
feat: Add compile.content() for raw LaTeX compilation with color modes

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -1,4 +1,4 @@
-# SciTeX Writer MCP Tools (28 total)
+# SciTeX Writer MCP Tools (29 total)
 
 Model Context Protocol tools for AI agent integration.
 
@@ -15,7 +15,8 @@ scitex-writer mcp start         # Start MCP server (stdio)
 |  | `add_figure` | Add a figure (copy image + create caption) to the  |
 |  | `add_table` | Add a new table (CSV + caption) to the project. |
 | **clone** (1) | `clone_project` | Create a new LaTeX manuscript project from templat |
-| **compile** (3) | `compile_manuscript` | Compile manuscript LaTeX document to PDF. |
+| **compile** (4) | `compile_content` | Compile raw LaTeX content to PDF with color mode. |
+|  | `compile_manuscript` | Compile manuscript LaTeX document to PDF. |
 |  | `compile_revision` | Compile revision document to PDF with optional cha |
 |  | `compile_supplementary` | Compile supplementary materials LaTeX document to  |
 | **convert** (1) | `convert_figure` | Convert figure between formats (e.g., PDF to PNG). |

--- a/src/scitex_writer/_mcp/content.py
+++ b/src/scitex_writer/_mcp/content.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Timestamp: 2026-01-27
+# File: src/scitex_writer/_mcp/content.py
+
+"""Content compilation for LaTeX snippets and sections.
+
+Provides quick compilation of raw LaTeX content with color mode support.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Literal, Optional
+
+from .utils import resolve_project_path
+
+
+def compile_content(
+    latex_content: str,
+    project_dir: Optional[str] = None,
+    color_mode: Literal["light", "dark", "sepia", "paper"] = "light",
+    section_name: str = "content",
+    timeout: int = 60,
+    keep_aux: bool = False,
+) -> dict:
+    """Compile raw LaTeX content to PDF.
+
+    Creates a standalone document from the provided LaTeX content and compiles
+    it to PDF. Supports various color modes for comfortable viewing and can
+    link to project bibliography for citation rendering.
+
+    Args:
+        latex_content: Raw LaTeX content to compile. Can be:
+            - A complete document (with \\documentclass)
+            - Document body only (will be wrapped automatically)
+        project_dir: Optional path to scitex-writer project for bibliography.
+        color_mode: Color theme for output:
+            - 'light': Default white background
+            - 'dark': Dark gray background with light text
+            - 'sepia': Warm cream background for comfortable reading
+            - 'paper': Pure white, optimized for printing
+        section_name: Name for the output (used in filename).
+        timeout: Compilation timeout in seconds.
+        keep_aux: Keep auxiliary files (.aux, .log, etc.) after compilation.
+
+    Returns:
+        Dict with success status, output_pdf path, log, and any errors.
+    """
+    try:
+        temp_dir = Path(tempfile.mkdtemp(prefix=f"scitex_content_{section_name}_"))
+        tex_file = temp_dir / f"{section_name}.tex"
+        pdf_file = temp_dir / f"{section_name}.pdf"
+
+        is_complete_document = "\\documentclass" in latex_content
+
+        if is_complete_document:
+            final_content = _inject_color_mode(latex_content, color_mode)
+        else:
+            final_content = _create_content_document(
+                latex_content, color_mode, project_dir
+            )
+
+        tex_file.write_text(final_content, encoding="utf-8")
+
+        if project_dir:
+            _setup_bibliography(temp_dir, project_dir)
+
+        cmd = [
+            "latexmk",
+            "-pdf",
+            "-interaction=nonstopmode",
+            "-halt-on-error",
+            f"-jobname={section_name}",
+            str(tex_file),
+        ]
+
+        result = subprocess.run(
+            cmd,
+            cwd=str(temp_dir),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+        log_content = _read_log_file(temp_dir, section_name)
+
+        if not keep_aux:
+            _cleanup_aux_files(temp_dir, section_name)
+
+        if result.returncode == 0 and pdf_file.exists():
+            return {
+                "success": True,
+                "output_pdf": str(pdf_file),
+                "temp_dir": str(temp_dir),
+                "color_mode": color_mode,
+                "log": log_content,
+                "message": f"Content compiled successfully: {section_name}",
+            }
+        else:
+            return {
+                "success": False,
+                "output_pdf": None,
+                "temp_dir": str(temp_dir),
+                "color_mode": color_mode,
+                "log": log_content,
+                "stdout": result.stdout[-2000:]
+                if len(result.stdout) > 2000
+                else result.stdout,
+                "stderr": result.stderr[-2000:]
+                if len(result.stderr) > 2000
+                else result.stderr,
+                "error": f"Compilation failed with exit code {result.returncode}",
+            }
+
+    except subprocess.TimeoutExpired:
+        return {
+            "success": False,
+            "error": f"Content compilation timed out after {timeout} seconds",
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "error": str(e),
+        }
+
+
+def _setup_bibliography(temp_dir: Path, project_dir: str) -> None:
+    """Set up bibliography files in temp directory."""
+    project_path = resolve_project_path(project_dir)
+    bib_dir = project_path / "00_shared" / "bib_files"
+    if bib_dir.exists():
+        for bib_file in bib_dir.glob("*.bib"):
+            link_path = temp_dir / bib_file.name
+            if not link_path.exists():
+                link_path.symlink_to(bib_file)
+
+
+def _read_log_file(temp_dir: Path, section_name: str) -> str:
+    """Read and truncate log file content."""
+    log_file = temp_dir / f"{section_name}.log"
+    if log_file.exists():
+        content = log_file.read_text(encoding="utf-8", errors="replace")
+        return content[-5000:] if len(content) > 5000 else content
+    return ""
+
+
+def _cleanup_aux_files(temp_dir: Path, section_name: str) -> None:
+    """Remove auxiliary files from compilation."""
+    aux_extensions = [
+        ".aux",
+        ".log",
+        ".fls",
+        ".fdb_latexmk",
+        ".synctex.gz",
+        ".out",
+        ".bbl",
+        ".blg",
+        ".toc",
+        ".lof",
+        ".lot",
+    ]
+    for ext in aux_extensions:
+        aux_file = temp_dir / f"{section_name}{ext}"
+        if aux_file.exists():
+            aux_file.unlink()
+
+
+def _inject_color_mode(latex_content: str, color_mode: str) -> str:
+    """Inject color mode styling into an existing LaTeX document."""
+    color_commands = _get_color_commands(color_mode)
+    if not color_commands:
+        return latex_content
+
+    begin_doc_pattern = r"(\\begin\{document\})"
+    match = re.search(begin_doc_pattern, latex_content)
+
+    if match:
+        insert_pos = match.end()
+        return (
+            latex_content[:insert_pos]
+            + "\n"
+            + color_commands
+            + "\n"
+            + latex_content[insert_pos:]
+        )
+    else:
+        return color_commands + "\n" + latex_content
+
+
+def _get_color_commands(color_mode: str) -> str:
+    """Get LaTeX color commands for the specified color mode."""
+    color_configs = {
+        "light": "",
+        "dark": """% Dark mode styling
+\\pagecolor{black!95!white}
+\\color{white}
+\\makeatletter
+\\@ifpackageloaded{hyperref}{%
+  \\hypersetup{
+    colorlinks=true,
+    linkcolor=cyan!80!white,
+    citecolor=green!70!white,
+    urlcolor=blue!60!white,
+  }%
+}{}
+\\makeatother""",
+        "sepia": """% Sepia mode styling
+\\pagecolor{Sepia!15!white}
+\\color{black!85!Sepia}
+\\makeatletter
+\\@ifpackageloaded{hyperref}{%
+  \\hypersetup{
+    colorlinks=true,
+    linkcolor=brown!70!black,
+    citecolor=olive!70!black,
+    urlcolor=teal!70!black,
+  }%
+}{}
+\\makeatother""",
+        "paper": "",
+    }
+    return color_configs.get(color_mode, "")
+
+
+def _create_content_document(
+    body_content: str, color_mode: str, project_dir: Optional[str]
+) -> str:
+    """Create a complete LaTeX document wrapping the body content."""
+    color_commands = _get_color_commands(color_mode)
+    bib_line = "\\bibliography{bibliography}" if project_dir else ""
+
+    return f"""\\documentclass[11pt]{{article}}
+
+% Essential packages
+\\usepackage[english]{{babel}}
+\\usepackage[T1]{{fontenc}}
+\\usepackage[utf8]{{inputenc}}
+\\usepackage[table,svgnames]{{xcolor}}
+\\usepackage{{amsmath, amssymb}}
+\\usepackage{{graphicx}}
+\\usepackage{{booktabs}}
+\\usepackage{{hyperref}}
+\\usepackage[numbers]{{natbib}}
+\\usepackage{{geometry}}
+\\geometry{{margin=1in}}
+\\usepackage{{pagecolor}}
+
+\\begin{{document}}
+{color_commands}
+{body_content}
+
+{bib_line}
+\\end{{document}}
+"""
+
+
+__all__ = ["compile_content"]
+
+# EOF

--- a/src/scitex_writer/_mcp/tools/compile.py
+++ b/src/scitex_writer/_mcp/tools/compile.py
@@ -90,5 +90,30 @@ def register_tools(mcp: FastMCP) -> None:
             quiet,
         )
 
+    @mcp.tool()
+    def compile_content(
+        latex_content: str,
+        project_dir: str | None = None,
+        color_mode: str = "light",
+        name: str = "content",
+        timeout: int = 60,
+        keep_aux: bool = False,
+    ) -> dict:
+        """[writer] Compile raw LaTeX content to PDF with color mode support.
+
+        Compiles provided LaTeX content to PDF. Supports color modes:
+        'light', 'dark', 'sepia', 'paper'.
+        """
+        from ..content import compile_content as _compile_content
+
+        return _compile_content(
+            latex_content,
+            project_dir,
+            color_mode,
+            name,
+            timeout,
+            keep_aux,
+        )
+
 
 # EOF

--- a/src/scitex_writer/compile.py
+++ b/src/scitex_writer/compile.py
@@ -18,6 +18,13 @@ Usage::
     # Compile other document types
     result = sw.compile.supplementary("./my-paper")
     result = sw.compile.revision("./my-paper", track_changes=True)
+
+    # Compile raw LaTeX content with color mode support
+    result = sw.compile.content(
+        latex_content,
+        project_dir="./my-paper",  # Optional, for bibliography
+        color_mode="dark",         # 'light', 'dark', 'sepia', 'paper'
+    )
 """
 
 from ._mcp.handlers import compile_manuscript as _compile_manuscript
@@ -130,6 +137,66 @@ def revision(
     )
 
 
-__all__ = ["manuscript", "supplementary", "revision"]
+def content(
+    latex_content: str,
+    project_dir: str | None = None,
+    color_mode: str = "light",
+    name: str = "content",
+    timeout: int = 60,
+    keep_aux: bool = False,
+) -> dict:
+    """Compile raw LaTeX content to PDF.
+
+    Creates a standalone document from the provided LaTeX content and compiles
+    it to PDF. Supports color modes for comfortable viewing and can link to
+    project bibliography for citation rendering.
+
+    Args:
+        latex_content: Raw LaTeX content to compile. Can be:
+            - A complete document (with \\documentclass)
+            - Document body only (will be wrapped automatically)
+        project_dir: Optional path to scitex-writer project for bibliography.
+        color_mode: Color theme for output:
+            - 'light': Default white background
+            - 'dark': Dark gray background with light text
+            - 'sepia': Warm cream background for comfortable reading
+            - 'paper': Pure white, optimized for printing
+        name: Name for the output (used in filename).
+        timeout: Compilation timeout in seconds.
+        keep_aux: Keep auxiliary files (.aux, .log, etc.) after compilation.
+
+    Returns:
+        Dict with success status, output_pdf path, log, and any errors.
+
+    Example::
+
+        import scitex_writer as sw
+
+        # Compile simple content
+        result = sw.compile.content(
+            r"\\section{Introduction}\\nThis is my introduction.",
+            color_mode="dark",
+        )
+
+        # With project bibliography
+        result = sw.compile.content(
+            latex_content,
+            project_dir="./my-paper",
+            color_mode="sepia",
+        )
+    """
+    from ._mcp.content import compile_content as _compile_content
+
+    return _compile_content(
+        latex_content,
+        project_dir=project_dir,
+        color_mode=color_mode,
+        section_name=name,
+        timeout=timeout,
+        keep_aux=keep_aux,
+    )
+
+
+__all__ = ["manuscript", "supplementary", "revision", "content"]
 
 # EOF

--- a/tests/python/test_compile_content.py
+++ b/tests/python/test_compile_content.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Timestamp: 2026-01-27
+# File: tests/python/test_compile_content.py
+
+"""Tests for scitex_writer compile.content functionality."""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+class TestContentModule:
+    """Test content module can be imported."""
+
+    def test_content_import(self):
+        """Test that content module can be imported."""
+        from scitex_writer._mcp.content import compile_content
+
+        assert callable(compile_content)
+
+    def test_content_via_compile_module(self):
+        """Test that content is accessible via compile module."""
+        from scitex_writer import compile
+
+        assert callable(compile.content)
+
+
+class TestContentHelpers:
+    """Test content helper functions."""
+
+    def test_get_color_commands_light(self):
+        """Test light mode returns empty string."""
+        from scitex_writer._mcp.content import _get_color_commands
+
+        result = _get_color_commands("light")
+        assert result == ""
+
+    def test_get_color_commands_dark(self):
+        """Test dark mode returns color commands."""
+        from scitex_writer._mcp.content import _get_color_commands
+
+        result = _get_color_commands("dark")
+        assert "pagecolor" in result
+        assert "black" in result
+        assert "white" in result
+
+    def test_get_color_commands_sepia(self):
+        """Test sepia mode returns color commands."""
+        from scitex_writer._mcp.content import _get_color_commands
+
+        result = _get_color_commands("sepia")
+        assert "pagecolor" in result
+        assert "Sepia" in result
+
+    def test_get_color_commands_paper(self):
+        """Test paper mode returns empty string."""
+        from scitex_writer._mcp.content import _get_color_commands
+
+        result = _get_color_commands("paper")
+        assert result == ""
+
+    def test_get_color_commands_unknown(self):
+        """Test unknown mode returns empty string."""
+        from scitex_writer._mcp.content import _get_color_commands
+
+        result = _get_color_commands("unknown")
+        assert result == ""
+
+
+class TestContentDocumentCreation:
+    """Test content document creation."""
+
+    def test_create_content_document_basic(self):
+        """Test creating a basic content document."""
+        from scitex_writer._mcp.content import _create_content_document
+
+        body = r"\section{Test}\nThis is a test."
+        result = _create_content_document(body, "light", None)
+
+        assert "\\documentclass" in result
+        assert "\\begin{document}" in result
+        assert "\\end{document}" in result
+        assert body in result
+
+    def test_create_content_document_with_color(self):
+        """Test creating content document with dark mode."""
+        from scitex_writer._mcp.content import _create_content_document
+
+        body = "Test content"
+        result = _create_content_document(body, "dark", None)
+
+        assert "pagecolor" in result
+        assert "black" in result
+
+    def test_inject_color_mode_into_document(self):
+        """Test injecting color mode into existing document."""
+        from scitex_writer._mcp.content import _inject_color_mode
+
+        doc = r"\documentclass{article}\begin{document}Content\end{document}"
+        result = _inject_color_mode(doc, "dark")
+
+        assert "pagecolor" in result
+        # Color commands should be after \begin{document}
+        begin_doc_pos = result.find(r"\begin{document}")
+        pagecolor_pos = result.find("pagecolor")
+        assert pagecolor_pos > begin_doc_pos
+
+
+class TestContentCompilation:
+    """Test content compilation (requires latexmk)."""
+
+    @pytest.fixture
+    def has_latexmk(self):
+        """Check if latexmk is available."""
+        return shutil.which("latexmk") is not None
+
+    def test_compile_simple_content(self, has_latexmk):
+        """Test compiling simple LaTeX content."""
+        if not has_latexmk:
+            pytest.skip("latexmk not available")
+
+        from scitex_writer import compile
+
+        content = r"""
+\documentclass{article}
+\begin{document}
+Hello, World!
+\end{document}
+"""
+        result = compile.content(content, name="test_simple")
+
+        assert result["success"] is True
+        assert result["output_pdf"] is not None
+        assert Path(result["output_pdf"]).exists()
+
+        # Cleanup
+        temp_dir = Path(result["temp_dir"])
+        if temp_dir.exists():
+            shutil.rmtree(temp_dir)
+
+    def test_compile_body_only(self, has_latexmk):
+        """Test compiling body-only content (auto-wrapped)."""
+        if not has_latexmk:
+            pytest.skip("latexmk not available")
+
+        from scitex_writer import compile
+
+        content = r"""
+\section{Introduction}
+
+This is the introduction.
+"""
+        result = compile.content(content, name="test_body")
+
+        assert result["success"] is True
+        assert result["output_pdf"] is not None
+
+        # Cleanup
+        temp_dir = Path(result["temp_dir"])
+        if temp_dir.exists():
+            shutil.rmtree(temp_dir)
+
+    def test_compile_with_dark_mode(self, has_latexmk):
+        """Test compiling with dark mode."""
+        if not has_latexmk:
+            pytest.skip("latexmk not available")
+
+        from scitex_writer import compile
+
+        content = r"""
+\documentclass{article}
+\usepackage{xcolor}
+\usepackage{pagecolor}
+\begin{document}
+Dark mode test.
+\end{document}
+"""
+        result = compile.content(content, color_mode="dark", name="test_dark")
+
+        assert result["success"] is True
+        assert result["color_mode"] == "dark"
+
+        # Cleanup
+        temp_dir = Path(result["temp_dir"])
+        if temp_dir.exists():
+            shutil.rmtree(temp_dir)
+
+    def test_compile_invalid_latex(self, has_latexmk):
+        """Test compiling invalid LaTeX content."""
+        if not has_latexmk:
+            pytest.skip("latexmk not available")
+
+        from scitex_writer import compile
+
+        content = r"""
+\documentclass{article}
+\begin{document}
+\invalid_command_that_does_not_exist
+\end{document}
+"""
+        result = compile.content(content, name="test_invalid")
+
+        assert result["success"] is False
+        assert "error" in result
+
+        # Cleanup
+        if "temp_dir" in result:
+            temp_dir = Path(result["temp_dir"])
+            if temp_dir.exists():
+                shutil.rmtree(temp_dir)
+
+    def test_compile_timeout(self, has_latexmk):
+        """Test compilation timeout."""
+        if not has_latexmk:
+            pytest.skip("latexmk not available")
+
+        from scitex_writer import compile
+
+        # Very short timeout to trigger timeout error
+        content = r"""
+\documentclass{article}
+\begin{document}
+Test
+\end{document}
+"""
+        # Note: timeout=1 might be too short even for simple docs on slow systems
+        # This test is more about verifying the timeout mechanism exists
+        result = compile.content(content, timeout=1, name="test_timeout")
+
+        # May succeed or timeout depending on system speed
+        assert "success" in result
+
+
+class TestMcpToolRegistration:
+    """Test MCP tool registration for content."""
+
+    def test_compile_content_tool_registered(self):
+        """Test that compile_content tool is registered with MCP."""
+        from scitex_writer._mcp import mcp
+
+        tool_names = [t.name for t in mcp._tool_manager._tools.values()]
+        assert "compile_content" in tool_names
+
+
+# EOF


### PR DESCRIPTION
## Summary
- Add new `compile.content()` function to compile raw LaTeX content to PDF
- Implements feature request #30

## Features
- **Python API**: `sw.compile.content(latex_content, color_mode="dark")`
- **CLI**: `scitex-writer compile content -f file.tex --color-mode dark`
- **MCP tool**: `compile_content`

## Key capabilities
- Compiles complete documents or body-only content (auto-wrapped)
- Color mode injection: light, dark, sepia, paper
- Bibliography linking from project directory
- Automatic cleanup of auxiliary files
- Configurable timeout

## Test plan
- [x] 16 unit tests for compile.content functionality
- [x] All 39 tests pass (compile_content + MCP tests)
- [x] CLI tested manually

Closes #30

🤖 Generated with [Claude Code](https://claude.ai/code)