### PR TITLE
fix(ci,ps168): cla.yml uses GH_PERSONAL_ACCESS_TOKEN secret

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,7 +28,7 @@ jobs:
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://github.com/ywatanabe1989/scitex-writer/blob/main/CLA.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,3 +155,15 @@ library_dirs = ["src", "tests", "examples"]
     "E722",  # bare except (legacy code)
     "F401",  # unused import (PIL check pattern)
 ]
+
+[tool.scitex_dev.audit]
+# PS-168 — Per-package secret + env-var prefix in GitHub Actions workflows.
+# `GH_PERSONAL_ACCESS_TOKEN` is the ecosystem-wide cross-cutting PAT used
+# by the contributor-assistant CLA action. The natural GITHUB_* namespace
+# is reserved by GitHub Actions on the secret-name surface (HTTP 422 on
+# every `gh secret set`), so the GH_ shorthand is the canonical
+# substitute and is registered ecosystem-wide via PR #122 on scitex-dev
+# (EXCEPTION_SECRETS_DEFAULT). This per-package entry pins the same
+# exception inline so the audit passes on every scitex-dev version,
+# independent of release timing.
+ps168_secret_exceptions = ["GH_PERSONAL_ACCESS_TOKEN"]


### PR DESCRIPTION
Ecosystem-wide rename of the CLA Assistant PAT secret to `GH_PERSONAL_ACCESS_TOKEN` (GITHUB_* is reserved by GitHub Actions on the secret-name surface). Self-contained — cla.yml + pyproject `[tool.scitex_dev.audit] ps168_secret_exceptions`. Companion PR scitex-dev #122 adds the ecosystem-wide allowlist; lead has already added the new secret to all 69 active scitex-* repos; the old name will be deleted out-of-band once all 61 sibling PRs merge.