### PR TITLE
feat: Add ensure_workspace()

### DIFF
--- a/src/scitex_writer/__init__.py
+++ b/src/scitex_writer/__init__.py
@@ -54,6 +54,37 @@ from ._usage import get_usage as usage
 # Import Writer class and dataclasses
 from .writer import Writer
 
+
+def ensure_workspace(project_dir, git_strategy="child", **kwargs):
+    """Ensure writer workspace exists at {project_dir}/scitex/writer/.
+
+    If the directory already exists, returns the path without modification.
+    If not, clones the full scitex-writer template.
+
+    Parameters
+    ----------
+    project_dir : str or Path
+        Root project directory. Writer workspace will be at
+        ``{project_dir}/scitex/writer/``.
+    git_strategy : str, optional
+        Git initialization strategy ('child', 'parent', 'origin', None).
+    **kwargs
+        Forwarded to Writer constructor (branch, tag, etc.).
+
+    Returns
+    -------
+    pathlib.Path
+        Path to the writer workspace directory.
+    """
+    from pathlib import Path
+
+    writer_path = Path(project_dir) / "scitex" / "writer"
+    if writer_path.exists():
+        return writer_path
+    Writer(str(writer_path), git_strategy=git_strategy, **kwargs)
+    return writer_path
+
+
 __all__ = [
     "__version__",
     # Branding
@@ -72,6 +103,7 @@ __all__ = [
     "prompts",
     # Writer class
     "Writer",
+    "ensure_workspace",
     # Dataclasses
     "CompilationResult",
     "ManuscriptTree",


### PR DESCRIPTION
## Summary
- Add `ensure_workspace()` to `scitex_writer.__init__` for lazy writer workspace creation
- Standardizes naming with `scitex.scholar.ensure_workspace()`

## Test plan
- [ ] `pip install -e .` and verify `from scitex_writer import ensure_workspace` works
- [ ] Verify `ensure_workspace(tmp_dir)` creates `{tmp}/scitex/writer/` structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)