### PR TITLE
fix(compile): atomic .preview/<name>.pdf write (race-free under auto-compile, G2)

### DIFF
--- a/scripts/shell/compile_content.sh
+++ b/scripts/shell/compile_content.sh
@@ -176,11 +176,43 @@ fi
 
 log_success "PDF generated: $PDF_FILE"
 
-# Copy to preview directory if specified
+# Copy to preview directory if specified — atomic (tmp + mv -f).
+#
+# Background (2026-06-10, proj-scitex-hub diagnosis confirmed in prod by
+# lead): the UI's Compile-on-Change auto-firing for the same
+# (project, section, color_mode) triple causes daphne's asyncio +
+# sync_to_async threadpool to invoke compile_content() concurrently
+# against the same .preview/<job_name>.pdf destination. The previous
+# `cp $PDF_FILE $PREVIEW_DIR/` is a raw write under `set -e` and races
+# (mid-write open + read, partial flushes, cp itself short-circuiting
+# with a non-zero exit) — surfacing as `Compilation failed with exit
+# code N` at content.py:186 even though the compile itself succeeded.
+#
+# Atomic write: stage to a uniquely-named temp file (PID-suffixed so
+# parallel processes do not collide on the tmp slot itself) inside the
+# SAME directory as the publish target, then `mv -f` it into place.
+# `mv` within one filesystem is rename(2), which is atomic — concurrent
+# readers either see the OLD pdf or the NEW pdf, never a half-written
+# fd. The `.` prefix on the tmp name keeps it out of normal directory
+# listings if any reader walks $PREVIEW_DIR.
+#
+# Failure modes are explicit (non-zero exit + cleanup) rather than
+# inheriting `set -e`'s opaque propagation, so content.py sees a
+# coherent error code instead of the indeterminate exit 12 race.
 if [ -n "$PREVIEW_DIR" ]; then
     mkdir -p "$PREVIEW_DIR"
-    cp "$PDF_FILE" "$PREVIEW_DIR/"
-    log_info "Copied to preview: $PREVIEW_DIR/$JOB_NAME.pdf"
+    PREVIEW_TMP="$PREVIEW_DIR/.$JOB_NAME.pdf.tmp.$$"
+    if ! cp "$PDF_FILE" "$PREVIEW_TMP"; then
+        log_error "Failed to stage PDF to $PREVIEW_TMP"
+        rm -f "$PREVIEW_TMP"
+        exit 1
+    fi
+    if ! mv -f "$PREVIEW_TMP" "$PREVIEW_DIR/$JOB_NAME.pdf"; then
+        log_error "Failed to publish PDF to $PREVIEW_DIR/$JOB_NAME.pdf"
+        rm -f "$PREVIEW_TMP"
+        exit 1
+    fi
+    log_info "Copied to preview: $PREVIEW_DIR/$JOB_NAME.pdf (atomic)"
 fi
 
 # Cleanup auxiliary files


### PR DESCRIPTION
## Summary

G2 fix: atomic write for `.preview/<name>.pdf` in `scripts/shell/compile_content.sh`, so the UI's auto-compile (Compile-on-Change) feature no longer races on the same destination path and surfaces a spurious `Compilation failed with exit code N` to the operator even though the compile itself succeeded.

## Root cause (lead-verified in prod 2026-06-10)

- UI auto-fires `compile_content()` for the same `(project, section, color_mode)` triple on every change.
- daphne's asyncio + sync_to_async threadpool runs those calls concurrently against the same destination `<project>/.preview/<name>.pdf`.
- The previous body
  ```sh
  cp "$PDF_FILE" "$PREVIEW_DIR/"
  ```
  is a raw write under `set -e`: concurrent `cp`s share the dest path's fd lifetime, the writer mid-write gets its fd truncated by the next `cp`'s `open(O_WRONLY | O_CREAT | O_TRUNC)`, partial flushes happen, `cp` short-circuits with a non-zero exit, `set -e` propagates an indeterminate code, and `content.py:186` returns the operator-visible exit-12 error.

`lead` reproduced `compile_content()` 3× in the live Django container with `-u scitex` + the operator's exact editor content + `color_mode=dark` — all three runs SUCCEED. Failure is purely the publish race.

## Fix

Stage the PDF to a uniquely-named temp file inside the SAME directory as the publish target, then `mv -f` it into place. `mv` within one filesystem is `rename(2)`, which is atomic — concurrent readers see either the OLD pdf or the NEW pdf, never a half-written fd.

```sh
PREVIEW_TMP="$PREVIEW_DIR/.$JOB_NAME.pdf.tmp.$$"
if ! cp "$PDF_FILE" "$PREVIEW_TMP"; then
    log_error "Failed to stage PDF to $PREVIEW_TMP"
    rm -f "$PREVIEW_TMP"
    exit 1
fi
if ! mv -f "$PREVIEW_TMP" "$PREVIEW_DIR/$JOB_NAME.pdf"; then
    log_error "Failed to publish PDF to $PREVIEW_DIR/$JOB_NAME.pdf"
    rm -f "$PREVIEW_TMP"
    exit 1
fi
```

- PID-suffix on the tmp name (`.$JOB_NAME.pdf.tmp.$$`) → parallel processes do not collide on the tmp slot itself.
- Leading `.` on the tmp name → out of normal directory listings.
- Failure modes are explicit (non-zero exit + cleanup of the orphan tmp) → `content.py` sees a coherent error code instead of the indeterminate exit 12 race.

## Test plan

- [x] `bash -n scripts/shell/compile_content.sh` — syntax OK.
- [ ] CI matrix green on this PR (existing `TestContentCompilation` suite in `tests/scripts/python/test_compile_content.py` exercises `compile.content(...)` which is the single-call path; the atomic-write change must keep that contract).
- [ ] Post-merge prod verification: trigger the UI auto-compile loop that previously fired exit-12 errors; confirm the error rate drops to zero (proj-scitex-hub will observe alongside the G4 server-side coalesce rollout).

## Scope (per 1 WI = 1 PR doctrine, lead-routed 2026-06-10)

- This PR is **G2 only** (atomic write).
- **G3** (flock-based per-`(project, section, color_mode)` serialization so concurrent compiles of the same target serialize end-to-end instead of just the publish step) lands as a follow-up PR.
- **G1** (preview-compile response schema unified to `CompilationResult`: `exit_code` / `stdout` / `stderr` / `log_file`) lands as a follow-up PR.
- **G4** (scitex-cloud server-side coalesce) is proj-scitex-hub's parallel scope; pin-bump in scitex-cloud waits for this PR to merge.

## References

- proj-scitex-hub a2a 2026-06-10 (`msg_id 7b085c50346c439ab2f63e99403d5cf2`) — diagnosis + patch proposal.
- lead routing GO 2026-06-10 (operator-approved, lead-verified prod repro).
- Operator approval: CI-green = the only merge gate (fleet doctrine).
