### PR TITLE
feat(containers): adopt ~/.scitex/writer/containers/ per-package convention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,9 @@ status:
 	@echo "Revision PDF:       $(shell [ -f ./03_revision/revision.pdf ] && echo "✓ Available" || echo "✗ Missing")"
 	@echo ""
 	@echo "Container Cache:"
-	@ls -lh ./.cache/containers/*.sif 2>/dev/null | awk '{print "  " $$9 " (" $$5 ")"}' || echo "  No containers cached"
+	@ls -lh $${HOME}/.scitex/writer/containers/*.sif 2>/dev/null | awk '{print "  " $$9 " (" $$5 ")"}'; \
+	 ls -lh ./.cache/containers/*.sif 2>/dev/null | awk '{print "  [legacy] " $$9 " (" $$5 ")"}'; \
+	 [ -d $${HOME}/.scitex/writer/containers ] || [ -d ./.cache/containers ] || echo "  No containers cached"
 
 # Help target
 help:

--- a/config/config_manuscript.yaml
+++ b/config/config_manuscript.yaml
@@ -75,10 +75,14 @@ paths:
   diff_tex: "./01_manuscript/manuscript_diff.tex"
   diff_pdf: "./01_manuscript/manuscript_diff.pdf"
   archive_dir: "./01_manuscript/archive"
-  texlive_apptainer_sif: "./.cache/containers/texlive_container.sif"
-  tectonic_apptainer_sif: "./.cache/containers/tectonic_container.sif"
-  mermaid_apptainer_sif: "./.cache/containers/mermaid_container.sif"
-  imagemagick_apptainer_sif: "./.cache/containers/imagemagick_container.sif"
+  # Canonical convention (operator design 8566 + sac PR #293): every
+  # scitex-* package owns SIFs under ~/.scitex/<pkg>/containers/<tool>.sif.
+  # Shell modules retain a legacy lookup at ./.cache/containers/<tool>_container.sif
+  # for caches built before the migration; deprecation log fires on legacy hit.
+  texlive_apptainer_sif: "~/.scitex/writer/containers/texlive.sif"
+  tectonic_apptainer_sif: "~/.scitex/writer/containers/tectonic.sif"
+  mermaid_apptainer_sif: "~/.scitex/writer/containers/mermaid.sif"
+  imagemagick_apptainer_sif: "~/.scitex/writer/containers/imagemagick.sif"
   
 figures:
   dir: "./01_manuscript/contents/figures"

--- a/config/config_revision.yaml
+++ b/config/config_revision.yaml
@@ -32,8 +32,10 @@ paths:
   diff_tex: "./03_revision/revision_diff.tex"
   diff_pdf: "./03_revision/revision_diff.pdf"
   archive_dir: "./03_revision/archive"
-  texlive_apptainer_sif: "./.cache/containers/texlive_container.sif"
-  mermaid_apptainer_sif: "./.cache/containers/mermaid_container.sif"
+  # Canonical convention: ~/.scitex/writer/containers/<tool>.sif
+  # (see config_manuscript.yaml for the full migration note).
+  texlive_apptainer_sif: "~/.scitex/writer/containers/texlive.sif"
+  mermaid_apptainer_sif: "~/.scitex/writer/containers/mermaid.sif"
 
 # Revision-specific paths
 revision:

--- a/config/config_supplementary.yaml
+++ b/config/config_supplementary.yaml
@@ -32,9 +32,11 @@ paths:
   diff_tex: "./02_supplementary/supplementary_diff.tex"
   diff_pdf: "./02_supplementary/supplementary_diff.pdf"
   archive_dir: "./02_supplementary/archive"
-  texlive_apptainer_sif: "./.cache/containers/texlive_container.sif"
-  mermaid_apptainer_sif: "./.cache/containers/mermaid_container.sif"
-  imagemagick_apptainer_sif: "./.cache/containers/imagemagick_container.sif"
+  # Canonical convention: ~/.scitex/writer/containers/<tool>.sif
+  # (see config_manuscript.yaml for the full migration note).
+  texlive_apptainer_sif: "~/.scitex/writer/containers/texlive.sif"
+  mermaid_apptainer_sif: "~/.scitex/writer/containers/mermaid.sif"
+  imagemagick_apptainer_sif: "~/.scitex/writer/containers/imagemagick.sif"
   
 figures:
   dir: "./02_supplementary/contents/figures"

--- a/scripts/containers/README.md
+++ b/scripts/containers/README.md
@@ -12,13 +12,23 @@ This directory contains container definition files for reproducible LaTeX compil
 
 ## Building Containers
 
-### Apptainer/Singularity
+### Preferred — scitex-writer CLI
+
+Builds the canonical SIF under the per-package convention
+(`~/.scitex/writer/containers/<tool>.sif`, operator design 8566 + sac PR #293)
+via `scitex-container.apptainer.build` so the artifact ships with a
+`.def-hash`, build log, and top-level symlink — the same engine sac uses for
+its own `:base` / `:scitex` SIFs.
 
 ```bash
-# Build TeX Live container
-apptainer build texlive.sif texlive.def
+scitex-writer containers install texlive -y
+scitex-writer containers install mermaid -y    # follow-up: enable when canonicalized
+```
 
-# Build Mermaid container
+### Raw apptainer (fallback)
+
+```bash
+apptainer build texlive.sif texlive.def
 apptainer build mermaid.sif mermaid.def
 ```
 
@@ -48,11 +58,16 @@ docker run --rm -v $(pwd):/workspace scitex-writer ./compile.sh manuscript
 
 ## Cache Location
 
-Built containers are cached in `.cache/containers/` for faster subsequent runs.
+Built containers live under `~/.scitex/writer/containers/<tool>.sif` per the
+per-package convention. The legacy `./.cache/containers/<tool>_container.sif`
+path is still consulted by the shell modules as a deprecated fallback for
+caches built before this migration (a `[DEPRECATED]` log line fires when it's
+used) — please rebuild via the `scitex-writer containers install` CLI to
+land on the canonical artifact.
 
 ## Automatic Download
 
-The compilation system automatically downloads pre-built containers if available:
+The bulk downloader still works and now writes to the canonical location:
 
 ```bash
 ./scripts/installation/download_containers.sh

--- a/scripts/installation/check_requirements.sh
+++ b/scripts/installation/check_requirements.sh
@@ -133,21 +133,29 @@ fi
 
 echo
 echo_info "Checking container availability..."
-CONTAINER_DIR="$PROJECT_ROOT/.cache/containers"
+# Canonical convention: ~/.scitex/writer/containers/<tool>.sif
+# (operator design 8566 + sac PR #293). Legacy ./.cache/containers/
+# is consulted as a fallback for caches built before the migration.
+CONTAINER_DIR="$HOME/.scitex/writer/containers"
+LEGACY_CONTAINER_DIR="$PROJECT_ROOT/.cache/containers"
 
-if [ -f "$CONTAINER_DIR/texlive.sif" ]; then
-    SIZE=$(du -h "$CONTAINER_DIR/texlive.sif" | cut -f1)
-    echo_success "✓ TeXLive container exists ($SIZE)"
-else
-    echo_warning "○ TeXLive container not found (will download on first use)"
-fi
+_check_sif() {
+    local tool="$1" canon legacy size
+    canon="$CONTAINER_DIR/${tool}.sif"
+    legacy="$LEGACY_CONTAINER_DIR/${tool}_container.sif"
+    if [ -f "$canon" ]; then
+        size=$(du -h "$canon" | cut -f1)
+        echo_success "✓ ${tool^} container exists ($size)"
+    elif [ -f "$legacy" ]; then
+        size=$(du -h "$legacy" | cut -f1)
+        echo_warning "○ ${tool^} container at legacy $legacy ($size) — rebuild via 'scitex-writer containers install ${tool} -y' to land at $canon"
+    else
+        echo_warning "○ ${tool^} container not found (will download/build on first use)"
+    fi
+}
 
-if [ -f "$CONTAINER_DIR/mermaid_container.sif" ]; then
-    SIZE=$(du -h "$CONTAINER_DIR/mermaid_container.sif" | cut -f1)
-    echo_success "✓ Mermaid container exists ($SIZE)"
-else
-    echo_warning "○ Mermaid container not found (will download on first use)"
-fi
+_check_sif texlive
+_check_sif mermaid
 
 echo
 if [ $MISSING_REQUIREMENTS -eq 0 ]; then

--- a/scripts/installation/download_containers.sh
+++ b/scripts/installation/download_containers.sh
@@ -49,12 +49,15 @@ fi
 
 echo_success "Found container runtime: $RUNTIME"
 
-# Setup container directory
-CONTAINER_DIR="$PROJECT_ROOT/.cache/containers"
+# Setup container directory under the per-package convention
+# (operator design 8566 + sac PR #293): ~/.scitex/writer/containers/.
+# The legacy ./.cache/containers/ path is still consulted by the shell
+# modules as a deprecated fallback for caches built before this migration.
+CONTAINER_DIR="$HOME/.scitex/writer/containers"
 mkdir -p "$CONTAINER_DIR"
 
 # Download TeXLive container
-TEXLIVE_SIF="$CONTAINER_DIR/texlive_container.sif"
+TEXLIVE_SIF="$CONTAINER_DIR/texlive.sif"
 if [ ! -f "$TEXLIVE_SIF" ]; then
     echo_info "Downloading TeXLive container (~2.3GB)..."
     $RUNTIME pull "$TEXLIVE_SIF" docker://texlive/texlive:latest
@@ -69,7 +72,7 @@ else
 fi
 
 # Download Mermaid container
-MERMAID_SIF="$CONTAINER_DIR/mermaid_container.sif"
+MERMAID_SIF="$CONTAINER_DIR/mermaid.sif"
 if [ ! -f "$MERMAID_SIF" ]; then
     echo_info "Downloading Mermaid container (~750MB)..."
     $RUNTIME pull "$MERMAID_SIF" docker://minlag/mermaid-cli:latest
@@ -84,7 +87,7 @@ else
 fi
 
 # Download ImageMagick container (optional but recommended)
-IMAGEMAGICK_SIF="$CONTAINER_DIR/imagemagick_container.sif"
+IMAGEMAGICK_SIF="$CONTAINER_DIR/imagemagick.sif"
 if [ ! -f "$IMAGEMAGICK_SIF" ]; then
     echo_info "Downloading ImageMagick container (~200MB)..."
     $RUNTIME pull "$IMAGEMAGICK_SIF" docker://dpokidov/imagemagick:latest

--- a/scripts/installation/init_project.sh
+++ b/scripts/installation/init_project.sh
@@ -99,9 +99,10 @@ create_log_dirs() {
     done
 }
 
-# Create container cache directory
+# Create container directory under the per-package convention
+# (operator design 8566 + sac PR #293): ~/.scitex/writer/containers/.
 create_container_dirs() {
-    mkdir -p "$PROJECT_ROOT/.cache/containers"
+    mkdir -p "$HOME/.scitex/writer/containers"
     mkdir -p "$PROJECT_ROOT/scripts/containers"
 
     # Create README for containers directory
@@ -118,12 +119,18 @@ This directory contains Apptainer/Singularity container definition files.
 
 ## Usage
 
-Build containers:
+Build the canonical SIFs via the scitex-writer CLI (uses scitex-container under
+the hood for uniform versioning + .def-hash + build-log pinning):
+
 ```bash
-./scripts/installation/download_containers.sh
+scitex-writer containers install texlive -y
+scitex-writer containers install mermaid -y
 ```
 
-Containers are cached in `.cache/containers/` after first build/download.
+Artifacts land under `~/.scitex/writer/containers/<tool>.sif` per the
+operator-design-8566 / sac-PR-#293 per-package convention. The legacy bulk
+downloader at `./scripts/installation/download_containers.sh` still works
+and is being kept until the build path is verified across hosts.
 EOF
     fi
 }

--- a/scripts/shell/modules/command_switching.src
+++ b/scripts/shell/modules/command_switching.src
@@ -27,19 +27,27 @@ _CACHE_CHECKED=false
 _CACHED_MODULE_AVAILABLE=""
 _MODULE_CACHE_CHECKED=false
 
+# Resolve a writer sub-tool SIF path under the per-package convention
+# (operator design 8566 + sac PR #293): ~/.scitex/writer/containers/<tool>.sif.
+# Falls back to legacy ./.cache/containers/<tool>_container.sif for caches built
+# before the migration; deprecation log fires on legacy hit. Sets the named var.
+# Returns 0 if resolved to an existing file, 1 otherwise (var still set to canon
+# so the caller's downloader/builder can populate it at the canonical path).
+_writer_resolve_sif() {
+    local t="$1" var="$2"
+    [ -n "${!var}" ] && [ -f "${!var}" ] && return 0
+    local canon="$HOME/.scitex/writer/containers/$t.sif"
+    [ -f "$canon" ] && { eval "$var=\"\$canon\""; return 0; }
+    local root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../" && pwd)"
+    local legacy="$root/.cache/containers/${t}_container.sif"
+    [ -f "$legacy" ] && { echo_info "    [DEPRECATED] $legacy — rebuild via 'scitex-writer containers install $t -y' (canonical: $canon)"; eval "$var=\"\$legacy\""; return 0; }
+    eval "$var=\"\$canon\""
+    return 1
+}
+
 # Setup container path (Singularity/Apptainer)
 setup_latex_container() {
-    # Check if container path is already set
-    if [ -n "$SCITEX_WRITER_TEXLIVE_APPTAINER_SIF" ] && [ -f "$SCITEX_WRITER_TEXLIVE_APPTAINER_SIF" ]; then
-        return 0
-    fi
-
-    # Use config value if set, otherwise use project directory default
-    if [ -z "$SCITEX_WRITER_TEXLIVE_APPTAINER_SIF" ]; then
-        # Use project directory to ensure availability across HPC nodes
-        local project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../" && pwd)"
-        SCITEX_WRITER_TEXLIVE_APPTAINER_SIF="${project_root}/.cache/containers/texlive_container.sif"
-    fi
+    _writer_resolve_sif texlive SCITEX_WRITER_TEXLIVE_APPTAINER_SIF && return 0
 
     if [ ! -f "$SCITEX_WRITER_TEXLIVE_APPTAINER_SIF" ]; then
         echo_info "    Downloading TeXLive container (one-time setup)..."
@@ -296,17 +304,7 @@ get_cmd_tectonic() {
 
 # Setup Tectonic container (for tectonic)
 setup_tectonic_container() {
-    # Check if container path is already set
-    if [ -n "$SCITEX_WRITER_TECTONIC_APPTAINER_SIF" ] && [ -f "$SCITEX_WRITER_TECTONIC_APPTAINER_SIF" ]; then
-        return 0
-    fi
-
-    # Use config value if set, otherwise use project directory default
-    if [ -z "$SCITEX_WRITER_TECTONIC_APPTAINER_SIF" ]; then
-        # Use project directory to ensure availability across HPC nodes
-        local project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../" && pwd)"
-        SCITEX_WRITER_TECTONIC_APPTAINER_SIF="${project_root}/.cache/containers/tectonic_container.sif"
-    fi
+    _writer_resolve_sif tectonic SCITEX_WRITER_TECTONIC_APPTAINER_SIF && return 0
 
     if [ ! -f "$SCITEX_WRITER_TECTONIC_APPTAINER_SIF" ]; then
         echo_info "    Downloading Tectonic container (one-time setup)..."
@@ -335,17 +333,7 @@ setup_tectonic_container() {
 
 # Setup Mermaid container (for mmdc)
 setup_mermaid_container() {
-    # Check if container path is already set
-    if [ -n "$SCITEX_WRITER_MERMAID_APPTAINER_SIF" ] && [ -f "$SCITEX_WRITER_MERMAID_APPTAINER_SIF" ]; then
-        return 0
-    fi
-
-    # Use config value if set, otherwise use project directory default
-    if [ -z "$SCITEX_WRITER_MERMAID_APPTAINER_SIF" ]; then
-        # Use project directory to ensure availability across HPC nodes
-        local project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../" && pwd)"
-        SCITEX_WRITER_MERMAID_APPTAINER_SIF="${project_root}/.cache/containers/mermaid_container.sif"
-    fi
+    _writer_resolve_sif mermaid SCITEX_WRITER_MERMAID_APPTAINER_SIF && return 0
 
     if [ ! -f "$SCITEX_WRITER_MERMAID_APPTAINER_SIF" ]; then
         echo_info "    Downloading Mermaid container (one-time setup)..."
@@ -426,17 +414,7 @@ check_latex_commands_available() {
 
 # Setup ImageMagick container
 setup_imagemagick_container() {
-    # Check if container path is already set
-    if [ -n "$SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF" ] && [ -f "$SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF" ]; then
-        return 0
-    fi
-
-    # Use config value if set, otherwise use project directory default
-    if [ -z "$SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF" ]; then
-        # Use project directory to ensure availability across HPC nodes
-        local project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../" && pwd)"
-        SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF="${project_root}/.cache/containers/imagemagick_container.sif"
-    fi
+    _writer_resolve_sif imagemagick SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF && return 0
 
     if [ ! -f "$SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF" ]; then
         echo_info "    Downloading ImageMagick container (one-time setup)..."
@@ -503,6 +481,7 @@ get_cmd_convert() {
 }
 
 # Export functions and cache variables for use in other scripts
+export -f _writer_resolve_sif
 export -f setup_latex_container
 export -f setup_tectonic_container
 export -f setup_mermaid_container

--- a/tests/scripts/shell/modules/test_writer_resolve_sif.sh
+++ b/tests/scripts/shell/modules/test_writer_resolve_sif.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Test file for: scripts/shell/modules/command_switching.src::_writer_resolve_sif
+#
+# Verifies the per-package SIF path resolver (operator design 8566 + sac PR #293).
+# Resolution order:
+#   1. pre-set var pointing to an existing file → keep as-is
+#   2. canonical ~/.scitex/writer/containers/<tool>.sif exists → use it
+#   3. legacy ./.cache/containers/<tool>_container.sif exists → use it with deprecation log
+#   4. neither exists → set var to canonical path, return 1 (caller may build/download)
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(realpath "$THIS_DIR/../../../..")"
+MODULE="$PROJECT_ROOT/scripts/shell/modules/command_switching.src"
+
+# Test counter
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Colors
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+# Sandbox: isolate HOME + sub-shell project root so the resolver never touches
+# the user's real ~/.scitex tree or the live repo cache.
+SANDBOX="$(mktemp -d -t writer-resolve-XXXXXX)"
+trap 'rm -rf "$SANDBOX"' EXIT
+export HOME="$SANDBOX/home"
+mkdir -p "$HOME/.scitex/writer/containers"
+mkdir -p "$SANDBOX/proj/scripts/shell/modules"
+mkdir -p "$SANDBOX/proj/.cache/containers"
+
+# Copy the module into the sandbox so BASH_SOURCE-derived project_root lands
+# at $SANDBOX/proj (not the real repo).
+cp "$MODULE" "$SANDBOX/proj/scripts/shell/modules/command_switching.src"
+mkdir -p "$SANDBOX/proj/config"
+# Stub out the load_config.sh source line + echo_info dependency.
+cat > "$SANDBOX/proj/config/load_config.sh" <<'EOF'
+#!/bin/bash
+# stub for test
+EOF
+echo_info() { echo "[INFO] $*" >&2; }
+echo_success() { echo "[OK] $*" >&2; }
+echo_warning() { echo "[WARN] $*" >&2; }
+echo_error() { echo "[ERR] $*" >&2; }
+export -f echo_info echo_success echo_warning echo_error
+
+# Source only the helper (skip the `source ./config/load_config.sh` at the top
+# of the module by extracting the function definition into a tmp file).
+sed -n '/^_writer_resolve_sif()/,/^}/p' "$MODULE" > "$SANDBOX/helper.sh"
+# shellcheck disable=SC1091
+source "$SANDBOX/helper.sh"
+
+# Make BASH_SOURCE inside the helper resolve to the sandbox layout.
+# The helper computes project_root as $(cd "$(dirname "${BASH_SOURCE[0]}")/../../../" && pwd)
+# from where it was sourced; with sourcing direct from /tmp/.../helper.sh,
+# project_root would be /tmp. To exercise the legacy-fallback branch we set up
+# the legacy file under the *real* project_root that the helper computes. We
+# accept that quirk and use $SANDBOX/proj as a stand-in by overriding HOME-only
+# checks; for legacy-branch coverage we pre-place the legacy file at whatever
+# the helper computes.
+
+assert_resolved() {
+    local description="$1"
+    local expected_var="$2"
+    local expected_value="$3"
+    local expected_rc="$4"
+    ((TESTS_RUN++))
+    if [ "${!expected_var}" = "$expected_value" ] && [ "$ACTUAL_RC" = "$expected_rc" ]; then
+        echo -e "${GREEN}✓${NC} $description"
+        ((TESTS_PASSED++))
+    else
+        echo -e "${RED}✗${NC} $description"
+        echo "    expected var=$expected_value rc=$expected_rc"
+        echo "    actual   var=${!expected_var} rc=$ACTUAL_RC"
+        ((TESTS_FAILED++))
+    fi
+}
+
+# ----- Case 1: pre-set var with existing file → kept as-is, rc=0 -----
+PRESET="$SANDBOX/preset.sif"
+touch "$PRESET"
+TEST_VAR="$PRESET"
+_writer_resolve_sif texlive TEST_VAR; ACTUAL_RC=$?
+assert_resolved "preset var with existing file kept" TEST_VAR "$PRESET" 0
+
+# ----- Case 2: canonical exists → resolved to canonical, rc=0 -----
+TEST_VAR=""
+touch "$HOME/.scitex/writer/containers/texlive.sif"
+_writer_resolve_sif texlive TEST_VAR; ACTUAL_RC=$?
+assert_resolved "canonical present → resolved to canonical" \
+    TEST_VAR "$HOME/.scitex/writer/containers/texlive.sif" 0
+
+# ----- Case 3: neither exists → var set to canonical path, rc=1 -----
+rm -f "$HOME/.scitex/writer/containers/texlive.sif"
+TEST_VAR=""
+_writer_resolve_sif texlive TEST_VAR; ACTUAL_RC=$?
+assert_resolved "neither present → var=canonical, rc=1" \
+    TEST_VAR "$HOME/.scitex/writer/containers/texlive.sif" 1
+
+# Run tests
+echo "Testing: _writer_resolve_sif (canonical-containers-path resolver)"
+echo "================================================================"
+echo ""
+echo "Tests run:    $TESTS_RUN"
+echo "Tests passed: $TESTS_PASSED"
+echo "Tests failed: $TESTS_FAILED"
+
+if [ "$TESTS_FAILED" -eq 0 ]; then
+    echo -e "${GREEN}All tests passed${NC}"
+    exit 0
+else
+    echo -e "${RED}Some tests failed${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Switch the legacy `./.cache/containers/<tool>_container.sif` plumbing to the canonical per-package convention (operator design 8566 + sac PR #293):

    ~/.scitex/writer/containers/<tool>.sif

This is **P1.a** of the brand-wide ecosystem containers/bin audit (proj-scitex-dev → lead). Lead gated GO on this scope (low-risk rewire, legacy fallback retained, no rebuild yet, no deletion). P1.b (rebuild remaining SIFs) and P1.c (delete legacy fallback) will each get separate gates.

### Why now
- The scitex-writer install CLI from #116 already writes to `~/.scitex/writer/containers/` via `scitex_container.apptainer.build` — same engine sac uses for its own `:base` / `:scitex` SIFs.
- **A canonical `~/.scitex/writer/containers/texlive.sif` already exists** (built today via the install CLI, verified compiling real manuscripts), so on merge scitex-writer immediately uses a working SIF — no rebuild required for texlive in this PR.
- Mermaid / tectonic / imagemagick still need their builds in P1.b (separate gate).

## Changes (10 files)

| File | Change |
|------|--------|
| `config/config_manuscript.yaml` | 4 `*_apptainer_sif` keys → canonical path (`~/.scitex/writer/containers/<tool>.sif`) |
| `config/config_supplementary.yaml` | 3 keys → canonical path |
| `config/config_revision.yaml` | 2 keys → canonical path |
| `scripts/shell/modules/command_switching.src` | Extract shared `_writer_resolve_sif(tool, var)` helper that resolves canonical first, falls back to legacy with `[DEPRECATED]` log. Removes 4-way duplication across `setup_latex/tectonic/mermaid/imagemagick_container`. File: 528→507 lines. |
| `scripts/installation/download_containers.sh` | Write to canonical path + drop `_container` suffix from filenames |
| `scripts/installation/check_requirements.sh` | Probe canonical first, deprecation-message on legacy hit |
| `scripts/installation/init_project.sh` | Create canonical dir + refresh auto-generated README to recommend install CLI |
| `scripts/containers/README.md` | Document install CLI as preferred, raw apptainer as fallback |
| `Makefile` | Status target lists canonical first, then any legacy with `[legacy]` tag |
| `tests/scripts/shell/modules/test_writer_resolve_sif.sh` | **NEW** — sandbox-based smoke test for the resolver (preset / canonical / not-found cases) |

## Behaviour after merge

| Scenario | Result |
|----------|--------|
| `~/.scitex/writer/containers/texlive.sif` exists (today's reality) | Canonical artifact used. No deprecation message. |
| Pre-migration user with `./.cache/containers/texlive_container.sif` | Legacy artifact still works; `[DEPRECATED]` log line prints once per resolver call advising `scitex-writer containers install texlive -y` |
| Neither exists | Downloader / build branch runs (now writing to canonical) |
| Pre-set `SCITEX_WRITER_TEXLIVE_APPTAINER_SIF=/explicit/path` | Honored as before |

## Out of scope (separate gates)

- **P1.b** — rebuild remaining SIFs (mermaid/tectonic/imagemagick) via `scitex-writer containers install` once that CLI accepts those targets (currently only `texlive` is wired in `_SUB_TOOLS`).
- **P1.c** — remove legacy fallback + `.cache/containers/` cleanup, after P1.b verified.
- **Ecosystem follow-ups** — same convention adoption for any other package that ships SIFs (umbrella scitex / scitex-scholar / scitex-ml in Phase 3 of the audit).

## Test plan

- [x] Smoke test: `bash tests/scripts/shell/modules/test_writer_resolve_sif.sh` — 3/3 pass
- [ ] CI green
- [ ] Manual: fresh checkout with canonical texlive.sif present → resolves canonical, no download
- [ ] Manual: fresh checkout with legacy `./.cache/containers/texlive_container.sif` only → deprecation log fires, legacy used

🤖 P1.a of brand-wide ecosystem containers/bin migration (proj-scitex-dev audit, lead-approved scope)