### PR TITLE
fix(ci): skills-quality test uses pytest.importorskip

### DIFF
--- a/tests/skills/test_skills_quality.py
+++ b/tests/skills/test_skills_quality.py
@@ -1,9 +1,19 @@
 """Enforces SciTeX skills quality checklist §1–§4.
 Canonical: src/scitex/_skills/general/21_scitex-package-quality-checklist.md
 """
-from pathlib import Path
-from scitex_dev._skills_quality_pytest import make_skill_quality_tests
 
-test_skills_quality = make_skill_quality_tests(
+from pathlib import Path
+
+import pytest
+
+# `_skills_quality_pytest` was introduced in a newer scitex-dev. Older peer
+# installs (e.g. PyPI lag) don't ship it, so collect-time crashes CI. Skip
+# gracefully when the helper is missing — same pattern as tests/integration/.
+sq = pytest.importorskip(
+    "scitex_dev._skills_quality_pytest",
+    reason="requires scitex-dev with _skills_quality_pytest helper",
+)
+
+test_skills_quality = sq.make_skill_quality_tests(
     package_root=Path(__file__).resolve().parents[1]
 )


### PR DESCRIPTION
Fixes CI on develop (run #25448356200). All 4 Python jobs were failing collect-time with `ModuleNotFoundError: No module named 'scitex_dev._skills_quality_pytest'` because the helper is only in newer scitex-dev (editable-installed locally, not yet on PyPI in the version CI picks up).

Same pattern as commit 3da09a2 used for tests/integration/ — `pytest.importorskip` with a clear reason. Local runs keep working; CI skips cleanly when the peer doesn't have it.