### PR TITLE
fix(cla): use unprotected branch for signatures

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://github.com/ywatanabe1989/scitex-writer/blob/main/CLA.md"
-          branch: "main"
+          branch: "cla-signatures"
           allowlist: bot*
-          message-success: |
+          custom-allsigned-prcomment: |
             Thank you for signing the SciTeX CLA. Your contribution can now be reviewed.
-          message-commit-not-allowed: |
+          custom-notsigned-prcomment: |
             Please sign the [SciTeX CLA](https://github.com/ywatanabe1989/scitex-writer/blob/main/CLA.md) before your contribution can be merged.
             Comment `I have read and agree to the SciTeX CLA.` to sign.


### PR DESCRIPTION
## Summary
- Store CLA signatures on `cla-signatures` branch instead of protected `main`
- Fix input parameter names for contributor-assistant v2.6.1

## Test plan
- [ ] CLA bot no longer fails with branch protection error
- [ ] Signature comments are properly recognized

🤖 Generated with [Claude Code](https://claude.com/claude-code)