### PR TITLE
feat: add docs CLI subcommand

### DIFF
--- a/src/scitex_writer/_cli/__init__.py
+++ b/src/scitex_writer/_cli/__init__.py
@@ -100,7 +100,7 @@ def main() -> int:
     introspect.register_list_python_apis(subparsers)
     _register_usage_command(subparsers)
 
-    # docs — reusable mixin from scitex_dev
+    # Docs subcommand (from scitex-dev)
     try:
         from scitex_dev.cli import register_docs_subcommand
 


### PR DESCRIPTION
## Summary

- Add `scitex-writer docs` CLI command via shared `scitex_dev.cli.docs_click_group()`
- Supports: `--tldr`, `--list`, `--page`, `--json`
- Graceful fallback if scitex-dev not installed

## Test plan

- [x] `scitex-writer docs --tldr` works
- [x] `scitex-writer docs --help` shows options
- [x] No error when scitex-dev not installed (ImportError caught)

🤖 Generated with [Claude Code](https://claude.com/claude-code)