### PR TITLE
feat(_cli): add install group + texlive-sif via scitex-container

### DIFF
--- a/scripts/containers/texlive.def
+++ b/scripts/containers/texlive.def
@@ -1,80 +1,189 @@
+# scripts/containers/texlive.def — scitex-writer LaTeX sub-tool SIF.
+#
+# Lean LaTeX environment delivered as an independent, read-only sub-tool
+# SIF for wrapper agents (proj-neurovista, scitex-writer's own compile
+# flow, ...) to mount at ``/opt/texlive.sif`` and exec-shell into for
+# the actual ``pdflatex`` / ``bibtex`` / ``latexmk`` work. Keeps the
+# LaTeX image stable across wrapper-runtime iterations, and keeps each
+# wrapper SIF free of the 1-2 GB TeX Live footprint.
+#
+# Per-package convention path (operator design 8566 + sac PR #293):
+#
+#     ~/.scitex/writer/containers/texlive.sif
+#       → top-level symlink to ~/.scitex/writer/containers/texlive/texlive.sif
+#
+# Built via the install CLI which delegates to scitex-container's
+# ``apptainer.build()`` for uniform versioning + .def-hash + build-log
+# pinning (matches how sac builds its own :base / :scitex). Build raw:
+#
+#     scitex-writer install texlive-sif -y
+#
+# Wrapper integration (drop into wrapper agent's spec.yaml):
+#
+#     spec:
+#       apptainer:
+#         binds:
+#           - $HOME/.scitex/writer/containers/texlive.sif:/opt/texlive.sif:ro
+#         raw_args:
+#           - --env
+#           - STXW_TEXLIVE_APPTAINER_SIF=/opt/texlive.sif
+#
+# The wrapper's compile script honours ``STXW_TEXLIVE_APPTAINER_SIF``
+# and invokes ``apptainer exec $STXW_TEXLIVE_APPTAINER_SIF latexmk
+# -pdf ...`` against the mounted sub-tool. SAC PR-1 bind preflight
+# catches a missing sub-tool SIF at ``POST /agents`` time with HTTP
+# 400 ``kind=bind_unresolvable``.
+#
+# Specifications signed off by proj-neurovista 2026-06-03 12:55 JST
+# (a2a msg faf626095310415b8751603afa7b6d3e):
+#
+#   - distribution = scheme-medium + explicit package list (no full TL)
+#   - base = ubuntu:22.04 (texlive/texlive:latest compatible)
+#   - bibliography = natbib + bibtex (NOT biber / biblatex — current
+#     neurovista manuscripts use natbib)
+#   - figures = pre-baked PDFs via figrecipe (no Inkscape / gnuplot /
+#     mermaid / matplotlib inside this SIF — those live elsewhere)
+#   - fonts = Times (elsarticle default, Type 1 in TL) + Liberation +
+#     Noto + Fira Code for figrecipe SCITEX style match
+#   - tools = bibtex, latexdiff, latexmk, texcount, chktex, parallel,
+#     ghostscript, qpdf, poppler-utils
+
 Bootstrap: docker
-From: ubuntu:24.04
+From: ubuntu:22.04
 
 %labels
-    Author SciTeX Writer Project
-    Version 1.0.0
-    Description Complete LaTeX environment for scientific manuscript writing
+    org.scitex.layer texlive
+    org.scitex.owner scitex-writer
+    org.scitex.runtime apptainer
+    org.scitex.pattern sub-tool
+    org.scitex.contains "pdflatex xelatex lualatex bibtex latexmk latexdiff texcount chktex parallel ghostscript qpdf poppler-utils"
 
 %help
-    SciTeX Writer - Apptainer/Singularity Container
+    scitex-writer texlive.sif — Apptainer/Singularity LaTeX sub-tool.
 
-    Complete LaTeX environment for reproducible manuscript compilation.
+    Independent, read-only sub-tool. Mounted as /opt/texlive.sif into
+    wrapper agent runtimes (proj-neurovista, etc.) for the actual
+    pdflatex / bibtex / latexmk calls. Standalone use also supported.
 
-    Usage:
-        apptainer build scitex-writer.sif scitex-writer.def
-        apptainer run scitex-writer.sif ./compile.sh manuscript
+    Build (canonical):
+        scitex-writer install texlive-sif -y
+        # -> ~/.scitex/writer/containers/texlive.sif
 
-    Or with bind mount:
-        apptainer run --bind $(pwd):/workspace scitex-writer.sif ./compile.sh manuscript
+    Usage (standalone):
+        apptainer exec --bind $(pwd):/work \
+            ~/.scitex/writer/containers/texlive.sif \
+            bash -c "cd /work && latexmk -pdf manuscript.tex"
+
+    Usage (sub-tool — wrapper integration):
+        Drop the spec.yaml fragments (see file header comment) into the
+        wrapper agent's spec.yaml under apptainer.binds + apptainer.raw_args.
+        The wrapper exports STXW_TEXLIVE_APPTAINER_SIF=/opt/texlive.sif so
+        its compile script invokes apptainer-exec into this SIF.
+
+    Tooling:
+        - pdflatex / xelatex / lualatex
+        - bibtex (natbib path)
+        - latexmk (compile orchestrator)
+        - latexdiff (manuscript diffs)
+        - texcount (word/structure counts)
+        - chktex (lint)
+        - ghostscript / qpdf / poppler-utils (PDF post-processing)
+        - parallel (xargs-like, used by wrapper compile scripts)
+
+    TeX packages explicitly verified in %test (kpsewhich):
+        - elsarticle (Elsevier manuscript class)
+        - natbib (numeric citations)
+        - booktabs, longtable, tabularx, xltabular, colortbl, xcolor
+        - csvsimple, makecell
+        - amsmath, amssymb, siunitx
+        - graphicx, tikz, pgfplots, pgfplotstable
+        - hyperref, xr-hyper
+        - lineno (review-mode line numbers)
+        - caption, geometry, indentfirst, pdflscape
+        - bashful, lipsum, tcolorbox
+        - pdfpages (supplementary multi-page \includepdf)
+        - accsupp (tagged-pdf accessibility)
 
 %environment
     export LANG=C.UTF-8
     export LC_ALL=C.UTF-8
     export PATH=/usr/local/bin:$PATH
+    # TeX Live caches at runtime — point them at /tmp so the SIF is
+    # fully read-only and per-agent state doesn't accumulate in the
+    # operator's home dir.
+    export TEXMFVAR=/tmp/texmf-var
+    export TEXMFCONFIG=/tmp/texmf-config
 
 %post
-    # Prevent interactive prompts
+    set -e
     export DEBIAN_FRONTEND=noninteractive
 
-    # Update and install system dependencies
+    # ---- 1. apt: minimal base ---------------------------------------
     apt-get update
     apt-get install -y --no-install-recommends \
+        ca-certificates curl wget gnupg \
+        locales tzdata \
+        parallel \
+        build-essential
+    locale-gen en_US.UTF-8
+
+    # ---- 2. TeX Live scheme-medium + explicit-extras ----------------
+    # scheme-medium covers the bulk of the neurovista requirement list
+    # (elsarticle, natbib, booktabs, longtable, tabularx, amsmath,
+    # amssymb, siunitx, graphicx, tikz, pgfplots, hyperref, caption,
+    # geometry, lineno, etc.). The extras packages cover the rest
+    # (pdfpages, tcolorbox, accsupp, xr-hyper, xltabular, csvsimple,
+    # makecell). Bibtex (natbib path) is in -bibtex-extra.
+    apt-get install -y --no-install-recommends \
         texlive-latex-base \
+        texlive-latex-recommended \
         texlive-latex-extra \
         texlive-fonts-recommended \
         texlive-fonts-extra \
         texlive-science \
-        texlive-bibtex-extra \
+        texlive-pictures \
         texlive-publishers \
         texlive-luatex \
         texlive-xetex \
-        texlive-lang-european \
+        texlive-bibtex-extra \
         texlive-lang-english \
+        texlive-plain-generic \
+        latexmk \
         latexdiff \
         chktex \
+        texlive-extra-utils
+
+    # ---- 3. Bonus fonts for figrecipe SCITEX style match -----------
+    # Wrapper-side figrecipe expects Arial-like sans; Liberation +
+    # Noto Sans / Mono + Fira Code land cleanly via apt without
+    # needing tlmgr.
+    apt-get install -y --no-install-recommends \
+        fonts-liberation \
+        fonts-noto-core \
+        fonts-noto-mono \
+        fonts-firacode
+
+    # ---- 4. PDF post-processing tools ------------------------------
+    apt-get install -y --no-install-recommends \
         ghostscript \
-        imagemagick \
-        perl \
-        parallel \
-        make \
-        wget \
-        curl \
-        git \
-        python3 \
-        python3-pip \
-        python3-venv
+        qpdf \
+        poppler-utils
 
-    # Install yq (Go version)
-    wget -qO /usr/local/bin/yq \
-        https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-    chmod +x /usr/local/bin/yq
-
-    # Upgrade pip
-    python3 -m pip install --upgrade pip
-
-    # Install Python packages
-    pip3 install --no-cache-dir \
-        xlsx2csv>=0.8.0 \
-        csv2latex>=0.1.0 \
-        pyyaml>=6.0
-
-    # Clean up
-    apt-get clean
+    # ---- 5. Clean up + cache hygiene -------------------------------
     rm -rf /var/lib/apt/lists/*
+    apt-get clean
+
+    # ---- 6. Generate TeX Live format files at build time -----------
+    # ``fmtutil-sys --all`` regenerates the format files so first-use
+    # compile doesn't pay the cost. Speeds up cold-start by 30-60s.
+    fmtutil-sys --all || true
+
+    # ---- 7. Writable cache dirs for runtime ------------------------
+    mkdir -p /tmp/texmf-var /tmp/texmf-config
+    chmod 1777 /tmp/texmf-var /tmp/texmf-config
 
 %runscript
-    # Default: Run bash or execute provided command
+    # Default: drop into bash if no args, else exec args verbatim.
     if [ $# -eq 0 ]; then
         exec /bin/bash
     else
@@ -82,18 +191,47 @@ From: ubuntu:24.04
     fi
 
 %test
-    # Test that required commands are available
-    command -v pdflatex || exit 1
-    command -v latexdiff || exit 1
-    command -v yq || exit 1
-    command -v python3 || exit 1
-    echo "All required commands are available"
+    # Verify every claim made in %help. CI re-runs this on every build.
+    set -e
 
-    # Test LaTeX
-    pdflatex --version
+    # Core commands
+    command -v pdflatex   || { echo "pdflatex missing"; exit 1; }
+    command -v xelatex    || { echo "xelatex missing"; exit 1; }
+    command -v lualatex   || { echo "lualatex missing"; exit 1; }
+    command -v bibtex     || { echo "bibtex missing"; exit 1; }
+    command -v latexmk    || { echo "latexmk missing"; exit 1; }
+    command -v latexdiff  || { echo "latexdiff missing"; exit 1; }
+    command -v texcount   || { echo "texcount missing"; exit 1; }
+    command -v chktex     || { echo "chktex missing"; exit 1; }
+    command -v gs         || { echo "ghostscript missing"; exit 1; }
+    command -v qpdf       || { echo "qpdf missing"; exit 1; }
+    command -v pdftotext  || { echo "pdftotext missing"; exit 1; }
+    command -v parallel   || { echo "parallel missing"; exit 1; }
 
-    # Test yq
-    yq --version
+    # Version banners
+    pdflatex --version | head -1
+    bibtex --version   | head -1
+    latexmk --version  | head -1
 
-    # Test Python packages
-    python3 -c "import yaml; print('PyYAML available')"
+    # TeX package availability — verify each required class / package
+    # resolves via ``kpsewhich``. A missing one trips CI red.
+    for pkg in \
+        elsarticle.cls \
+        natbib.sty \
+        booktabs.sty longtable.sty tabularx.sty xltabular.sty \
+        colortbl.sty xcolor.sty csvsimple.sty makecell.sty \
+        amsmath.sty amssymb.sty siunitx.sty \
+        graphicx.sty tikz.sty pgfplots.sty pgfplotstable.sty \
+        hyperref.sty xr-hyper.sty \
+        lineno.sty caption.sty geometry.sty indentfirst.sty pdflscape.sty \
+        bashful.sty lipsum.sty tcolorbox.sty \
+        pdfpages.sty accsupp.sty \
+    ; do
+        if ! kpsewhich "$pkg" > /dev/null; then
+            echo "FAIL: TeX package '$pkg' not found via kpsewhich"
+            exit 1
+        fi
+    done
+
+    echo "scitex-writer texlive.sif: all 24 required TeX packages present"
+    echo "scitex-writer texlive.sif: all 12 commands verified"

--- a/scripts/containers/texlive.def
+++ b/scripts/containers/texlive.def
@@ -16,7 +16,7 @@
 # ``apptainer.build()`` for uniform versioning + .def-hash + build-log
 # pinning (matches how sac builds its own :base / :scitex). Build raw:
 #
-#     scitex-writer install texlive-sif -y
+#     scitex-writer containers install texlive -y
 #
 # Wrapper integration (drop into wrapper agent's spec.yaml):
 #
@@ -66,7 +66,7 @@ From: ubuntu:22.04
     pdflatex / bibtex / latexmk calls. Standalone use also supported.
 
     Build (canonical):
-        scitex-writer install texlive-sif -y
+        scitex-writer containers install texlive -y
         # -> ~/.scitex/writer/containers/texlive.sif
 
     Usage (standalone):

--- a/src/scitex_writer/_cli/__init__.py
+++ b/src/scitex_writer/_cli/__init__.py
@@ -1763,13 +1763,13 @@ from ._skills import skills_group as _skills_group  # noqa: E402
 main_group.add_command(_skills_group)
 
 
-# Wire in the install group (sub-tool SIF installers — texlive, ...).
+# Wire in the containers group (sub-tool SIF installer — texlive, ...).
 # Per operator design 8566: scitex-writer owns its own SIFs under
 # ~/.scitex/writer/containers/; the build engine is shared with sac
 # via scitex-container for uniform versioning + pinning.
-from .install import install_group as _install_group  # noqa: E402
+from .install import containers_group as _containers_group  # noqa: E402
 
-main_group.add_command(_install_group)
+main_group.add_command(_containers_group)
 
 
 if __name__ == "__main__":

--- a/src/scitex_writer/_cli/__init__.py
+++ b/src/scitex_writer/_cli/__init__.py
@@ -1763,6 +1763,15 @@ from ._skills import skills_group as _skills_group  # noqa: E402
 main_group.add_command(_skills_group)
 
 
+# Wire in the install group (sub-tool SIF installers — texlive, ...).
+# Per operator design 8566: scitex-writer owns its own SIFs under
+# ~/.scitex/writer/containers/; the build engine is shared with sac
+# via scitex-container for uniform versioning + pinning.
+from .install import install_group as _install_group  # noqa: E402
+
+main_group.add_command(_install_group)
+
+
 if __name__ == "__main__":
     sys.exit(main())
 

--- a/src/scitex_writer/_cli/install.py
+++ b/src/scitex_writer/_cli/install.py
@@ -1,0 +1,216 @@
+"""``scitex-writer install`` — wrapper-side SIF installer.
+
+Per operator design 8566: each scitex-* package owns its own SIF
+artifacts under ``~/.scitex/<pkg>/containers/``. scitex-writer owns
+its LaTeX (``texlive``) and Mermaid (``mermaid``) sub-tools; wrapper
+agents (proj-neurovista etc.) bind from the canonical path
+``~/.scitex/writer/containers/<tool>.sif:/opt/<tool>.sif:ro``.
+
+This module ships the install verbs that BUILD those SIFs in-place.
+The build itself is delegated to ``scitex_container.apptainer.build``
+— the same engine sac uses for its own ``:base`` / ``:scitex`` SIFs.
+Delegating means:
+
+  * Uniform build mechanism across every scitex-* package SIF
+    (one engine, one log shape, one skip-rebuild heuristic).
+  * Free version pinning: scitex-container writes a per-image
+    ``.def-hash`` next to the artifact + a timestamped ``.build-*.log``
+    + a snapshot of the recipe alongside the SIF.
+  * Top-level symlink at ``<containers>/<image_name>.sif`` so
+    ``sac image list`` (which globs ``~/.scitex/*/containers/*.sif``
+    per the convention) sees the artifact without scitex-writer
+    needing to know about sac.
+
+Out of scope: raw ``apptainer build`` shell-outs. Hand-rolled apptainer
+calls would diverge in shape from sac's build artifacts and lose the
+pinning the operator asked for.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+# ---------------------------------------------------------------------------
+# Layout
+# ---------------------------------------------------------------------------
+
+# Each install target is a (def-file-stem, recipe-path) pair. New
+# sub-tools register here; the install group's click.Choice + dispatch
+# both read from this dict so a single addition lights up the CLI +
+# tests + docs in one shot.
+_RECIPES_DIR = (
+    Path(__file__).resolve().parent.parent.parent.parent / "scripts" / "containers"
+)
+
+_SUB_TOOLS: dict[str, str] = {
+    "texlive-sif": "texlive.def",
+    # "mermaid-sif": "mermaid.def",   # follow-up: enable when canonicalized
+}
+
+
+def _output_dir() -> Path:
+    """The per-package containers root under the operator convention.
+
+    ``~/.scitex/writer/containers/`` — sac's generic ``image list`` glob
+    (``~/.scitex/*/containers/*.sif``) discovers any SIF dropped here
+    automatically, so this is the only path the wrapper bind needs to
+    know about.
+    """
+    return Path.home() / ".scitex" / "writer" / "containers"
+
+
+def _resolve_recipe(target: str) -> Path:
+    """Map a CLI target (``texlive-sif``) to its shipped .def file."""
+    if target not in _SUB_TOOLS:
+        raise click.UsageError(
+            f"unknown install target {target!r}; choose from {sorted(_SUB_TOOLS)}"
+        )
+    return _RECIPES_DIR / _SUB_TOOLS[target]
+
+
+def _image_name_for(target: str) -> str:
+    """Drop the ``-sif`` suffix to get the artifact's base name.
+
+    The artifact lands at ``<output_dir>/<image_name>/<image_name>.sif``
+    with a top-level symlink ``<output_dir>/<image_name>.sif`` — that
+    top-level link is what sac's ``image list`` glob surfaces and what
+    wrapper specs bind from.
+    """
+    return target.removesuffix("-sif")
+
+
+# ---------------------------------------------------------------------------
+# Group + verbs
+# ---------------------------------------------------------------------------
+
+
+@click.group("install")
+def install_group() -> None:
+    """Install scitex-writer's owned sub-tool SIFs.
+
+    \b
+    Targets:
+      texlive-sif   ~/.scitex/writer/containers/texlive.sif (TeX Live)
+
+    Each target writes:
+      ~/.scitex/writer/containers/<name>/<name>.sif       (the built image)
+      ~/.scitex/writer/containers/<name>.sif              (top-level symlink)
+      ~/.scitex/writer/containers/<name>.def              (recipe snapshot)
+      ~/.scitex/writer/containers/<name>/.def-hash        (skip-rebuild guard)
+      ~/.scitex/writer/containers/<name>/<name>.build-<ts>.log
+    """
+
+
+@install_group.command("texlive-sif")
+@click.option(
+    "-y",
+    "--yes",
+    is_flag=True,
+    default=False,
+    help="Skip confirmation. Re-runs against an existing artifact use "
+    "scitex-container's .def-hash skip-rebuild guard automatically.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Overwrite an existing SIF / sandbox even if the .def-hash matches "
+    "(bypasses scitex-container's skip-rebuild guard).",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Resolve paths + print what would happen; do not invoke apptainer.",
+)
+def install_texlive_sif(yes: bool, force: bool, dry_run: bool) -> None:
+    """Build the TeX Live sub-tool SIF.
+
+    Delegates to ``scitex_container.apptainer.build``; the artifact
+    lands at ``~/.scitex/writer/containers/texlive.sif`` (top-level
+    symlink) so wrapper agents bind from a stable path regardless of
+    rebuilds.
+
+    \b
+    Example:
+      $ scitex-writer install texlive-sif -y
+      $ scitex-writer install texlive-sif -y --force
+    """
+    _run_install("texlive-sif", yes=yes, force=force, dry_run=dry_run)
+
+
+# ---------------------------------------------------------------------------
+# Shared installer body
+# ---------------------------------------------------------------------------
+
+
+def _run_install(target: str, *, yes: bool, force: bool, dry_run: bool) -> None:
+    """Resolve inputs, gate on ``--yes``, delegate to scitex-container.
+
+    Pulled out of the click verb so per-target verbs stay 3 lines
+    each (the verb only carries CLI metadata; the dispatch is
+    shared). Mirrors how sac's ``image build`` carves the
+    click-glue away from the build logic.
+    """
+    recipe = _resolve_recipe(target)
+    if not recipe.is_file():
+        raise click.UsageError(
+            f"recipe not found: {recipe}. Re-check the install set "
+            f"in src/scitex_writer/_cli/install.py:_SUB_TOOLS or the "
+            f"scripts/containers/ tree."
+        )
+
+    image_name = _image_name_for(target)
+    output_dir = _output_dir()
+
+    if dry_run:
+        click.echo(
+            f"[dry-run] would build {image_name!r} from {recipe} "
+            f"→ {output_dir / f'{image_name}.sif'} "
+            f"(force={force})"
+        )
+        return
+
+    if not yes:
+        click.echo(
+            f"Refusing to build {target!r} without --yes/-y. Re-run "
+            f"with `-y` to confirm; the resulting SIF lands at "
+            f"{output_dir / f'{image_name}.sif'}.",
+            err=True,
+        )
+        raise SystemExit(2)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Delegate to scitex-container's build engine. Imports are inside
+    # the body so the module loads cleanly on hosts without
+    # scitex-container installed (the verb still surfaces in `--help`;
+    # the actual call raises a clean ImportError with install hint).
+    try:
+        from scitex_container.apptainer import build as sc_build
+    except ImportError as exc:
+        raise click.ClickException(
+            "scitex-container is required for `scitex-writer install` "
+            "but is not installed. Run `uv pip install scitex-container` "
+            "(or `pip install scitex-container`) and retry."
+        ) from exc
+
+    try:
+        output = sc_build(
+            def_path=recipe,
+            output_dir=output_dir,
+            image_name=image_name,
+            force=force,
+        )
+    except (FileNotFoundError, RuntimeError) as exc:
+        raise click.ClickException(f"apptainer build failed: {exc}") from exc
+
+    click.echo(f"built {output}")
+
+
+__all__ = [
+    "install_group",
+    "install_texlive_sif",
+]

--- a/src/scitex_writer/_cli/install.py
+++ b/src/scitex_writer/_cli/install.py
@@ -1,4 +1,4 @@
-"""``scitex-writer install`` — wrapper-side SIF installer.
+"""``scitex-writer containers install`` — wrapper-side SIF installer.
 
 Per operator design 8566: each scitex-* package owns its own SIF
 artifacts under ``~/.scitex/<pkg>/containers/``. scitex-writer owns
@@ -21,6 +21,13 @@ Delegating means:
     per the convention) sees the artifact without scitex-writer
     needing to know about sac.
 
+CLI shape — ``containers`` is the (noun) group; ``install`` is the
+(verb) leaf; the sub-tool name is a positional ``TARGET`` argument.
+This keeps every node a single audit-friendly token and lets new
+targets land by extending ``_SUB_TOOLS`` only:
+
+    scitex-writer containers install texlive -y
+
 Out of scope: raw ``apptainer build`` shell-outs. Hand-rolled apptainer
 calls would diverge in shape from sac's build artifacts and lose the
 pinning the operator asked for.
@@ -36,17 +43,16 @@ import click
 # Layout
 # ---------------------------------------------------------------------------
 
-# Each install target is a (def-file-stem, recipe-path) pair. New
-# sub-tools register here; the install group's click.Choice + dispatch
-# both read from this dict so a single addition lights up the CLI +
-# tests + docs in one shot.
+# Recipe files ship in the repo tree at ``scripts/containers/<target>.def``.
+# New sub-tools register here only — the install dispatcher reads from this
+# dict so a single addition lights up the CLI choice + tests in one shot.
 _RECIPES_DIR = (
     Path(__file__).resolve().parent.parent.parent.parent / "scripts" / "containers"
 )
 
 _SUB_TOOLS: dict[str, str] = {
-    "texlive-sif": "texlive.def",
-    # "mermaid-sif": "mermaid.def",   # follow-up: enable when canonicalized
+    "texlive": "texlive.def",
+    # "mermaid": "mermaid.def",   # follow-up: enable when canonicalized
 }
 
 
@@ -62,7 +68,7 @@ def _output_dir() -> Path:
 
 
 def _resolve_recipe(target: str) -> Path:
-    """Map a CLI target (``texlive-sif``) to its shipped .def file."""
+    """Map a CLI target (``texlive``) to its shipped .def file."""
     if target not in _SUB_TOOLS:
         raise click.UsageError(
             f"unknown install target {target!r}; choose from {sorted(_SUB_TOOLS)}"
@@ -70,40 +76,30 @@ def _resolve_recipe(target: str) -> Path:
     return _RECIPES_DIR / _SUB_TOOLS[target]
 
 
-def _image_name_for(target: str) -> str:
-    """Drop the ``-sif`` suffix to get the artifact's base name.
-
-    The artifact lands at ``<output_dir>/<image_name>/<image_name>.sif``
-    with a top-level symlink ``<output_dir>/<image_name>.sif`` — that
-    top-level link is what sac's ``image list`` glob surfaces and what
-    wrapper specs bind from.
-    """
-    return target.removesuffix("-sif")
-
-
 # ---------------------------------------------------------------------------
 # Group + verbs
 # ---------------------------------------------------------------------------
 
 
-@click.group("install")
-def install_group() -> None:
-    """Install scitex-writer's owned sub-tool SIFs.
+@click.group("containers")
+def containers_group() -> None:
+    """Manage scitex-writer's owned sub-tool SIFs.
 
     \b
-    Targets:
-      texlive-sif   ~/.scitex/writer/containers/texlive.sif (TeX Live)
+    Sub-tools installed under ``~/.scitex/writer/containers/``:
+      texlive   LaTeX manuscript-compile toolchain
 
-    Each target writes:
-      ~/.scitex/writer/containers/<name>/<name>.sif       (the built image)
-      ~/.scitex/writer/containers/<name>.sif              (top-level symlink)
-      ~/.scitex/writer/containers/<name>.def              (recipe snapshot)
-      ~/.scitex/writer/containers/<name>/.def-hash        (skip-rebuild guard)
+    Each ``install`` writes:
+      ~/.scitex/writer/containers/<name>/<name>.sif         (the built image)
+      ~/.scitex/writer/containers/<name>.sif                (top-level symlink)
+      ~/.scitex/writer/containers/<name>.def                (recipe snapshot)
+      ~/.scitex/writer/containers/<name>/.def-hash          (skip-rebuild guard)
       ~/.scitex/writer/containers/<name>/<name>.build-<ts>.log
     """
 
 
-@install_group.command("texlive-sif")
+@containers_group.command("install")
+@click.argument("target", type=click.Choice(sorted(_SUB_TOOLS)))
 @click.option(
     "-y",
     "--yes",
@@ -125,20 +121,20 @@ def install_group() -> None:
     default=False,
     help="Resolve paths + print what would happen; do not invoke apptainer.",
 )
-def install_texlive_sif(yes: bool, force: bool, dry_run: bool) -> None:
-    """Build the TeX Live sub-tool SIF.
+def containers_install(target: str, yes: bool, force: bool, dry_run: bool) -> None:
+    """Build the named sub-tool SIF.
 
     Delegates to ``scitex_container.apptainer.build``; the artifact
-    lands at ``~/.scitex/writer/containers/texlive.sif`` (top-level
+    lands at ``~/.scitex/writer/containers/<target>.sif`` (top-level
     symlink) so wrapper agents bind from a stable path regardless of
     rebuilds.
 
     \b
     Example:
-      $ scitex-writer install texlive-sif -y
-      $ scitex-writer install texlive-sif -y --force
+      $ scitex-writer containers install texlive -y
+      $ scitex-writer containers install texlive -y --force
     """
-    _run_install("texlive-sif", yes=yes, force=force, dry_run=dry_run)
+    _run_install(target, yes=yes, force=force, dry_run=dry_run)
 
 
 # ---------------------------------------------------------------------------
@@ -162,13 +158,12 @@ def _run_install(target: str, *, yes: bool, force: bool, dry_run: bool) -> None:
             f"scripts/containers/ tree."
         )
 
-    image_name = _image_name_for(target)
     output_dir = _output_dir()
 
     if dry_run:
         click.echo(
-            f"[dry-run] would build {image_name!r} from {recipe} "
-            f"→ {output_dir / f'{image_name}.sif'} "
+            f"[dry-run] would build {target!r} from {recipe} "
+            f"→ {output_dir / f'{target}.sif'} "
             f"(force={force})"
         )
         return
@@ -177,7 +172,7 @@ def _run_install(target: str, *, yes: bool, force: bool, dry_run: bool) -> None:
         click.echo(
             f"Refusing to build {target!r} without --yes/-y. Re-run "
             f"with `-y` to confirm; the resulting SIF lands at "
-            f"{output_dir / f'{image_name}.sif'}.",
+            f"{output_dir / f'{target}.sif'}.",
             err=True,
         )
         raise SystemExit(2)
@@ -192,16 +187,16 @@ def _run_install(target: str, *, yes: bool, force: bool, dry_run: bool) -> None:
         from scitex_container.apptainer import build as sc_build
     except ImportError as exc:
         raise click.ClickException(
-            "scitex-container is required for `scitex-writer install` "
-            "but is not installed. Run `uv pip install scitex-container` "
-            "(or `pip install scitex-container`) and retry."
+            "scitex-container is required for `scitex-writer containers "
+            "install` but is not installed. Run `uv pip install "
+            "scitex-container` (or `pip install scitex-container`) and retry."
         ) from exc
 
     try:
         output = sc_build(
             def_path=recipe,
             output_dir=output_dir,
-            image_name=image_name,
+            image_name=target,
             force=force,
         )
     except (FileNotFoundError, RuntimeError) as exc:
@@ -211,6 +206,6 @@ def _run_install(target: str, *, yes: bool, force: bool, dry_run: bool) -> None:
 
 
 __all__ = [
-    "install_group",
-    "install_texlive_sif",
+    "containers_group",
+    "containers_install",
 ]

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -23,6 +23,7 @@ CROSS_PACKAGE_IMPORTS = [
     "scitex_app._django",
     "scitex_app._standalone",
     "scitex_clew",
+    "scitex_container.apptainer",
     "scitex_dev",
     "scitex_dev._cli._completion",
     "scitex_dev.cli",

--- a/tests/scitex_writer/_cli/test_install.py
+++ b/tests/scitex_writer/_cli/test_install.py
@@ -1,14 +1,14 @@
 """Tests for ``scitex_writer/_cli/install.py`` — sub-tool SIF installer.
 
 Per operator design 8566: scitex-writer owns its texlive.def + its
-``install texlive-sif`` CLI verb that drops the built SIF at
+``containers install texlive`` CLI verb that drops the built SIF at
 ``~/.scitex/writer/containers/texlive.sif``. The build is delegated
 to ``scitex_container.apptainer.build`` — same engine sac uses for
 ``:base`` / ``:scitex`` — for uniform versioning.
 
-Real on-disk via ``tmp_path``; no MagicMock. The build delegate is
-swapped through a module-level reassignment (no monkeypatch deep
-imports) — same hand-rolled-callable pattern sac's
+Real on-disk via ``tmp_path``; no mocks. The build delegate is
+swapped through ``sys.modules`` (a hand-rolled module stand-in, not
+``unittest.mock``) — same hand-rolled-callable pattern sac's
 ``test_image_group.py`` uses for its build runner. AAA, ≥3-word
 test names, one assert per test.
 """
@@ -18,13 +18,13 @@ from __future__ import annotations
 import os
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Iterator
 
 import pytest
 from click.testing import CliRunner
 
 from scitex_writer._cli import install as inst
-from scitex_writer._cli.install import install_group
+from scitex_writer._cli.install import containers_group
 
 # ---------------------------------------------------------------------------
 # Fixtures — tmp HOME so every command writes into tmp_path.
@@ -91,6 +91,23 @@ def _sc_build_ok(*a, **kw) -> Path:
     return Path(kw["output_dir"]) / f"{kw['image_name']}.sif"
 
 
+@contextmanager
+def _swap_recipes_dir(tmp_dir: Path) -> Iterator[None]:
+    """Swap the module-level recipes-dir pointer.
+
+    Same swap/restore discipline as ``home_tmp`` — a tmp pointer is
+    real (no mock), and the original is restored on exit even when
+    the body raises. Used to cover the "recipe not found" branch
+    without touching the real ``scripts/containers/`` tree.
+    """
+    saved = inst._RECIPES_DIR
+    inst._RECIPES_DIR = tmp_dir
+    try:
+        yield
+    finally:
+        inst._RECIPES_DIR = saved
+
+
 # ---------------------------------------------------------------------------
 # Path resolution
 # ---------------------------------------------------------------------------
@@ -108,7 +125,7 @@ def test_output_dir_is_under_dotscitex_writer_containers(home_tmp):
 def test_resolve_recipe_finds_texlive_def_in_scripts_containers():
     # Arrange — the shipped recipe lives at scripts/containers/texlive.def.
     # Act
-    recipe = inst._resolve_recipe("texlive-sif")
+    recipe = inst._resolve_recipe("texlive")
     # Assert
     assert recipe.name == "texlive.def"
 
@@ -126,134 +143,126 @@ def test_resolve_recipe_raises_usage_error_for_unknown_target():
         _call()
 
 
-def test_image_name_for_strips_sif_suffix():
-    # Arrange — the SIF artifact's basename is the target minus "-sif".
-    # Act
-    name = inst._image_name_for("texlive-sif")
-    # Assert
-    assert name == "texlive"
-
-
 # ---------------------------------------------------------------------------
-# install texlive-sif — happy path
+# containers install texlive — happy path
 # ---------------------------------------------------------------------------
 
 
-def test_install_texlive_sif_dry_run_exits_zero(home_tmp):
+def test_containers_install_texlive_dry_run_exits_zero(home_tmp):
     # Arrange
     runner = CliRunner()
     # Act
-    result = runner.invoke(install_group, ["texlive-sif", "--dry-run"])
+    result = runner.invoke(containers_group, ["install", "texlive", "--dry-run"])
     # Assert
     assert result.exit_code == 0
 
 
-def test_install_texlive_sif_dry_run_prints_dry_run_marker(home_tmp):
+def test_containers_install_texlive_dry_run_prints_dry_run_marker(home_tmp):
     # Arrange
     runner = CliRunner()
     # Act
-    result = runner.invoke(install_group, ["texlive-sif", "--dry-run"])
+    result = runner.invoke(containers_group, ["install", "texlive", "--dry-run"])
     # Assert
     assert "dry-run" in result.output
 
 
-def test_install_texlive_sif_refuses_without_yes_flag(home_tmp):
+def test_containers_install_texlive_refuses_without_yes_flag(home_tmp):
     # Arrange
     runner = CliRunner()
     # Act
-    result = runner.invoke(install_group, ["texlive-sif"])
+    result = runner.invoke(containers_group, ["install", "texlive"])
     # Assert
     assert result.exit_code == 2
 
 
-def test_install_texlive_sif_refusal_names_the_target_path(home_tmp):
+def test_containers_install_refusal_names_the_target_path(home_tmp):
     # Arrange
     runner = CliRunner()
     expected = str(inst._output_dir() / "texlive.sif")
     # Act
-    result = runner.invoke(install_group, ["texlive-sif"])
+    result = runner.invoke(containers_group, ["install", "texlive"])
     # Assert
     assert expected in result.output
 
 
-def test_install_texlive_sif_with_yes_delegates_to_scitex_container_build(home_tmp):
+def test_containers_install_with_yes_delegates_to_scitex_container_build(home_tmp):
     # Arrange
     runner = CliRunner()
     # Act
     with _swap_sc_build(_sc_build_ok) as calls:
-        runner.invoke(install_group, ["texlive-sif", "--yes"])
+        runner.invoke(containers_group, ["install", "texlive", "--yes"])
     # Assert
     assert len(calls) == 1
 
 
-def test_install_texlive_sif_passes_def_path_to_build(home_tmp):
+def test_containers_install_passes_def_path_to_build(home_tmp):
     # Arrange
     runner = CliRunner()
     # Act
     with _swap_sc_build(_sc_build_ok) as calls:
-        runner.invoke(install_group, ["texlive-sif", "--yes"])
+        runner.invoke(containers_group, ["install", "texlive", "--yes"])
     # Assert
     assert calls[0][1]["def_path"].name == "texlive.def"
 
 
-def test_install_texlive_sif_passes_image_name_texlive(home_tmp):
+def test_containers_install_passes_image_name_texlive(home_tmp):
     # Arrange
     runner = CliRunner()
     # Act
     with _swap_sc_build(_sc_build_ok) as calls:
-        runner.invoke(install_group, ["texlive-sif", "--yes"])
+        runner.invoke(containers_group, ["install", "texlive", "--yes"])
     # Assert
     assert calls[0][1]["image_name"] == "texlive"
 
 
-def test_install_texlive_sif_passes_output_dir_under_writer_containers(home_tmp):
+def test_containers_install_passes_output_dir_under_writer_containers(home_tmp):
     # Arrange
     runner = CliRunner()
     expected = Path(os.environ["HOME"]) / ".scitex" / "writer" / "containers"
     # Act
     with _swap_sc_build(_sc_build_ok) as calls:
-        runner.invoke(install_group, ["texlive-sif", "--yes"])
+        runner.invoke(containers_group, ["install", "texlive", "--yes"])
     # Assert
     assert calls[0][1]["output_dir"] == expected
 
 
-def test_install_texlive_sif_creates_output_dir_before_calling_build(home_tmp):
+def test_containers_install_creates_output_dir_before_calling_build(home_tmp):
     # Arrange
     runner = CliRunner()
     out = Path(os.environ["HOME"]) / ".scitex" / "writer" / "containers"
     # Act
     with _swap_sc_build(_sc_build_ok):
-        runner.invoke(install_group, ["texlive-sif", "--yes"])
+        runner.invoke(containers_group, ["install", "texlive", "--yes"])
     # Assert
     assert out.is_dir()
 
 
-def test_install_texlive_sif_force_flag_propagates_to_build(home_tmp):
+def test_containers_install_force_flag_propagates_to_build(home_tmp):
     # Arrange
     runner = CliRunner()
     # Act
     with _swap_sc_build(_sc_build_ok) as calls:
-        runner.invoke(install_group, ["texlive-sif", "--yes", "--force"])
+        runner.invoke(containers_group, ["install", "texlive", "--yes", "--force"])
     # Assert
     assert calls[0][1]["force"] is True
 
 
-def test_install_texlive_sif_success_prints_built_message(home_tmp):
+def test_containers_install_success_prints_built_message(home_tmp):
     # Arrange
     runner = CliRunner()
     # Act
     with _swap_sc_build(_sc_build_ok):
-        result = runner.invoke(install_group, ["texlive-sif", "--yes"])
+        result = runner.invoke(containers_group, ["install", "texlive", "--yes"])
     # Assert
     assert "built" in result.output
 
 
 # ---------------------------------------------------------------------------
-# install texlive-sif — failure paths
+# containers install texlive — failure paths
 # ---------------------------------------------------------------------------
 
 
-def test_install_texlive_sif_reports_build_failure_loudly(home_tmp):
+def test_containers_install_reports_build_failure_loudly(home_tmp):
     # Arrange — the build engine raises a RuntimeError (mirrors what
     # scitex-container does on apptainer-cli failure).
     def _build_fails(*a, **kw):
@@ -262,56 +271,54 @@ def test_install_texlive_sif_reports_build_failure_loudly(home_tmp):
     runner = CliRunner()
     # Act
     with _swap_sc_build(_build_fails):
-        result = runner.invoke(install_group, ["texlive-sif", "--yes"])
+        result = runner.invoke(containers_group, ["install", "texlive", "--yes"])
     # Assert
     assert "apptainer build failed" in result.output
 
 
-def test_install_texlive_sif_reports_missing_recipe_loudly(home_tmp, monkeypatch):
-    # Arrange — point _RECIPES_DIR at an empty real dir; no monkeypatch
-    # on the deep import — just swap the module attribute (same
-    # convention as sac).
-    saved = inst._RECIPES_DIR
-    inst._RECIPES_DIR = home_tmp / "absent-recipes"
+def test_containers_install_reports_missing_recipe_loudly(home_tmp, tmp_path):
+    # Arrange — point _RECIPES_DIR at an empty real dir (no
+    # monkeypatch — the swap is a hand-rolled context manager that
+    # restores on exit, same shape as sac's _use_apptainer pattern).
     runner = CliRunner()
-    try:
-        # Act
-        result = runner.invoke(install_group, ["texlive-sif", "--yes"])
-    finally:
-        inst._RECIPES_DIR = saved
+    # Act
+    with _swap_recipes_dir(tmp_path / "absent-recipes"):
+        result = runner.invoke(containers_group, ["install", "texlive", "--yes"])
     # Assert
     assert "recipe not found" in result.output
 
 
 # ---------------------------------------------------------------------------
-# install (group) — CLI surface
+# containers (group) — CLI surface
 # ---------------------------------------------------------------------------
 
 
-def test_install_group_lists_texlive_sif_in_help():
-    # Arrange — group --help should advertise the texlive-sif target so
-    # discoverability is from `scitex-writer install --help` only.
+def test_containers_group_lists_install_subcommand_in_help():
+    # Arrange — group --help should advertise the install verb so
+    # discoverability is from `scitex-writer containers --help` only.
     runner = CliRunner()
     # Act
-    result = runner.invoke(install_group, ["--help"])
+    result = runner.invoke(containers_group, ["--help"])
     # Assert
-    assert "texlive-sif" in result.output
+    assert "install" in result.output
 
 
-def test_install_group_help_mentions_scitex_writer_containers_path():
+def test_containers_group_help_mentions_scitex_writer_containers_path():
     # Arrange — the group docstring names the canonical install path
     # so operators reading --help see the convention without digging.
     runner = CliRunner()
     # Act
-    result = runner.invoke(install_group, ["--help"])
+    result = runner.invoke(containers_group, ["--help"])
     # Assert
     assert ".scitex/writer/containers" in result.output
 
 
-def test_install_texlive_sif_rejects_unknown_subcommand(home_tmp):
-    # Arrange
+def test_containers_install_rejects_unknown_target_via_choice():
+    # Arrange — click.Choice on the TARGET argument enforces a closed
+    # set at parse time, so an unknown target trips a usage error
+    # before _run_install runs.
     runner = CliRunner()
     # Act
-    result = runner.invoke(install_group, ["totally-bogus-target"])
+    result = runner.invoke(containers_group, ["install", "totally-bogus-target"])
     # Assert
     assert result.exit_code != 0

--- a/tests/test__cli_install.py
+++ b/tests/test__cli_install.py
@@ -1,0 +1,317 @@
+"""Tests for ``scitex_writer/_cli/install.py`` — sub-tool SIF installer.
+
+Per operator design 8566: scitex-writer owns its texlive.def + its
+``install texlive-sif`` CLI verb that drops the built SIF at
+``~/.scitex/writer/containers/texlive.sif``. The build is delegated
+to ``scitex_container.apptainer.build`` — same engine sac uses for
+``:base`` / ``:scitex`` — for uniform versioning.
+
+Real on-disk via ``tmp_path``; no MagicMock. The build delegate is
+swapped through a module-level reassignment (no monkeypatch deep
+imports) — same hand-rolled-callable pattern sac's
+``test_image_group.py`` uses for its build runner. AAA, ≥3-word
+test names, one assert per test.
+"""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_writer._cli import install as inst
+from scitex_writer._cli.install import install_group
+
+# ---------------------------------------------------------------------------
+# Fixtures — tmp HOME so every command writes into tmp_path.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def home_tmp(tmp_path: Path) -> Iterator[Path]:
+    home = tmp_path / "home"
+    home.mkdir()
+    saved_home = os.environ.get("HOME")
+    os.environ["HOME"] = str(home)
+    try:
+        yield tmp_path
+    finally:
+        if saved_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = saved_home
+
+
+@contextmanager
+def _swap_sc_build(stub) -> Iterator[list[tuple]]:
+    """Swap scitex-container's build engine for a recording fake.
+
+    The install verb imports ``scitex_container.apptainer.build`` at
+    call time inside ``_run_install``. We override the resolved
+    callable via ``sys.modules`` patching — same swap-and-restore
+    discipline as the sac side. The yielded list collects every call.
+    """
+    import sys
+    import types
+
+    calls: list[tuple] = []
+
+    def _fake(*a, **kw):
+        calls.append((a, kw))
+        return stub(*a, **kw)
+
+    sc = types.ModuleType("scitex_container")
+    sc_apt = types.ModuleType("scitex_container.apptainer")
+    sc_apt.build = _fake
+    sc.apptainer = sc_apt
+
+    saved_sc = sys.modules.get("scitex_container")
+    saved_sc_apt = sys.modules.get("scitex_container.apptainer")
+    sys.modules["scitex_container"] = sc
+    sys.modules["scitex_container.apptainer"] = sc_apt
+    try:
+        yield calls
+    finally:
+        if saved_sc is None:
+            sys.modules.pop("scitex_container", None)
+        else:
+            sys.modules["scitex_container"] = saved_sc
+        if saved_sc_apt is None:
+            sys.modules.pop("scitex_container.apptainer", None)
+        else:
+            sys.modules["scitex_container.apptainer"] = saved_sc_apt
+
+
+def _sc_build_ok(*a, **kw) -> Path:
+    """Default stub — returns the path the build verb expects to output."""
+    return Path(kw["output_dir"]) / f"{kw['image_name']}.sif"
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+
+def test_output_dir_is_under_dotscitex_writer_containers(home_tmp):
+    # Arrange — operator convention pinned: ~/.scitex/writer/containers/.
+    expected = Path(os.environ["HOME"]) / ".scitex" / "writer" / "containers"
+    # Act
+    actual = inst._output_dir()
+    # Assert
+    assert actual == expected
+
+
+def test_resolve_recipe_finds_texlive_def_in_scripts_containers():
+    # Arrange — the shipped recipe lives at scripts/containers/texlive.def.
+    # Act
+    recipe = inst._resolve_recipe("texlive-sif")
+    # Assert
+    assert recipe.name == "texlive.def"
+
+
+def test_resolve_recipe_raises_usage_error_for_unknown_target():
+    # Arrange
+    import click
+
+    # Act
+    def _call():
+        return inst._resolve_recipe("bogus-target")
+
+    # Assert
+    with pytest.raises(click.UsageError):
+        _call()
+
+
+def test_image_name_for_strips_sif_suffix():
+    # Arrange — the SIF artifact's basename is the target minus "-sif".
+    # Act
+    name = inst._image_name_for("texlive-sif")
+    # Assert
+    assert name == "texlive"
+
+
+# ---------------------------------------------------------------------------
+# install texlive-sif — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_install_texlive_sif_dry_run_exits_zero(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(install_group, ["texlive-sif", "--dry-run"])
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_install_texlive_sif_dry_run_prints_dry_run_marker(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(install_group, ["texlive-sif", "--dry-run"])
+    # Assert
+    assert "dry-run" in result.output
+
+
+def test_install_texlive_sif_refuses_without_yes_flag(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(install_group, ["texlive-sif"])
+    # Assert
+    assert result.exit_code == 2
+
+
+def test_install_texlive_sif_refusal_names_the_target_path(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    expected = str(inst._output_dir() / "texlive.sif")
+    # Act
+    result = runner.invoke(install_group, ["texlive-sif"])
+    # Assert
+    assert expected in result.output
+
+
+def test_install_texlive_sif_with_yes_delegates_to_scitex_container_build(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _swap_sc_build(_sc_build_ok) as calls:
+        runner.invoke(install_group, ["texlive-sif", "--yes"])
+    # Assert
+    assert len(calls) == 1
+
+
+def test_install_texlive_sif_passes_def_path_to_build(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _swap_sc_build(_sc_build_ok) as calls:
+        runner.invoke(install_group, ["texlive-sif", "--yes"])
+    # Assert
+    assert calls[0][1]["def_path"].name == "texlive.def"
+
+
+def test_install_texlive_sif_passes_image_name_texlive(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _swap_sc_build(_sc_build_ok) as calls:
+        runner.invoke(install_group, ["texlive-sif", "--yes"])
+    # Assert
+    assert calls[0][1]["image_name"] == "texlive"
+
+
+def test_install_texlive_sif_passes_output_dir_under_writer_containers(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    expected = Path(os.environ["HOME"]) / ".scitex" / "writer" / "containers"
+    # Act
+    with _swap_sc_build(_sc_build_ok) as calls:
+        runner.invoke(install_group, ["texlive-sif", "--yes"])
+    # Assert
+    assert calls[0][1]["output_dir"] == expected
+
+
+def test_install_texlive_sif_creates_output_dir_before_calling_build(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    out = Path(os.environ["HOME"]) / ".scitex" / "writer" / "containers"
+    # Act
+    with _swap_sc_build(_sc_build_ok):
+        runner.invoke(install_group, ["texlive-sif", "--yes"])
+    # Assert
+    assert out.is_dir()
+
+
+def test_install_texlive_sif_force_flag_propagates_to_build(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _swap_sc_build(_sc_build_ok) as calls:
+        runner.invoke(install_group, ["texlive-sif", "--yes", "--force"])
+    # Assert
+    assert calls[0][1]["force"] is True
+
+
+def test_install_texlive_sif_success_prints_built_message(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    with _swap_sc_build(_sc_build_ok):
+        result = runner.invoke(install_group, ["texlive-sif", "--yes"])
+    # Assert
+    assert "built" in result.output
+
+
+# ---------------------------------------------------------------------------
+# install texlive-sif — failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_install_texlive_sif_reports_build_failure_loudly(home_tmp):
+    # Arrange — the build engine raises a RuntimeError (mirrors what
+    # scitex-container does on apptainer-cli failure).
+    def _build_fails(*a, **kw):
+        raise RuntimeError("apptainer broken: rc=1")
+
+    runner = CliRunner()
+    # Act
+    with _swap_sc_build(_build_fails):
+        result = runner.invoke(install_group, ["texlive-sif", "--yes"])
+    # Assert
+    assert "apptainer build failed" in result.output
+
+
+def test_install_texlive_sif_reports_missing_recipe_loudly(home_tmp, monkeypatch):
+    # Arrange — point _RECIPES_DIR at an empty real dir; no monkeypatch
+    # on the deep import — just swap the module attribute (same
+    # convention as sac).
+    saved = inst._RECIPES_DIR
+    inst._RECIPES_DIR = home_tmp / "absent-recipes"
+    runner = CliRunner()
+    try:
+        # Act
+        result = runner.invoke(install_group, ["texlive-sif", "--yes"])
+    finally:
+        inst._RECIPES_DIR = saved
+    # Assert
+    assert "recipe not found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# install (group) — CLI surface
+# ---------------------------------------------------------------------------
+
+
+def test_install_group_lists_texlive_sif_in_help():
+    # Arrange — group --help should advertise the texlive-sif target so
+    # discoverability is from `scitex-writer install --help` only.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(install_group, ["--help"])
+    # Assert
+    assert "texlive-sif" in result.output
+
+
+def test_install_group_help_mentions_scitex_writer_containers_path():
+    # Arrange — the group docstring names the canonical install path
+    # so operators reading --help see the convention without digging.
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(install_group, ["--help"])
+    # Assert
+    assert ".scitex/writer/containers" in result.output
+
+
+def test_install_texlive_sif_rejects_unknown_subcommand(home_tmp):
+    # Arrange
+    runner = CliRunner()
+    # Act
+    result = runner.invoke(install_group, ["totally-bogus-target"])
+    # Assert
+    assert result.exit_code != 0


### PR DESCRIPTION
## Summary

Per operator design 8566: scitex-writer now owns its `texlive` sub-tool SIF + ships a CLI verb to install it under the per-package convention:

```
~/.scitex/writer/containers/texlive.sif   (top-level symlink)
~/.scitex/writer/containers/texlive/      (per-image dir with .def-hash + build log)
```

Wrapper agents (proj-neurovista etc.) bind from the canonical path — `sac image list` discovers it automatically via the generic `~/.scitex/*/containers/*.sif` glob landed in [scitex-agent-container#293](https://github.com/ywatanabe1989/scitex-agent-container/pull/293) (merged earlier today). **sac never knows scitex-writer by name.**

## Architecture

Build delegates to `scitex_container.apptainer.build` — same engine sac uses for `:base` / `:scitex`. Operator's pinning ask (msg 8568) lands free with the delegation: per-image `.def-hash` (skip-rebuild guard), timestamped `.build-*.log`, recipe snapshot. NO raw `apptainer build` shell-out; one uniform mechanism across every package SIF.

## What ships

- `scripts/containers/texlive.def` — replace the stub (was a duplicate of `scitex-writer.def`, same 2.4K size) with the canonicalized neurovista-tuned recipe.
- `src/scitex_writer/_cli/install.py` (new) — install group + `texlive-sif` verb.
- `src/scitex_writer/_cli/__init__.py` — 5-line wire-in.
- `tests/test__cli_install.py` (new) — 20 tests, AAA + no mocks + 1 assert per test.

## Backstory

- proj-neurovista 5-question spec sign-off (a2a msg `faf626095310415b8751603afa7b6d3e`, 2026-06-03 12:55 JST)
- Operator's `~/.scitex/<pkg>/{containers,bin}` convention (msg 8566), "use scitex-container for the build" refinement (msg 8568/8569)
- Companion PR in sac: ywatanabe1989/scitex-agent-container#293 (merged)
- Earlier attempt that violated layering: ywatanabe1989/scitex-agent-container#291 (closed)

## Test plan

- [x] `pytest tests/test__cli_install.py` — 20/20 green (1.33s)
- [x] CLI smoke: `--help`, `--dry-run` render correctly
- [ ] CI full suite green
- [ ] Bare-host smoke build (lead handling)