### PR TITLE
docs: refresh stale documentation to match current codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ See [`Four Interfaces`](#four-interfaces) below for usage details per surface.
 |-----------|-----|-------------|
 | **Python API** | Human researchers | `import scitex_writer as sw` |
 | **Command-Line Interface (CLI) Commands** | Terminal users | `scitex-writer compile`, `scitex-writer bib` |
-| **MCP Tools** | AI agents | 39 tools for Claude/GPT integration |
+| **MCP Tools** | AI agents | 44 tools for Claude/GPT integration |
 | **Skills** | AI agent discovery | Workflow guides for capabilities and patterns |
 
 <details open>
@@ -274,7 +274,7 @@ scitex-writer prompts asta -t coauthors        # Find collaborators
 # MCP server management
 scitex-writer mcp list-tools                   # List all MCP tools (markdown)
 scitex-writer mcp doctor                       # Check server health
-scitex-writer mcp installation                 # Show Claude Desktop config
+scitex-writer mcp install                     # Show Claude Desktop config
 scitex-writer mcp start                        # Start MCP server
 
 # GUI - Browser-based editor
@@ -286,7 +286,7 @@ scitex-writer gui --port 8080 --no-browser     # Custom port, no auto-open
 </details>
 
 <details>
-<summary><strong>MCP Tools — 39 tools for AI Agents</strong></summary>
+<summary><strong>MCP Tools — 44 tools for AI Agents</strong></summary>
 
 Turn AI agents into autonomous manuscript compilers.
 
@@ -294,14 +294,16 @@ Turn AI agents into autonomous manuscript compilers.
 |----------|-------|-------------|
 | project | 4 | Clone, info, PDF paths, document types |
 | compile | 4 | Manuscript, supplementary, revision, content |
-| tables | 5 | CSV to LaTeX, list/add/remove tables |
-| figures | 5 | Convert, render PDF, list/add/remove |
+| tables | 6 | CSV to LaTeX, list/add/remove, archive |
+| figures | 6 | Convert, render PDF, list/add/remove, archive |
 | bib | 6 | List files/entries, CRUD, merge/dedupe |
 | guidelines | 3 | List, get, build with draft |
 | prompts | 1 | AI2 Asta prompt generation |
 | export | 1 | arXiv-ready tarball packaging |
 | claim | 6 | Traceable scientific assertions |
 | migration | 2 | Overleaf import/export |
+| checks | 2 | Reference integrity, float order |
+| skills | 2 | List and retrieve skill pages |
 | update | 1 | Template update from upstream |
 
 **Claude Desktop** (`~/.config/Claude/claude_desktop_config.json`):

--- a/docs/00_INDEX.md
+++ b/docs/00_INDEX.md
@@ -17,7 +17,7 @@ Technical design and implementation details:
 - **02_ARCHITECTURE_IMPLEMENTATION.md** - System architecture, technical implementation, and troubleshooting guide
 
 ### MCP Tools
-- **MCP_TOOLS.md** - Reference for all 29 MCP tools for AI agent integration
+- **MCP_TOOLS.md** - Reference for all 44 MCP tools for AI agent integration
 
 ## Subdirectories
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -1,4 +1,4 @@
-# SciTeX Writer MCP Tools (36 total)
+# SciTeX Writer MCP Tools (44 total)
 
 Model Context Protocol tools for AI agent integration.
 
@@ -6,7 +6,7 @@ Model Context Protocol tools for AI agent integration.
 scitex-writer mcp list-tools    # List all tools
 scitex-writer mcp start         # Start MCP server (stdio)
 scitex-writer mcp doctor        # Health check
-scitex-writer mcp installation  # Show Claude Desktop config
+scitex-writer mcp install       # Show Claude Desktop config guide
 ```
 
 ## Tools by Module
@@ -21,22 +21,11 @@ scitex-writer mcp installation  # Show Claude Desktop config
 | `writer_merge_bibfiles` | Merge all .bib files into one, with deduplication |
 | `writer_remove_bibentry` | Remove a BibTeX entry by citation key |
 
-### compile (4 tools)
+### checks (2 tools)
 | Tool | Description |
 |------|-------------|
-| `writer_compile_content` | Compile raw LaTeX content to PDF with color modes |
-| `writer_compile_manuscript` | Compile manuscript LaTeX document to PDF |
-| `writer_compile_revision` | Compile revision document to PDF with change tracking |
-| `writer_compile_supplementary` | Compile supplementary materials to PDF |
-
-### figures (5 tools)
-| Tool | Description |
-|------|-------------|
-| `writer_add_figure` | Add a figure (copy image + create caption) |
-| `writer_convert_figure` | Convert figure between formats (e.g., PDF to PNG) |
-| `writer_list_figures` | List all figures in a writer project |
-| `writer_pdf_to_images` | Render PDF pages as images |
-| `writer_remove_figure` | Remove a figure (image + caption) |
+| `writer_checks_references` | Check all LaTeX `\ref{}` / `\cite{}` resolve correctly |
+| `writer_checks_float_order` | Audit float (figure/table) numbering order |
 
 ### claim (6 tools)
 | Tool | Description |
@@ -48,15 +37,28 @@ scitex-writer mcp installation  # Show Claude Desktop config
 | `writer_remove_claim` | Delete a claim by ID |
 | `writer_render_claims` | Generate claims_rendered.tex for LaTeX compilation |
 
+### compile (4 tools)
+| Tool | Description |
+|------|-------------|
+| `writer_compile_content` | Compile raw LaTeX content to PDF with color modes |
+| `writer_compile_manuscript` | Compile manuscript LaTeX document to PDF |
+| `writer_compile_revision` | Compile revision document to PDF with change tracking |
+| `writer_compile_supplementary` | Compile supplementary materials to PDF |
+
 ### export (1 tool)
 | Tool | Description |
 |------|-------------|
 | `writer_export_manuscript` | Export manuscript for arXiv submission |
 
-### general (1 tool)
+### figures (6 tools)
 | Tool | Description |
 |------|-------------|
-| `usage` | Get usage guide for SciTeX Writer |
+| `writer_add_figure` | Add a figure (copy image + create caption) |
+| `writer_figures_archive` | Move a figure to legacy/ instead of deleting |
+| `writer_figures_convert` | Convert figure between formats (e.g., PDF to PNG) |
+| `writer_figures_list` | List all figures in a writer project |
+| `writer_figures_pdf_to_images` | Render PDF pages as images |
+| `writer_figures_remove` | Remove a figure (image + caption) |
 
 ### guidelines (3 tools)
 | Tool | Description |
@@ -64,6 +66,12 @@ scitex-writer mcp installation  # Show Claude Desktop config
 | `writer_guideline_build` | Build editing prompt by combining guideline with draft |
 | `writer_guideline_get` | Get IMRAD writing guideline for a manuscript section |
 | `writer_guideline_list` | List available IMRAD writing guideline sections |
+
+### migration (2 tools)
+| Tool | Description |
+|------|-------------|
+| `writer_migration_from_overleaf` | Import an Overleaf ZIP into a scitex-writer project |
+| `writer_migration_to_overleaf` | Export a scitex-writer project as an Overleaf-compatible ZIP |
 
 ### project (4 tools)
 | Tool | Description |
@@ -78,7 +86,13 @@ scitex-writer mcp installation  # Show Claude Desktop config
 |------|-------------|
 | `writer_prompts_asta` | Generate AI2 Asta prompt for finding related papers |
 
-### tables (5 tools)
+### skills (2 tools)
+| Tool | Description |
+|------|-------------|
+| `writer_skills_list` | List available skill pages |
+| `writer_skills_get` | Get the content of a specific skill page |
+
+### tables (6 tools)
 | Tool | Description |
 |------|-------------|
 | `writer_add_table` | Add a new table (CSV + caption) to the project |
@@ -86,6 +100,12 @@ scitex-writer mcp installation  # Show Claude Desktop config
 | `writer_latex_to_csv` | Convert LaTeX table to CSV format |
 | `writer_list_tables` | List all tables in a writer project |
 | `writer_remove_table` | Remove a table (CSV + caption) from the project |
+| `writer_tables_archive` | Move a table to legacy/ instead of deleting |
+
+### update (1 tool)
+| Tool | Description |
+|------|-------------|
+| `writer_update_project` | Update engine files from upstream template, preserving user content |
 
 ## Claude Desktop Configuration
 

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -21,7 +21,7 @@ SciTeX Writer - LaTeX Manuscript Compilation
 Key Features
 ------------
 
-- **Five Interfaces**: Shell/Make, Python API, CLI, GUI editor, and MCP server (38 tools)
+- **Five Interfaces**: Shell/Make, Python API, CLI, GUI editor, and MCP server (44 tools)
 - **GUI Editor**: Browser-based LaTeX editor with PDF preview (``scitex-writer gui``)
 - **Container-based Compilation**: Consistent LaTeX compilation across environments
 - **Document Types**: Manuscript, Supplementary, and Revision documents

--- a/src/scitex_writer/_skills/scitex-writer/07_cli-reference.md
+++ b/src/scitex_writer/_skills/scitex-writer/07_cli-reference.md
@@ -38,5 +38,5 @@ scitex-writer skills get                     # Get skill content
 
 Each compile stamps a 6-char build ID into the PDF `/Info` dictionary
 (`pdfsubject=build:XXXXXX`) and records it in
-`.scitex/writer/builds/builds.json`. Verify on any PDF via
+`.scitex/writer/runtime/builds/builds.json`. Verify on any PDF via
 `pdfinfo manuscript.pdf | grep Subject`.

--- a/src/scitex_writer/_skills/scitex-writer/SKILL.md
+++ b/src/scitex_writer/_skills/scitex-writer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scitex-writer
 description: |
-  [WHAT] End-to-end LaTeX manuscript toolchain — 45 MCP tools — project (clone/info/get_pdf), compile (manuscript / supplementary / revision with tracked changes), BibTeX (add/list/get/remove/merge, dedup by DOI), figures + tables (add/list/remove/archive, csv_to_latex, pdf_to_images), claims (`\vclaim{}` linked to scitex-clew session hashes for verifiable assertions), checks (float order, references), export + Overleaf migration, per-journal guidelines, AI2 Asta prompts.
+  [WHAT] End-to-end LaTeX manuscript toolchain — 44 MCP tools — project (clone/info/get_pdf), compile (manuscript / supplementary / revision with tracked changes), BibTeX (add/list/get/remove/merge, dedup by DOI), figures + tables (add/list/remove/archive, csv_to_latex, pdf_to_images), claims (`\vclaim{}` linked to scitex-clew session hashes for verifiable assertions), checks (float order, references), export + Overleaf migration, per-journal guidelines, AI2 Asta prompts.
   [WHEN] Use whenever the user asks to compile manuscript / build PDF / supplementary / revision with tracked changes, add figure/table/bibentry, merge or dedup .
   [HOW] `pip install scitex-writer` then `import scitex_writer`; see leaf skills for details.
 tags: [scitex-writer]


### PR DESCRIPTION
Update all stale documentation references to match the current codebase:
- MCP tool counts corrected (44 tools across 13 modules)
- Missing tool categories added to MCP_TOOLS.md
- CLI command name fix (mcp installation -> mcp install)
- Build registry path updated (builds/ -> runtime/builds/)
- Sphinx index and SKILL.md aligned