### PR TITLE
feat(#82): integrate scitex-ui shell + scitex-app standalone (PR2/N)

### DIFF
--- a/src/scitex_writer/_django/_server.py
+++ b/src/scitex_writer/_django/_server.py
@@ -2,20 +2,19 @@
 # -*- coding: utf-8 -*-
 """Standalone local-dev launcher for the writer editor.
 
-Bootstraps Django with minimal `scitex_writer._django.settings` and serves
-the editor on localhost. Cloud deployments do NOT use this — they mount
-`scitex_writer._django.urls` into their own Django project.
+Delegates to `scitex_app._standalone.run_standalone`, which pre-wires
+scitex-ui static assets + the workspace shell so the same local server
+looks like scitex.ai/apps/writer.
 
-This is what `scitex-writer gui` invokes.
+Cloud deployments do NOT use this — they mount `scitex_writer._django.urls`
+into their own Django project.
 """
 
 from __future__ import annotations
 
 import os
 import socket
-import sys
 import threading
-import time
 import webbrowser
 from pathlib import Path
 
@@ -38,47 +37,59 @@ def run(
     host: str = "127.0.0.1",
     open_browser: bool = True,
     desktop: bool = False,
+    hot_reload: bool = False,
 ) -> None:
-    """Launch the Django editor server locally."""
+    """Launch the Django editor server locally.
+
+    Tries `scitex_app._standalone.run_standalone` first (gets the full
+    workspace shell from scitex-ui). Falls back to a bare runserver
+    bootstrap if scitex-app is not installed.
+    """
     project_path = Path(project_dir).resolve()
     if not project_path.exists():
         raise FileNotFoundError(f"Project directory not found: {project_path}")
 
     os.environ["WRITER_WORKING_DIR"] = str(project_path)
+    os.environ["SCITEX_WORKING_DIR"] = str(project_path)
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "scitex_writer._django.settings")
 
-    import django
-
-    django.setup()
-
     port = _find_available_port(host, port)
-    url = f"http://{host}:{port}"
-    print(f"SciTeX Writer GUI: {url}")
+    print(f"SciTeX Writer GUI: http://{host}:{port}")
     print(f"Project: {project_path}")
     print("Press Ctrl+C to stop")
 
+    try:
+        import django
+
+        django.setup()
+
+        from django.core.management import call_command
+
+        call_command("migrate", "--run-syncdb", verbosity=0)
+
+        from scitex_app._standalone import run_standalone
+
+        run_standalone(
+            app_module="scitex_writer._django",
+            port=port,
+            host=host,
+            open_browser=open_browser,
+            hot_reload=hot_reload,
+            working_dir=str(project_path),
+            desktop=desktop,
+        )
+        return
+    except ImportError:
+        pass
+
+    # Fallback: no scitex-app available, run bare Django
+    import django
+
+    django.setup()
+    from django.core.management import call_command
+
     if open_browser and not desktop:
-        threading.Timer(1.0, webbrowser.open, args=[url]).start()
+        threading.Timer(1.0, webbrowser.open, args=[f"http://{host}:{port}"]).start()
 
-    from django.core.management import execute_from_command_line
-
-    if desktop:
-        try:
-            import webview  # type: ignore
-
-            def _serve():
-                time.sleep(0.3)
-                execute_from_command_line(
-                    [sys.argv[0], "runserver", f"{host}:{port}", "--noreload"]
-                )
-
-            threading.Thread(target=_serve, daemon=True).start()
-            webview.create_window("SciTeX Writer", url, width=1400, height=900)
-            webview.start()
-            return
-        except ImportError:
-            print("pywebview not installed. Falling back to browser mode.")
-
-    execute_from_command_line(
-        [sys.argv[0], "runserver", f"{host}:{port}", "--noreload"]
-    )
+    noreload = [] if hot_reload else ["--noreload"]
+    call_command("runserver", f"{host}:{port}", *noreload)

--- a/src/scitex_writer/_django/settings.py
+++ b/src/scitex_writer/_django/settings.py
@@ -2,30 +2,44 @@
 # -*- coding: utf-8 -*-
 """Minimal standalone Django settings for `scitex-writer gui`.
 
-Enough to run `django.core.management runserver`; cloud deployments
-do NOT import this file — they use their own settings and just mount
-`scitex_writer._django.urls` under a prefix (see scitex-cloud
-`writer_app/urls/__init__.py`).
+Used only by the standalone launcher; cloud deployments ignore this
+module and mount `scitex_writer._django.urls` under their own prefix.
+
+Mirrors the `figrecipe._django.settings` pattern: bare-minimum installed
+apps, optional `scitex_ui` for the shared workspace shell, and a SQLite
+database so any future models (chat sessions, comments, versions) work
+out of the box.
 """
 
 from __future__ import annotations
 
 import os
 import secrets
+import tempfile
 from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent
 
 SECRET_KEY = os.environ.get("WRITER_DJANGO_SECRET", secrets.token_urlsafe(32))
-DEBUG = True
-ALLOWED_HOSTS = ["*"]
+DEBUG = os.environ.get("DJANGO_DEBUG", "true").lower() == "true"
+ALLOWED_HOSTS = ["127.0.0.1", "localhost", "0.0.0.0", "testserver"]
 
 INSTALLED_APPS = [
+    "django.contrib.contenttypes",
     "django.contrib.staticfiles",
     "scitex_writer._django.apps.WriterEditorConfig",
 ]
 
+# Optional: scitex-ui supplies the workspace shell (template + CSS/JS assets)
+try:
+    import scitex_ui  # noqa: F401
+
+    INSTALLED_APPS.append("scitex_ui")
+except ImportError:
+    pass
+
 MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
     "django.middleware.common.CommonMiddleware",
 ]
 
@@ -44,6 +58,18 @@ TEMPLATES = [
     },
 ]
 
+# SQLite lives in the temp dir so local runs don't pollute the project
+_DB_DIR = Path(tempfile.gettempdir()) / "scitex_writer"
+_DB_DIR.mkdir(parents=True, exist_ok=True)
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": str(_DB_DIR / "db.sqlite3"),
+    }
+}
+
 STATIC_URL = "/static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 USE_TZ = True
+
+WRITER_TEMP_DIR = _DB_DIR

--- a/src/scitex_writer/_django/static/writer/css/editor.css
+++ b/src/scitex_writer/_django/static/writer/css/editor.css
@@ -1,26 +1,78 @@
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
-html,
-body {
+/* Writer app content — shell chrome comes from scitex-ui.
+ * All writer styles live inside `.writer-app` so they don't collide with
+ * shell CSS. Theme variables are shadowed only within `.writer-app`.
+ */
+
+.writer-app {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
   height: 100%;
   overflow: hidden;
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   font-size: 14px;
-}
-body {
   background: var(--bg-primary);
   color: var(--text-primary);
-  display: flex;
-  flex-direction: column;
 }
 
-[data-theme="light"] {
+.writer-app *,
+.writer-app *::before,
+.writer-app *::after {
+  box-sizing: border-box;
+}
+
+.writer-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 12px;
+  background: var(--toolbar-bg);
+  border-bottom: 1px solid var(--border-color);
+  flex: 0 0 auto;
+}
+.writer-toolbar-left,
+.writer-toolbar-center,
+.writer-toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.writer-toolbar-center {
+  flex: 1;
+  justify-content: center;
+  min-width: 0;
+}
+.writer-logo {
+  font-weight: 600;
+}
+.writer-split {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+.writer-editor-pane,
+.writer-preview-pane {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  flex: 1;
+  background: var(--bg-editor);
+}
+.writer-split-resizer {
+  flex: 0 0 4px;
+  background: var(--border-color);
+  cursor: col-resize;
+}
+.writer-split-resizer:hover {
+  background: var(--accent);
+}
+
+[data-theme="light"] .writer-app,
+.writer-app[data-theme="light"] {
   --bg-primary: #fdfcfa;
   --bg-secondary: #f5f3f0;
   --bg-tertiary: #eae7e2;
@@ -62,7 +114,8 @@ body {
   --cm-tag: #170;
   --cm-attribute: #00c;
 }
-[data-theme="dark"] {
+[data-theme="dark"] .writer-app,
+.writer-app[data-theme="dark"] {
   --bg-primary: #1e1e1e;
   --bg-secondary: #252526;
   --bg-tertiary: #2d2d2d;

--- a/src/scitex_writer/_django/templates/writer/editor.html
+++ b/src/scitex_writer/_django/templates/writer/editor.html
@@ -1,77 +1,50 @@
+{% extends "scitex_ui/standalone_shell.html" %}
 {% load static %}
-<!DOCTYPE html>
-<html lang="en"
-      data-theme="{% if dark_mode %}dark{% else %}light{% endif %}">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>SciTeX Writer</title>
-        <link rel="stylesheet"
-              href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css">
-        <link rel="stylesheet"
-              href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/fold/foldgutter.min.css">
-        <link rel="stylesheet"
-              href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/dialog/dialog.min.css">
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/mode/stex/stex.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/edit/matchbrackets.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/edit/closebrackets.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/fold/foldcode.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/fold/foldgutter.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/fold/brace-fold.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/search/search.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/search/searchcursor.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/search/jump-to-line.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/dialog/dialog.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
-        <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
-        <link rel="stylesheet" href="{% static 'writer/css/editor.css' %}">
-    </head>
-    <body data-api-base="{{ api_base|default:'/' }}">
-        <header class="toolbar">
-            <div class="toolbar-left">
-                <span class="logo">SciTeX Writer</span>
+{% block extra_css %}
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css">
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/fold/foldgutter.min.css">
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/dialog/dialog.min.css">
+    <link rel="stylesheet" href="{% static 'writer/css/editor.css' %}">
+{% endblock %}
+{% block worktree_title_full %}Project files{% endblock %}
+{% block worktree_data_attrs %}data-working-dir="{{ project_dir|default:'' }}"{% endblock %}
+{% block app_content %}
+    <div class="writer-app"
+         data-api-base="{{ api_base|default:'/' }}"
+         data-project-dir="{{ project_dir|default:'' }}">
+        <!-- Writer-specific toolbar -->
+        <header class="writer-toolbar">
+            <div class="writer-toolbar-left">
+                <span class="writer-logo"><i class="fas fa-file-alt"></i> Writer</span>
                 <select id="doc-type-select" title="Document type">
                     <option value="manuscript">Manuscript</option>
                     <option value="supplementary">Supplementary</option>
                     <option value="revision">Revision</option>
                 </select>
             </div>
-            <div class="toolbar-center">
+            <div class="writer-toolbar-center">
                 <span id="current-file" class="current-file">No file open</span>
                 <span id="save-status" class="save-status"></span>
             </div>
-            <div class="toolbar-right">
+            <div class="writer-toolbar-right">
                 <button id="btn-compile"
                         class="btn btn-primary"
-                        title="Compile (Ctrl+Shift+B)">Compile</button>
+                        title="Compile (Ctrl+Shift+B)">
+                    <i class="fas fa-hammer"></i> Compile
+                </button>
                 <button id="btn-toggle-log"
                         class="btn btn-secondary"
-                        title="Toggle compilation log">Log</button>
-                <button id="btn-toggle-theme"
-                        class="btn btn-icon"
-                        title="Toggle dark/light mode">
-                    <span id="theme-icon">&#9789;</span>
+                        title="Toggle compilation log">
+                    <i class="fas fa-terminal"></i> Log
                 </button>
             </div>
         </header>
-        <div class="workspace">
-            <aside class="sidebar" id="sidebar">
-                <div class="sidebar-header">
-                    <span class="sidebar-title">Files</span>
-                    <button id="btn-collapse-sidebar"
-                            class="btn btn-icon btn-sm"
-                            title="Collapse sidebar">&#9664;</button>
-                </div>
-                <div class="file-tree" id="file-tree">
-                    <div class="loading">Loading...</div>
-                </div>
-            </aside>
-            <div class="resizer"
-                 id="sidebar-resizer"
-                 data-target="sidebar"
-                 data-direction="left"></div>
-            <div class="editor-panel" id="editor-panel">
+        <!-- Editor + preview split -->
+        <div class="writer-split">
+            <div class="writer-editor-pane" id="editor-panel">
                 <div class="file-tabs" id="file-tabs"></div>
                 <div class="editor-container" id="editor-container">
                     <div class="welcome-message" id="welcome-message">
@@ -81,11 +54,8 @@
                     </div>
                 </div>
             </div>
-            <div class="resizer"
-                 id="preview-resizer"
-                 data-target="preview-panel"
-                 data-direction="right"></div>
-            <div class="preview-panel" id="preview-panel">
+            <div class="writer-split-resizer" id="writer-split-resizer"></div>
+            <div class="writer-preview-pane" id="preview-panel">
                 <div class="preview-header">
                     <div class="preview-tabs">
                         <button class="preview-tab active" data-view="pdf">PDF</button>
@@ -93,7 +63,9 @@
                         <button class="preview-tab" data-view="claims">Claims</button>
                     </div>
                     <div class="preview-actions">
-                        <button id="btn-refresh-pdf" class="btn btn-icon btn-sm" title="Refresh PDF">&#8635;</button>
+                        <button id="btn-refresh-pdf" class="btn btn-icon btn-sm" title="Refresh PDF">
+                            <i class="fas fa-sync"></i>
+                        </button>
                     </div>
                 </div>
                 <div class="preview-content" id="preview-content">
@@ -124,10 +96,14 @@
                         <div class="claims-toolbar">
                             <button class="btn btn-sm btn-secondary"
                                     id="btn-refresh-claims"
-                                    title="Reload claims">&#8635; Refresh</button>
+                                    title="Reload claims">
+                                <i class="fas fa-sync"></i> Refresh
+                            </button>
                             <button class="btn btn-sm btn-secondary"
                                     id="btn-render-claims"
-                                    title="Regenerate claims_rendered.tex">&#9881; Render .tex</button>
+                                    title="Regenerate claims_rendered.tex">
+                                <i class="fas fa-cog"></i> Render .tex
+                            </button>
                             <span id="claims-count" class="claims-count"></span>
                         </div>
                         <div class="claims-list" id="claims-list">
@@ -137,6 +113,7 @@
                 </div>
             </div>
         </div>
+        <!-- Claim hover tooltip (floats above everything) -->
         <div id="claim-tooltip" class="claim-tooltip u-hidden">
             <div class="claim-tooltip-header">
                 <span id="ct-id" class="ct-id"></span>
@@ -175,6 +152,7 @@
                 </div>
             </div>
         </div>
+        <!-- Compilation log drawer -->
         <div class="log-panel u-hidden" id="log-panel">
             <div class="log-header">
                 <span>Compilation Log</span>
@@ -182,6 +160,21 @@
             </div>
             <pre class="log-content" id="log-content"></pre>
         </div>
-        <script src="{% static 'writer/js/editor.js' %}"></script>
-    </body>
-</html>
+    </div>
+{% endblock %}
+{% block extra_js %}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/mode/stex/stex.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/edit/matchbrackets.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/edit/closebrackets.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/fold/foldcode.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/fold/foldgutter.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/fold/brace-fold.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/search/search.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/search/searchcursor.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/search/jump-to-line.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/dialog/dialog.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+    <script src="{% static 'writer/js/editor.js' %}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary

Stacked on #84 (PR1). Gets the writer editor rendering inside the canonical scitex-ui workspace shell — three-column layout, sidebars, AI panel, resizers — so local \`scitex-writer gui\` visually matches scitex.ai/apps/writer.

## Changes

- **\`_django/settings.py\`** — register \`scitex_ui\` as INSTALLED_APP (optional import), add SQLite DB in tempdir (mirrors figrecipe pattern), add \`testserver\` to ALLOWED_HOSTS
- **\`_django/_server.py\`** — delegate to \`scitex_app._standalone.run_standalone\` with fallback to bare runserver. Pre-configures Django + \`migrate --run-syncdb\` before handoff so scitex-app re-uses our settings
- **\`_django/templates/writer/editor.html\`** — extends \`scitex_ui/standalone_shell.html\`; writer content in \`app_content\` block; \`worktree_data_attrs\` filled with project_dir
- **\`_django/static/writer/css/editor.css\`** — all writer styles scoped under \`.writer-app\` to avoid shell-var collision; new \`.writer-toolbar\`/\`.writer-split\`/\`.writer-editor-pane\` replace old \`.toolbar\`/\`.workspace\`/\`.sidebar\` chrome; removed top-level \`*\`/\`html\`/\`body\` rules (shell provides them)

## Verification

- Django \`check\` passes
- 14 parity tests still pass
- Live server: shell CSS+JS load (6 KB theme.css, 4 KB init.js) + writer assets (21 KB css, 38 KB js)
- Playwright screenshot confirms writer UI inside workspace shell (workspace-three-col, ws-module-pane, AI/worktree/viewer panes all present)

## Known follow-ups (PR3+)

- Shell's file-tree / panel-resizing TS modules require Vite build per-app (arrives with Monaco absorption in PR3)
- AI/worktree panes appear empty until chat + files JS bundle wired

## Stacking

Base branch: \`feat/82-django-port\` (PR #84). Rebase when PR1 merges to \`develop\`.

## Test plan

- [x] Parity tests pass
- [x] Live smoke: shell chrome renders around writer content
- [ ] Reviewer: open in browser, verify three-column shell + writer panes look reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)