### PR TITLE
chore: Bump version to 2.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.7.0"
+version = "2.7.1"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0"


### PR DESCRIPTION
## Summary
- Patch version bump 2.7.0 → 2.7.1
- Includes CI fixes: stale export.py removal, coverage exclusions for MCP handlers and editor

## Test plan
- [x] All Python Tests pass (3.10, 3.11, 3.12, 3.13)
- [x] Lint passes
- [x] Coverage ≥ 40%

🤖 Generated with [Claude Code](https://claude.com/claude-code)