### PR TITLE
fix(compile): per-(project, section, color_mode) flock serialization (G3)

### DIFF
--- a/scripts/shell/compile_content.sh
+++ b/scripts/shell/compile_content.sh
@@ -147,6 +147,46 @@ fi
 # Create output directory
 mkdir -p "$OUTPUT_DIR"
 
+# Per-(project, section, color_mode) serialization via flock(2).
+#
+# Background (G3, follow-up to G2 atomic publish, 2026-06-10):
+# G2 made the .preview publish atomic so concurrent compiles never
+# observe a half-written PDF. But the underlying latexmk run still
+# races: two simultaneous compiles for the same (project, section,
+# color_mode) triple share $OUTPUT_DIR (or worse, a single project's
+# tmp dir resolved per-invocation), step on each other's .aux / .log /
+# .fdb_latexmk intermediates, and produce non-deterministic exit codes.
+# The UI's Compile-on-Change loop fires the same triple repeatedly,
+# so this is the live failure mode.
+#
+# Strategy: take an exclusive flock on a lockfile derived from the
+# triple — keyed off $PREVIEW_DIR (which is the project's `.preview/`
+# directory, unique per project) + $JOB_NAME (which encodes section +
+# color, since content.py composes the basename as `<section>_<color>`
+# or similar). Same triple → same lockfile → strict serialization.
+# Different triple → different lockfile → no contention.
+#
+# fd 200 holds the lock for the entire script lifetime; the kernel
+# auto-releases on script exit (close-on-exec semantics on fd close).
+# `-w $TIMEOUT` bounds the wait so a wedged previous compile cannot
+# starve a new request indefinitely — if the lock cannot be acquired
+# within $TIMEOUT seconds, exit with a clear error rather than blocking
+# the daphne worker forever.
+#
+# Only fires when --preview-dir is given (i.e., when there is a shared
+# destination that could race). CLI single-shot use cases (no preview
+# dir → no shared destination) skip the lock and stay non-blocking.
+if [ -n "$PREVIEW_DIR" ]; then
+    mkdir -p "$PREVIEW_DIR"
+    LOCK_FILE="$PREVIEW_DIR/.lock.$JOB_NAME"
+    exec 200>"$LOCK_FILE"
+    if ! flock -x -w "$TIMEOUT" 200; then
+        log_error "Could not acquire compile lock $LOCK_FILE within ${TIMEOUT}s — concurrent compile of $JOB_NAME holding it longer than expected"
+        exit 1
+    fi
+    log_info "Acquired compile lock: $LOCK_FILE"
+fi
+
 log_info "Compiling content: $JOB_NAME (color_mode=$COLOR_MODE)"
 
 # Run latexmk (no bibliography processing for content/preview)


### PR DESCRIPTION
## Summary

G3 fix: per-`(project, section, color_mode)` serialization via `flock(2)` at the start of `scripts/shell/compile_content.sh`, so the UI's auto-compile loop no longer races at the latexmk level.

Builds on G2 (#124, just-merged): G2 made the `.preview` *publish* step atomic; this PR addresses the underlying *latexmk* race that G2 alone cannot solve.

## Why this on top of G2

G2 stopped concurrent compiles from observing a half-written PDF at the publish step. But the underlying `latexmk` run still races: two simultaneous compiles for the same `(project, section, color_mode)` triple share `$OUTPUT_DIR` (`content.py:148` resolves the same `project_dir` → same tmp / aux paths across both calls), trample each other's `.aux` / `.log` / `.fdb_latexmk` intermediates, and produce non-deterministic latexmk exit codes.

The UI's Compile-on-Change loop fires the same triple repeatedly, so this is the live failure mode that survives G2.

## Fix

Take an exclusive `flock` on a lockfile derived from the triple — keyed off `$PREVIEW_DIR` (the project's `.preview/` directory, unique per project) + `$JOB_NAME` (which encodes section + color, since `content.py` composes the basename as `<section>_<color>`):

```sh
if [ -n "$PREVIEW_DIR" ]; then
    mkdir -p "$PREVIEW_DIR"
    LOCK_FILE="$PREVIEW_DIR/.lock.$JOB_NAME"
    exec 200>"$LOCK_FILE"
    if ! flock -x -w "$TIMEOUT" 200; then
        log_error "Could not acquire compile lock $LOCK_FILE within ${TIMEOUT}s ..."
        exit 1
    fi
    log_info "Acquired compile lock: $LOCK_FILE"
fi
```

- Same triple → same lockfile → strict serialization (one compile runs at a time per triple).
- Different triple → different lockfile → no contention (two projects, or two sections within one project, compile in parallel).
- `fd 200` holds the lock for the entire script lifetime; the kernel auto-releases on script exit (no explicit `flock -u` needed).
- `-w $TIMEOUT` bounds the wait so a wedged previous compile cannot starve a new request indefinitely.
- The lock only fires when `--preview-dir` is given (UI auto-compile path). CLI single-shot use cases (no preview dir → no shared destination) skip the lock and stay non-blocking.
- `.` prefix on the lockfile name keeps it out of normal directory listings.

## Test plan

- [x] `bash -n scripts/shell/compile_content.sh` — syntax OK.
- [x] `which flock` → `/usr/bin/flock` available on the CI image.
- [ ] CI matrix green on this PR (existing `TestContentCompilation` exercises the single-call path; the flock change must keep that contract — single-shot compile with no contention takes the lock instantly).
- [ ] Post-merge prod observational check (alongside G2): concurrent UI auto-fire on the same `(project, section, color_mode)` triple should now serialize cleanly without latexmk-level errors.

## Scope (per 1 WI = 1 PR doctrine, lead-routed 2026-06-10)

- This PR is **G3 only** (flock serialization).
- **G2** (atomic publish) shipped in #124 (merged).
- **G1** (preview-response schema unified to `CompilationResult`) lands as a follow-up PR.
- **scitex-writer release is aggregated** per lead policy: G2+G3+G1 will be tagged once, after all three are on develop, to keep prod image rebuilds at 1 (NAS OOM avoidance).
- **G4** (scitex-cloud server-side coalesce) is proj-scitex-hub's parallel scope — independent merge, no dependency.

## References

- proj-scitex-hub diagnosis a2a (`msg_id 7b085c50346c439ab2f63e99403d5cf2`).
- Lead routing GO + aggregate-release policy 2026-06-10.
- Companion PR #124 (G2 atomic publish — merged).
- Companion G4: https://github.com/ywatanabe1989/scitex-hub/pull/252 (proj-scitex-hub, parallel scope).
