### PR TITLE
ci(quality): fix broken quality workflow (single-package audit-all)

### DIFF
--- a/.github/workflows/scitex-writer-quality-audit-on-ubuntu-latest.yml
+++ b/.github/workflows/scitex-writer-quality-audit-on-ubuntu-latest.yml
@@ -1,8 +1,17 @@
 name: quality
 
-# Nightly ecosystem-wide static audit — catches regressions like the missing
-# scitex-config dep that broke 6 PyPI packages on 2026-04-28. Outputs a JSON
-# artifact and creates a GitHub issue if any CRITICAL/HIGH findings surface.
+# Single-package quality gate — runs `scitex-dev ecosystem audit-all`
+# against this package (audit-cli / audit-mcp-tools / audit-skills /
+# audit-python-apis / audit-project). Mirrors the canonical audit that
+# `tests/develop/test_audit.py` runs inside the test suite, but as a
+# standalone gate so an audit regression is visible even when the matrix
+# is skipped.
+#
+# The previous body of this workflow shallow-cloned the entire ecosystem
+# and ran `scripts/quality/audit_ecosystem.py` — both of which live only
+# in scitex-dev, not in leaf packages. That template was copied here
+# verbatim and was always broken (FileNotFoundError on a non-existent
+# ecosystem registry file). This version audits just this package.
 
 on:
   schedule:
@@ -11,116 +20,29 @@ on:
   push:
     branches: [develop]
     paths:
-      - "scripts/quality/audit_ecosystem.py"
-      - "src/scitex_writer/_ecosystem/_core.py"
-      - "src/scitex_writer/ecosystem.py"
-      - ".github/workflows/quality-audit.yml"
+      - "src/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/scitex-writer-quality-audit-on-ubuntu-latest.yml"
+  pull_request:
+    branches: [main, develop]
 
 jobs:
   audit:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Checkout scitex-writer
-        uses: actions/checkout@v4
-        with:
-          path: scitex-writer
+      - uses: actions/checkout@v4
 
-      - name: Checkout scitex-dev + ecosystem list script
-        uses: actions/checkout@v4
-        with:
-          path: scitex-dev
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
-      - name: Install scitex-dev + ecosystem list script
-        run: pip install -e "scitex-dev[dev]"
-
-      - name: Clone every ecosystem package
+      - name: Install package + audit tooling
         run: |
-          set -e
-          mkdir -p proj
-          python3 scitex-dev/scripts/quality/ecosystem_list.py 2>/dev/null | while IFS= read -r line; do
-            name=$(echo "$line" | python3 -c "import json,sys; print(json.load(sys.stdin)['name'])")
-            repo=$(echo "$line" | python3 -c "import json,sys; print(json.load(sys.stdin)['github_repo'])")
-            dest="proj/$name"
-            [ -d "$dest" ] && continue
-            git clone --depth 1 --no-tags "https://github.com/$repo.git" "$dest"
-          done
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+          pip install "scitex-dev[cli-audit]"
 
-      - name: Run ecosystem audit
-        id: audit
-        run: |
-          python3 scitex-dev/scripts/quality/audit_ecosystem.py \
-            --projects-root proj \
-            --scitex-dev-root scitex-dev \
-            --out audit.json
-          echo "json_path=$(pwd)/audit.json" >> "$GITHUB_OUTPUT"
-          # Surface summary in step output.
-          python3 - <<'PY'
-          import json
-          d = json.load(open("audit.json"))
-          s = d["summary"]
-          print(f"::notice ::Packages audited: {s['packages_audited']}")
-          print(f"::notice ::Findings by severity: {s['by_severity']}")
-          if s["by_severity"].get("CRITICAL", 0):
-              print(f"::error ::{s['by_severity']['CRITICAL']} CRITICAL findings — see audit.json")
-          if s["by_severity"].get("HIGH", 0):
-              print(f"::warning ::{s['by_severity']['HIGH']} HIGH findings — see audit.json")
-          PY
-        continue-on-error: true  # never block the workflow on findings
-
-      - name: Upload audit JSON
-        uses: actions/upload-artifact@v4
-        with:
-          name: ecosystem-audit
-          path: audit.json
-          retention-days: 30
-
-      - name: Open / update tracking issue on CRITICAL or HIGH
-        if: ${{ always() }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -e
-          counts=$(python3 -c "import json; d=json.load(open('audit.json')); s=d['summary']['by_severity']; print(s.get('CRITICAL',0), s.get('HIGH',0))")
-          read crit high <<< "$counts"
-          if [[ "$crit" -eq 0 && "$high" -eq 0 ]]; then
-            echo "No CRITICAL/HIGH; skipping issue."
-            exit 0
-          fi
-          # Build a markdown body listing offenders.
-          body=$(python3 - <<'PY'
-          import json
-          d = json.load(open("audit.json"))
-          out = ["# Ecosystem Quality Audit findings", ""]
-          out.append(f"Generated: {d['generated_at']}")
-          out.append(f"Packages: {d['summary']['packages_audited']}")
-          out.append(f"By severity: `{d['summary']['by_severity']}`")
-          out.append("")
-          for sev in ("CRITICAL", "HIGH"):
-              hits = [(p, f) for p in d["packages"] for f in p["findings"] if f["severity"] == sev]
-              if not hits:
-                  continue
-              out.append(f"## {sev}")
-              for p, f in hits:
-                  out.append(f"- **{p['package']}** §{f['section']} ({f['lens']}) — {f['message']}")
-                  if f.get("detail"):
-                      out.append(f"    - {f['detail']}")
-          print("\n".join(out))
-          PY
-          )
-          # Reuse a single rolling issue per day.
-          title="quality-audit: $(date -u +%Y-%m-%d) — CRITICAL=$crit HIGH=$high"
-          existing=$(gh issue list -R "$GITHUB_REPOSITORY" --label quality-audit --state open --json number,title \
-              | python3 -c "import sys,json; d=json.load(sys.stdin); print(next((x['number'] for x in d if x['title'].startswith('quality-audit:')), ''))")
-          if [[ -n "$existing" ]]; then
-            gh issue comment "$existing" -R "$GITHUB_REPOSITORY" --body "$body"
-            gh issue edit "$existing" -R "$GITHUB_REPOSITORY" --title "$title"
-          else
-            gh issue create -R "$GITHUB_REPOSITORY" --title "$title" --body "$body" \
-              --label quality-audit
-          fi
+      - name: Run scitex-dev ecosystem audit-all
+        run: scitex-dev ecosystem audit-all scitex-writer --no-version-check


### PR DESCRIPTION
Replace the broken ecosystem-clone quality template (FileNotFoundError on a non-existent `_ecosystem/_core.py` + missing `scripts/quality/audit_ecosystem.py`) with the canonical single-package `scitex-dev ecosystem audit-all scitex-writer`. Mirrors the audit `tests/develop/test_audit.py` runs.