### PR TITLE
feat: add _skills/ with non-monolith skills layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.10.0"
+version = "2.10.1"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,9 @@ scitex-writer = "scitex_writer._cli:main"
 [project.entry-points."scitex_dev.docs"]
 scitex-writer = "scitex_writer"
 
+[project.entry-points."scitex_dev.skills"]
+scitex-writer = "scitex_writer"
+
 [project.urls]
 Homepage = "https://github.com/ywatanabe1989/scitex-writer"
 Documentation = "https://scitex-writer.readthedocs.io"
@@ -91,6 +94,9 @@ Issues = "https://github.com/ywatanabe1989/scitex-writer/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/scitex_writer"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"src/scitex_writer/skills" = "scitex_writer/skills"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/scitex_writer/_cli/__init__.py
+++ b/src/scitex_writer/_cli/__init__.py
@@ -108,6 +108,14 @@ def main() -> int:
     except ImportError:
         pass
 
+    # Skills subcommand (from scitex-dev)
+    try:
+        from scitex_dev.cli import register_skills_subcommand
+
+        register_skills_subcommand(subparsers, package="scitex-writer")
+    except ImportError:
+        pass
+
     # Handle --help-recursive before parse_args to avoid requiring a subcommand
     if "--help-recursive" in sys.argv:
         all_subparsers = {}

--- a/src/scitex_writer/_mcp/tools/__init__.py
+++ b/src/scitex_writer/_mcp/tools/__init__.py
@@ -20,6 +20,7 @@ def register_all_tools(mcp: FastMCP) -> None:
         migration,
         project,
         prompts,
+        skills,
         tables,
         update,
     )
@@ -36,6 +37,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     claim.register_tools(mcp)
     update.register_tools(mcp)
     migration.register_tools(mcp)
+    skills.register_tools(mcp)
 
 
 __all__ = ["register_all_tools"]

--- a/src/scitex_writer/_mcp/tools/skills.py
+++ b/src/scitex_writer/_mcp/tools/skills.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Timestamp: 2026-03-20
+# File: src/scitex_writer/_mcp/tools/skills.py
+
+"""Skills MCP tools for scitex-writer."""
+
+from fastmcp import FastMCP
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register skills tools."""
+
+    @mcp.tool()
+    def writer_skills_list() -> dict:
+        """List available skill pages for scitex-writer."""
+        try:
+            from scitex_dev.skills import list_skills
+
+            result = list_skills(package="scitex-writer")
+            return {"success": True, "skills": result.get("scitex-writer", [])}
+        except ImportError:
+            return {"success": False, "error": "scitex-dev not installed"}
+
+    @mcp.tool()
+    def writer_skills_get(name: str = None) -> dict:
+        """Get a skill page for scitex-writer. Without name, returns main SKILL.md."""
+        try:
+            from scitex_dev.skills import get_skill
+
+            content = get_skill(package="scitex-writer", name=name)
+            if content:
+                return {"success": True, "name": name, "content": content}
+            target = f"'{name}'" if name else "SKILL.md"
+            return {"success": False, "error": f"Skill {target} not found"}
+        except ImportError:
+            return {"success": False, "error": "scitex-dev not installed"}
+
+
+# EOF

--- a/src/scitex_writer/_skills/scitex-writer/SKILL.md
+++ b/src/scitex_writer/_skills/scitex-writer/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: scitex-writer
+description: LaTeX manuscript compilation with bibliography, figures, tables, claims tracking, and journal guideline enforcement.
+allowed-tools: mcp__scitex__writer_*
+---
+
+# scitex-writer
+
+LaTeX manuscript compilation framework for scientific papers.
+
+## Sub-skills
+
+- [quick-start.md](quick-start.md) — Basic manuscript workflow
+- [compilation.md](compilation.md) — Compile manuscript, supplementary, revision
+- [bibliography.md](bibliography.md) — BibTeX management, enrichment
+- [figures-and-tables.md](figures-and-tables.md) — Figure/table insertion and conversion
+- [claims.md](claims.md) — Claim tracking and rendering
+- [cli-reference.md](cli-reference.md) — CLI commands
+- [mcp-tools.md](mcp-tools.md) — MCP tools for AI agents
+
+## CLI
+
+```bash
+scitex-writer <command> [options]
+```
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `writer_compile_manuscript` | Compile LaTeX manuscript to PDF |
+| `writer_compile_content` | Compile content sections |
+| `writer_compile_supplementary` | Compile supplementary materials |
+| `writer_compile_revision` | Compile revision with tracked changes |
+| `writer_add_figure` | Add figure to manuscript |
+| `writer_add_table` | Add table to manuscript |
+| `writer_add_bibentry` | Add bibliography entry |
+| `writer_add_claim` | Add verifiable claim |
+| `writer_render_claims` | Render claims to LaTeX |
+| `writer_export_manuscript` | Export for submission |
+| `writer_export_overleaf` | Export to Overleaf format |

--- a/src/scitex_writer/_skills/scitex-writer/bibliography.md
+++ b/src/scitex_writer/_skills/scitex-writer/bibliography.md
@@ -1,0 +1,24 @@
+---
+name: bibliography
+description: BibTeX management — add, list, merge, enrich bibliography entries.
+---
+
+# Bibliography
+
+MCP tools for bibliography management:
+
+| Tool | Description |
+|------|-------------|
+| `writer_add_bibentry` | Add a BibTeX entry |
+| `writer_get_bibentry` | Get entry by key |
+| `writer_list_bibentries` | List all entries |
+| `writer_remove_bibentry` | Remove an entry |
+| `writer_list_bibfiles` | List .bib files |
+| `writer_merge_bibfiles` | Merge multiple .bib files |
+
+```python
+# Via MCP or CLI
+# scitex-writer bib add "key" --doi 10.1038/nature12373
+# scitex-writer bib list
+# scitex-writer bib merge
+```

--- a/src/scitex_writer/_skills/scitex-writer/claims.md
+++ b/src/scitex_writer/_skills/scitex-writer/claims.md
@@ -1,0 +1,19 @@
+---
+name: claims
+description: Verifiable claims — add, track, render claims linked to evidence.
+---
+
+# Claims
+
+Claims are verifiable statements linked to evidence (data, figures, statistics).
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `writer_add_claim` | Add a verifiable claim |
+| `writer_get_claim` | Get claim by ID |
+| `writer_list_claims` | List all claims |
+| `writer_remove_claim` | Remove a claim |
+| `writer_render_claims` | Render claims to LaTeX |
+| `writer_format_claim` | Format claim for display |

--- a/src/scitex_writer/_skills/scitex-writer/cli-reference.md
+++ b/src/scitex_writer/_skills/scitex-writer/cli-reference.md
@@ -1,0 +1,24 @@
+---
+name: cli-reference
+description: CLI commands for scitex-writer.
+---
+
+# CLI Reference
+
+```bash
+scitex-writer compile [project_dir]          # Compile manuscript
+scitex-writer compile --supplementary        # Compile supplementary
+scitex-writer compile --revision             # Compile revision
+
+scitex-writer export [project_dir]           # Export for submission
+scitex-writer export --overleaf              # Export to Overleaf
+
+scitex-writer bib add KEY                    # Add bibliography entry
+scitex-writer bib list                       # List entries
+
+scitex-writer mcp start                      # Start MCP server
+scitex-writer mcp doctor                     # Diagnose MCP setup
+
+scitex-writer skills list                    # List skills
+scitex-writer skills get                     # Get skill content
+```

--- a/src/scitex_writer/_skills/scitex-writer/compilation.md
+++ b/src/scitex_writer/_skills/scitex-writer/compilation.md
@@ -1,0 +1,28 @@
+---
+name: compilation
+description: Compile manuscript, supplementary, and revision documents to PDF.
+---
+
+# Compilation
+
+```python
+writer = sw.Writer("/path/to/project")
+
+# Main manuscript
+result = writer.compile_manuscript()
+
+# Supplementary materials
+result = writer.compile_supplementary()
+
+# Revision with tracked changes
+result = writer.compile_revision()
+
+# Get section content
+content = writer.get_section("introduction")
+content = writer.get_section("methods", doc_type="supplementary")
+
+# Get PDF path
+pdf = writer.get_pdf("manuscript")
+pdf = writer.get_pdf("supplementary")
+pdf = writer.get_pdf("revision")
+```

--- a/src/scitex_writer/_skills/scitex-writer/figures-and-tables.md
+++ b/src/scitex_writer/_skills/scitex-writer/figures-and-tables.md
@@ -1,0 +1,21 @@
+---
+name: figures-and-tables
+description: Add, list, and manage figures and tables in manuscripts.
+---
+
+# Figures and Tables
+
+## MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `writer_add_figure` | Add figure to manuscript |
+| `writer_list_figures` | List all figures |
+| `writer_remove_figure` | Remove a figure |
+| `writer_add_table` | Add table to manuscript |
+| `writer_list_tables` | List all tables |
+| `writer_remove_table` | Remove a table |
+| `writer_convert_figure` | Convert figure format |
+| `writer_csv_to_latex` | Convert CSV to LaTeX table |
+| `writer_latex_to_csv` | Convert LaTeX table to CSV |
+| `writer_pdf_to_images` | Convert PDF pages to images |

--- a/src/scitex_writer/_skills/scitex-writer/mcp-tools.md
+++ b/src/scitex_writer/_skills/scitex-writer/mcp-tools.md
@@ -1,0 +1,40 @@
+---
+name: mcp-tools
+description: MCP tools for AI agents — manuscript compilation, bibliography, figures, tables, claims.
+---
+
+# MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `writer_compile_manuscript` | Compile manuscript to PDF |
+| `writer_compile_content` | Compile content sections |
+| `writer_compile_supplementary` | Compile supplementary |
+| `writer_compile_revision` | Compile revision |
+| `writer_add_figure` | Add figure |
+| `writer_list_figures` | List figures |
+| `writer_remove_figure` | Remove figure |
+| `writer_add_table` | Add table |
+| `writer_list_tables` | List tables |
+| `writer_remove_table` | Remove table |
+| `writer_add_bibentry` | Add bibliography entry |
+| `writer_get_bibentry` | Get bibliography entry |
+| `writer_list_bibentries` | List bibliography |
+| `writer_remove_bibentry` | Remove bibliography entry |
+| `writer_list_bibfiles` | List .bib files |
+| `writer_merge_bibfiles` | Merge bibliography files |
+| `writer_add_claim` | Add verifiable claim |
+| `writer_get_claim` | Get claim |
+| `writer_list_claims` | List claims |
+| `writer_remove_claim` | Remove claim |
+| `writer_render_claims` | Render claims to LaTeX |
+| `writer_format_claim` | Format claim |
+| `writer_export_manuscript` | Export for submission |
+| `writer_export_overleaf` | Export to Overleaf |
+| `writer_import_overleaf` | Import from Overleaf |
+| `writer_get_pdf` | Get compiled PDF |
+| `writer_get_project_info` | Get project info |
+| `writer_update_project` | Update project settings |
+| `writer_csv_to_latex` | CSV to LaTeX table |
+| `writer_latex_to_csv` | LaTeX table to CSV |
+| `writer_pdf_to_images` | PDF to image conversion |

--- a/src/scitex_writer/_skills/scitex-writer/quick-start.md
+++ b/src/scitex_writer/_skills/scitex-writer/quick-start.md
@@ -1,0 +1,37 @@
+---
+name: quick-start
+description: Basic manuscript workflow — create project, add content, compile PDF.
+---
+
+# Quick Start
+
+```python
+import scitex_writer as sw
+
+# Create or open a project
+writer = sw.Writer("/path/to/project")
+
+# Compile manuscript to PDF
+result = writer.compile_manuscript()
+# result.pdf_path → Path to generated PDF
+
+# Compile supplementary
+result = writer.compile_supplementary()
+
+# Compile revision with tracked changes
+result = writer.compile_revision()
+
+# Get compiled PDF
+pdf = writer.get_pdf("manuscript")
+
+# Ensure workspace structure
+sw.ensure_workspace("/path/to/project", git_strategy="child")
+```
+
+## Key Classes
+
+- `Writer` — Main class for manuscript operations
+- `CompilationResult` — Result of compilation (pdf_path, log, success)
+- `ManuscriptTree` — Manuscript directory structure
+- `RevisionTree` — Revision directory structure
+- `SupplementaryTree` — Supplementary materials structure

--- a/src/scitex_writer/skills/SKILL.md
+++ b/src/scitex_writer/skills/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: scitex-writer
+description: LaTeX manuscript compilation with bibliography, figures, tables, claims tracking, and journal guideline enforcement. Use when writing, compiling, or managing scientific papers.
+allowed-tools: mcp__scitex__writer_*
+---
+
+# Scientific Manuscript Writing with scitex-writer
+
+## Quick Start
+
+```python
+from scitex_writer import compile_manuscript, add_figure, add_bibentry
+
+# Compile manuscript to PDF
+compile_manuscript("./project/")
+
+# Add a figure
+add_figure("./project/", "fig1.png", caption="Results overview", label="fig:results")
+
+# Add bibliography entry
+add_bibentry("./project/", doi="10.1038/s41586-024-00001-1")
+```
+
+## Common Workflows
+
+### "Compile my manuscript"
+
+```bash
+scitex-writer compile manuscript ./project/
+scitex-writer compile supplementary ./project/
+```
+
+### "Manage bibliography"
+
+```bash
+scitex-writer bib add ./project/ --doi 10.1038/s41586-024-00001-1
+scitex-writer bib enrich ./project/references.bib
+scitex-writer bib merge ./project/ -o merged.bib
+scitex-writer bib list ./project/
+```
+
+### "Add figures and tables"
+
+```bash
+scitex-writer figures add ./project/ fig1.png --caption "Results" --label fig:results
+scitex-writer tables add ./project/ results.csv --caption "Main results"
+scitex-writer tables csv-to-latex data.csv
+```
+
+### "Track claims"
+
+```python
+writer_add_claim(project_dir="./project/",
+    claim="Model achieves 95% accuracy",
+    evidence="results/accuracy.csv", section="results")
+writer_render_claims(project_dir="./project/")
+```
+
+### "Export"
+
+```bash
+scitex-writer export overleaf ./project/ -o overleaf_export/
+scitex-writer export manuscript ./project/ -o submission/
+```
+
+### "Check journal guidelines"
+
+```bash
+scitex-writer guidelines list
+scitex-writer guidelines get nature
+```
+
+## CLI Commands
+
+```bash
+# Compilation
+scitex-writer compile manuscript|supplementary|revision ./project/
+
+# Bibliography
+scitex-writer bib add|list|enrich|merge ./project/
+
+# Figures & Tables
+scitex-writer figures add|list|convert ./project/
+scitex-writer tables add|list|csv-to-latex ./project/
+
+# Export
+scitex-writer export overleaf|manuscript ./project/
+
+# Guidelines & Prompts
+scitex-writer guidelines list|get
+scitex-writer prompts asta
+
+# Skills
+scitex-writer skills list
+scitex-writer skills get SKILL
+scitex-writer skills get manuscript-workflow
+```
+
+## MCP Tools (for AI agents)
+
+| Tool | Purpose |
+|------|---------|
+| `writer_compile_manuscript` | Compile LaTeX to PDF |
+| `writer_compile_supplementary` | Compile supplementary materials |
+| `writer_compile_revision` | Compile revision with tracked changes |
+| `writer_add_figure` | Add figure to manuscript |
+| `writer_list_figures` | List figures in project |
+| `writer_add_table` | Add table to manuscript |
+| `writer_list_tables` | List tables |
+| `writer_csv_to_latex` | Convert CSV to LaTeX table |
+| `writer_add_bibentry` | Add bibliography entry |
+| `writer_list_bibentries` | List all bib entries |
+| `writer_merge_bibfiles` | Merge .bib files |
+| `writer_enrich_bibtex` | Enrich with metadata |
+| `writer_add_claim` | Add tracked claim |
+| `writer_list_claims` | List all claims |
+| `writer_render_claims` | Render claims with status |
+| `writer_guideline_list` | List journal guidelines |
+| `writer_guideline_get` | Get specific guideline |
+| `writer_export_manuscript` | Export manuscript |
+| `writer_export_overleaf` | Export for Overleaf |
+| `writer_get_project_info` | Get project metadata |
+| `writer_get_pdf` | Get compiled PDF |
+
+## Specific Topics
+
+* **Manuscript workflow** [references/manuscript-workflow.md](references/manuscript-workflow.md)

--- a/src/scitex_writer/skills/references/manuscript-workflow.md
+++ b/src/scitex_writer/skills/references/manuscript-workflow.md
@@ -1,0 +1,63 @@
+---
+name: manuscript-workflow
+description: Complete manuscript workflow from project creation to submission.
+---
+
+# Manuscript Workflow
+
+## 1. Create Project
+```bash
+scitex template clone-template research-paper ./my-paper/
+```
+
+## 2. Write Sections
+Edit LaTeX files in `sections/`: abstract, introduction, methods, results, discussion.
+
+## 3. Add Figures
+```bash
+scitex-writer figures add ./my-paper/ fig.png --caption "Results" --label fig:results
+```
+
+## 4. Add Tables
+```bash
+scitex-writer tables add ./my-paper/ data.csv --caption "Summary" --label tab:summary
+```
+
+## 5. Manage Bibliography
+```bash
+scitex-writer bib add ./my-paper/ --doi 10.1038/s41586-024-00001-1
+scitex-writer bib enrich ./my-paper/references.bib
+```
+
+## 6. Track Claims
+Link claims to computational evidence for reproducibility.
+
+## 7. Check Guidelines
+```bash
+scitex-writer guidelines get nature
+```
+
+## 8. Compile
+```bash
+scitex-writer compile manuscript ./my-paper/
+scitex-writer compile supplementary ./my-paper/
+scitex-writer compile revision ./my-paper/
+```
+
+## 9. Export
+```bash
+scitex-writer export overleaf ./my-paper/ -o overleaf/
+scitex-writer export manuscript ./my-paper/ -o submission/
+```
+
+## Directory Structure
+```
+my-paper/
+├── main.tex
+├── sections/{abstract,introduction,methods,results,discussion}.tex
+├── figures/
+├── tables/
+├── references.bib
+├── claims.yaml
+└── project.yaml
+```


### PR DESCRIPTION
## Summary
- Add `_skills/<pkg>/` directory with non-monolith skills layout
- SKILL.md is index-only with links to focused sub-skill files
- pyproject.toml force-include for wheel bundling

## Test plan
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)