### PR TITLE
chore: Track export submodule files

### DIFF
--- a/src/scitex_writer/export/_arxiv_categories.py
+++ b/src/scitex_writer/export/_arxiv_categories.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/export/_arxiv_categories.py
+
+"""arXiv category data and suggestion algorithm.
+
+Pure data structures and functions for arXiv subject classification.
+No Django or ORM dependencies.
+"""
+
+from typing import Dict, List, Tuple
+
+# Common arXiv categories
+ARXIV_CATEGORIES: List[Dict[str, str]] = [
+    # Computer Science
+    {
+        "code": "cs.AI",
+        "name": "Artificial Intelligence",
+        "description": "Covers all areas of AI",
+    },
+    {
+        "code": "cs.CL",
+        "name": "Computation and Language",
+        "description": "Natural language processing, computational linguistics",
+    },
+    {
+        "code": "cs.CV",
+        "name": "Computer Vision and Pattern Recognition",
+        "description": "Image processing, computer vision",
+    },
+    {
+        "code": "cs.LG",
+        "name": "Machine Learning",
+        "description": "Machine learning research",
+    },
+    {
+        "code": "cs.NI",
+        "name": "Networking and Internet Architecture",
+        "description": "Network protocols, internet architecture",
+    },
+    {
+        "code": "cs.SE",
+        "name": "Software Engineering",
+        "description": "Software development, engineering practices",
+    },
+    # Mathematics
+    {
+        "code": "math.ST",
+        "name": "Statistics Theory",
+        "description": "Mathematical statistics",
+    },
+    {"code": "math.PR", "name": "Probability", "description": "Probability theory"},
+    {
+        "code": "math.NA",
+        "name": "Numerical Analysis",
+        "description": "Numerical methods and analysis",
+    },
+    # Physics
+    {
+        "code": "physics.comp-ph",
+        "name": "Computational Physics",
+        "description": "Computational methods in physics",
+    },
+    {
+        "code": "physics.data-an",
+        "name": "Data Analysis, Statistics and Probability",
+        "description": "Data analysis in physics",
+    },
+    # Quantitative Biology
+    {
+        "code": "q-bio.BM",
+        "name": "Biomolecules",
+        "description": "Molecular biology, biochemistry",
+    },
+    {
+        "code": "q-bio.GN",
+        "name": "Genomics",
+        "description": "Genomics and bioinformatics",
+    },
+    {
+        "code": "q-bio.NC",
+        "name": "Neurons and Cognition",
+        "description": "Neuroscience, cognition",
+    },
+    # Statistics
+    {"code": "stat.AP", "name": "Applications", "description": "Applied statistics"},
+    {
+        "code": "stat.ML",
+        "name": "Machine Learning",
+        "description": "Statistical machine learning",
+    },
+    # Electrical Engineering
+    {
+        "code": "eess.SP",
+        "name": "Signal Processing",
+        "description": "Signal processing, filtering, detection",
+    },
+]
+
+# Keyword maps for category suggestion
+CATEGORY_KEYWORDS: Dict[str, List[str]] = {
+    "cs.AI": [
+        "artificial intelligence",
+        "ai",
+        "machine learning",
+        "deep learning",
+        "neural network",
+    ],
+    "cs.CL": [
+        "natural language",
+        "nlp",
+        "language model",
+        "text processing",
+        "linguistics",
+    ],
+    "cs.CV": ["computer vision", "image processing", "object detection", "recognition"],
+    "cs.LG": ["machine learning", "learning algorithm", "classification", "regression"],
+    "stat.ML": ["statistical learning", "bayesian", "statistics", "probabilistic"],
+    "math.ST": ["statistics", "statistical theory", "hypothesis testing"],
+    "q-bio.GN": ["genomics", "bioinformatics", "dna", "rna", "genome"],
+    "q-bio.NC": ["neuroscience", "brain", "neural", "eeg", "cognition", "hippocampus"],
+    "eess.SP": ["signal processing", "filtering", "spectral", "frequency", "wavelet"],
+}
+
+
+def suggest_categories(
+    content: str,
+    max_suggestions: int = 5,
+) -> List[Tuple[str, str, int]]:
+    """Suggest arXiv categories based on text content.
+
+    Args:
+        content: Text to analyse (typically title + abstract).
+        max_suggestions: Maximum number of suggestions to return.
+
+    Returns:
+        List of (code, name, score) tuples sorted by relevance score.
+    """
+    content_lower = content.lower()
+
+    # Build a code -> name lookup from ARXIV_CATEGORIES
+    code_to_name = {cat["code"]: cat["name"] for cat in ARXIV_CATEGORIES}
+
+    suggestions: List[Tuple[str, str, int]] = []
+    for code, keywords in CATEGORY_KEYWORDS.items():
+        score = sum(1 for kw in keywords if kw in content_lower)
+        if score > 0:
+            name = code_to_name.get(code, code)
+            suggestions.append((code, name, score))
+
+    suggestions.sort(key=lambda x: x[2], reverse=True)
+    return suggestions[:max_suggestions]
+
+
+# EOF

--- a/src/scitex_writer/export/_arxiv_cleaner.py
+++ b/src/scitex_writer/export/_arxiv_cleaner.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/export/_arxiv_cleaner.py
+
+"""LaTeX cleaning and validation for arXiv submission.
+
+Provides utilities for cleaning, validating, and normalizing
+LaTeX content to meet arXiv compliance requirements.
+"""
+
+import re
+
+
+class ArxivLatexCleaner:
+    """Clean and validate LaTeX content for arXiv compliance."""
+
+    def __init__(self):
+        # Packages to remove or replace
+        self.problematic_packages = {
+            "pstricks": None,  # Not supported on arXiv
+            "xy": "xymatrix",  # Replace with xymatrix
+            "pdfpages": None,  # Not allowed
+            "epstopdf": None,  # Automatic conversion
+        }
+
+        # arXiv-approved packages
+        self.approved_packages = {
+            "amsmath",
+            "amsfonts",
+            "amssymb",
+            "amsthm",
+            "graphicx",
+            "cite",
+            "natbib",
+            "biblatex",
+            "hyperref",
+            "url",
+            "geometry",
+            "fancyhdr",
+            "array",
+            "booktabs",
+            "longtable",
+            "multirow",
+            "algorithm",
+            "algorithmic",
+            "algorithm2e",
+            "listings",
+            "xcolor",
+            "tikz",
+            "pgfplots",
+            "subcaption",
+            "caption",
+            "float",
+        }
+
+    def clean_latex_for_arxiv(self, latex_content: str) -> str:
+        """Clean LaTeX content for arXiv compliance."""
+        latex_content = self.remove_problematic_packages(latex_content)
+        latex_content = self.fix_common_latex_issues(latex_content)
+        latex_content = self.validate_packages(latex_content)
+        latex_content = self.clean_formatting(latex_content)
+        return latex_content
+
+    def remove_problematic_packages(self, content: str) -> str:
+        """Remove or replace packages not supported by arXiv."""
+        for problematic, replacement in self.problematic_packages.items():
+            pattern = rf"\\usepackage(?:\[[^\]]*\])?\{{{problematic}\}}"
+            if replacement:
+                repl = f"\\usepackage{{{replacement}}}"
+                content = re.sub(pattern, lambda _: repl, content)
+            else:
+                content = re.sub(
+                    pattern, f"% Removed unsupported package: {problematic}", content
+                )
+        return content
+
+    def fix_common_latex_issues(self, content: str) -> str:
+        """Fix common LaTeX issues for arXiv."""
+        # Fix figure paths (remove absolute paths)
+        content = re.sub(
+            r"\\includegraphics\{[^}]*[/\\]([^/\\}]+)\}",
+            r"\\includegraphics{\1}",
+            content,
+        )
+
+        # Ensure UTF-8 encoding
+        if (
+            "\\usepackage[utf8]{inputenc}" not in content
+            and "\\documentclass" in content
+        ):
+            content = content.replace(
+                "\\documentclass", "\\usepackage[utf8]{inputenc}\n\\documentclass"
+            )
+
+        # Fix citation commands
+        content = re.sub(r"\\cite\s*\{([^}]+)\}", r"\\cite{\1}", content)
+
+        # Remove excessive whitespace
+        content = re.sub(r"\n\s*\n\s*\n", "\n\n", content)
+
+        return content
+
+    def validate_packages(self, content: str) -> str:
+        """Validate that only approved packages are used."""
+        package_pattern = r"\\usepackage(?:\[[^\]]*\])?\{([^}]+)\}"
+        packages = re.findall(package_pattern, content)
+
+        warnings = []
+        for package in packages:
+            if package not in self.approved_packages:
+                warnings.append(
+                    f"Warning: Package '{package}' may not be supported by arXiv"
+                )
+
+        if warnings:
+            warning_comment = (
+                "% arXiv Package Warnings:\n% " + "\n% ".join(warnings) + "\n\n"
+            )
+            content = warning_comment + content
+
+        return content
+
+    def clean_formatting(self, content: str) -> str:
+        """Clean up LaTeX formatting."""
+        content = re.sub(r"\s*\{\s*", "{", content)
+        content = re.sub(r"\s*\}\s*", "}", content)
+        content = re.sub(r"(?<!\\)\\\\(?!\s*\n)", "\\\\\n", content)
+        content = re.sub(r"%\s*$", "%", content, flags=re.MULTILINE)
+        return content
+
+    def clean_section_content(self, content: str) -> str:
+        """Clean individual section content."""
+        content = re.sub(r"^\\section\*?\{[^}]+\}\s*", "", content, flags=re.MULTILINE)
+        content = content.strip()
+        return content
+
+
+# EOF

--- a/src/scitex_writer/export/_arxiv_compliance.py
+++ b/src/scitex_writer/export/_arxiv_compliance.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/export/_arxiv_compliance.py
+
+"""Compliance checking for arXiv submission.
+
+Pure functions to validate manuscript metadata and LaTeX structure
+against arXiv submission requirements.  No Django or ORM dependencies.
+"""
+
+import re
+from typing import Any, Dict
+
+# arXiv limits
+MAX_TITLE_LENGTH = 256
+MAX_ABSTRACT_LENGTH = 1920
+MIN_ABSTRACT_LENGTH = 100
+
+
+def check_compliance(
+    title: str,
+    abstract: str,
+    latex_content: str,
+) -> Dict[str, Any]:
+    """Check manuscript compliance with arXiv requirements.
+
+    Args:
+        title: Manuscript title.
+        abstract: Manuscript abstract.
+        latex_content: Full LaTeX source.
+
+    Returns:
+        Dict with keys: is_compliant (bool), errors (list), warnings (list),
+        checks (dict of sub-check results).
+    """
+    result = {
+        "is_compliant": True,
+        "errors": [],
+        "warnings": [],
+        "checks": {},
+    }
+
+    title_check = _check_title(title)
+    result["checks"]["title"] = title_check
+    if not title_check["passed"]:
+        result["errors"].extend(title_check["errors"])
+        result["is_compliant"] = False
+
+    abstract_check = _check_abstract(abstract)
+    result["checks"]["abstract"] = abstract_check
+    if not abstract_check["passed"]:
+        result["errors"].extend(abstract_check["errors"])
+        result["is_compliant"] = False
+
+    latex_check = check_latex_structure(latex_content)
+    result["checks"]["latex"] = latex_check
+    if not latex_check["passed"]:
+        result["errors"].extend(latex_check["errors"])
+        result["is_compliant"] = False
+
+    return result
+
+
+def _check_title(title: str) -> Dict[str, Any]:
+    """Check title compliance."""
+    errors = []
+    warnings = []
+
+    if not title or not title.strip():
+        errors.append("Title is required")
+    elif len(title) > MAX_TITLE_LENGTH:
+        errors.append(f"Title exceeds maximum length of {MAX_TITLE_LENGTH} characters")
+
+    if title and len(title) < 10:
+        warnings.append("Title is very short")
+
+    return {"passed": len(errors) == 0, "errors": errors, "warnings": warnings}
+
+
+def _check_abstract(abstract: str) -> Dict[str, Any]:
+    """Check abstract compliance."""
+    errors = []
+    warnings = []
+
+    if not abstract or not abstract.strip():
+        errors.append("Abstract is required")
+    else:
+        if len(abstract) > MAX_ABSTRACT_LENGTH:
+            errors.append(
+                f"Abstract exceeds maximum length of {MAX_ABSTRACT_LENGTH} characters"
+            )
+        elif len(abstract) < MIN_ABSTRACT_LENGTH:
+            warnings.append(
+                f"Abstract is shorter than recommended minimum of {MIN_ABSTRACT_LENGTH} characters"
+            )
+
+    return {"passed": len(errors) == 0, "errors": errors, "warnings": warnings}
+
+
+def check_latex_structure(latex_content: str) -> Dict[str, Any]:
+    """Check LaTeX structure compliance.
+
+    Args:
+        latex_content: Full LaTeX source string.
+
+    Returns:
+        Dict with passed (bool), errors (list), warnings (list).
+    """
+    errors = []
+    warnings = []
+
+    if not re.search(r"\\documentclass", latex_content):
+        errors.append("Missing \\documentclass declaration")
+
+    if not re.search(r"\\begin\{document\}", latex_content):
+        errors.append("Missing \\begin{document}")
+    if not re.search(r"\\end\{document\}", latex_content):
+        errors.append("Missing \\end{document}")
+
+    if not re.search(r"\\title\{", latex_content):
+        warnings.append("Missing \\title command")
+    if not re.search(r"\\author\{", latex_content):
+        warnings.append("Missing \\author command")
+
+    return {"passed": len(errors) == 0, "errors": errors, "warnings": warnings}
+
+
+# EOF

--- a/src/scitex_writer/export/_arxiv_packager.py
+++ b/src/scitex_writer/export/_arxiv_packager.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/export/_arxiv_packager.py
+
+"""File packaging for arXiv submission.
+
+Pure functions to package manuscript files into arXiv-compatible
+zip archives with validation.  No Django or ORM dependencies.
+"""
+
+import zipfile
+from pathlib import Path
+from typing import List, Tuple
+
+# arXiv limits and allowed file types
+MAX_FILE_SIZE = 50 * 1024 * 1024  # 50 MB
+ALLOWED_EXTENSIONS = {
+    ".tex",
+    ".bib",
+    ".bbl",
+    ".cls",
+    ".sty",
+    ".eps",
+    ".ps",
+    ".pdf",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+}
+
+
+def package_submission(
+    work_dir: Path,
+    submission_id: str = "submission",
+) -> Path:
+    """Package all files for arXiv submission.
+
+    Args:
+        work_dir: Working directory containing manuscript files.
+        submission_id: Identifier for the output zip filename.
+
+    Returns:
+        Path to the created zip archive.
+
+    Raises:
+        ValueError: If the package exceeds the arXiv size limit.
+    """
+    work_dir = Path(work_dir)
+    package_path = work_dir / f"arxiv_submission_{submission_id}.zip"
+
+    with zipfile.ZipFile(package_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+        # Add main LaTeX file
+        if (work_dir / "main.tex").exists():
+            zipf.write(work_dir / "main.tex", "main.tex")
+
+        # Add bibliography
+        if (work_dir / "references.bib").exists():
+            zipf.write(work_dir / "references.bib", "references.bib")
+
+        # Add figures
+        figures_dir = work_dir / "figures"
+        if figures_dir.exists():
+            for figure_file in figures_dir.iterdir():
+                if (
+                    figure_file.is_file()
+                    and figure_file.suffix.lower() in ALLOWED_EXTENSIONS
+                ):
+                    zipf.write(figure_file, f"figures/{figure_file.name}")
+
+        # Add any additional allowed files
+        for file_path in work_dir.iterdir():
+            if (
+                file_path.is_file()
+                and file_path.suffix.lower() in ALLOWED_EXTENSIONS
+                and file_path.name not in ["main.tex", "references.bib"]
+            ):
+                zipf.write(file_path, file_path.name)
+
+    if package_path.stat().st_size > MAX_FILE_SIZE:
+        raise ValueError(
+            f"Submission package exceeds {MAX_FILE_SIZE / (1024 * 1024):.1f}MB limit"
+        )
+
+    return package_path
+
+
+def validate_file_types(work_dir: Path) -> Tuple[List[str], List[str]]:
+    """Validate file types in a directory against arXiv allowed types.
+
+    Args:
+        work_dir: Directory to validate.
+
+    Returns:
+        Tuple of (valid_files, invalid_files) as relative path strings.
+    """
+    work_dir = Path(work_dir)
+    valid_files = []
+    invalid_files = []
+
+    for file_path in work_dir.rglob("*"):
+        if file_path.is_file():
+            if file_path.suffix.lower() in ALLOWED_EXTENSIONS:
+                valid_files.append(str(file_path.relative_to(work_dir)))
+            else:
+                invalid_files.append(str(file_path.relative_to(work_dir)))
+
+    return valid_files, invalid_files
+
+
+# EOF


### PR DESCRIPTION
## Summary

- Track `src/scitex_writer/export/` submodule files that were previously caught by `**/export/` gitignore rule
- These are source code files needed for arXiv export functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)