### PR TITLE
refactor(compile.content): return CompilationResult, drop ad-hoc dict (G1)

### DIFF
--- a/src/scitex_writer/_compile/content.py
+++ b/src/scitex_writer/_compile/content.py
@@ -17,6 +17,8 @@ import tempfile
 from pathlib import Path
 from typing import Literal, Optional
 
+from .._dataclasses import CompilationResult
+
 
 def _get_scripts_dir(project_dir: Optional[str] = None) -> Path:
     """Get the scripts directory, preferring package scripts over project.
@@ -51,7 +53,7 @@ def compile_content(
     name: str = "content",
     timeout: int = 60,
     keep_aux: bool = False,
-) -> dict:
+) -> CompilationResult:
     """Compile raw LaTeX content to PDF.
 
     Creates a standalone document from the provided LaTeX content and compiles
@@ -76,9 +78,21 @@ def compile_content(
 
     Returns
     -------
-    dict
-        Result with keys: success, output_pdf, temp_dir, color_mode,
-        log, message/error.
+    CompilationResult
+        Unified compile-result dataclass. Always carries ``success``,
+        ``exit_code``, ``stdout``, ``stderr``, ``output_pdf``,
+        ``log_file``, ``color_mode``, ``temp_dir``, ``message`` —
+        regardless of which code path (success / failure / timeout /
+        internal exception) the call took.
+
+        Migrated from the legacy ad-hoc dict return in 2026-06-10 (G1
+        of the proj-scitex-hub triage, follow-up to G2 #124 atomic
+        publish + G3 #125 flock serialization). Callers that previously
+        did ``result["success"]`` now use ``result.success``;
+        ``result.get("temp_dir")`` becomes ``result.temp_dir``; etc.
+        The Django consumer can serialize the dataclass via
+        ``dataclasses.asdict(result)`` if a dict-shaped JSON payload is
+        still required on the wire.
     """
     # Sanitize name: strip .tex extension if present
     if name.endswith(".tex"):
@@ -93,6 +107,7 @@ def compile_content(
         body_file = temp_dir / "body.tex"
         tex_file = temp_dir / f"{name}.tex"
         pdf_file = temp_dir / f"{name}.pdf"
+        log_path = temp_dir / f"{name}.log"
 
         # Write body content
         body_file.write_text(latex_content, encoding="utf-8")
@@ -119,11 +134,17 @@ def compile_content(
             timeout=30,
         )
         if build_result.returncode != 0:
-            return {
-                "success": False,
-                "output_pdf": None,
-                "error": f"Document build failed: {build_result.stderr}",
-            }
+            return CompilationResult(
+                success=False,
+                exit_code=build_result.returncode,
+                stdout=_truncate(build_result.stdout),
+                stderr=_truncate(build_result.stderr),
+                output_pdf=None,
+                log_file=None,
+                color_mode=color_mode,
+                temp_dir=temp_dir,
+                message=f"Document build failed: {_truncate(build_result.stderr, 200)}",
+            )
 
         # Step 2: Compile to PDF
         compile_cmd = [
@@ -155,60 +176,78 @@ def compile_content(
             timeout=timeout + 10,
         )
 
-        # Read log file
-        log_content = _read_log(temp_dir, name)
-
         # Determine final PDF path
-        final_pdf = pdf_file
+        final_pdf: Optional[Path] = pdf_file if pdf_file.exists() else None
         if compile_result.returncode == 0 and preview_dir:
             preview_pdf = preview_dir / f"{name}.pdf"
             if preview_pdf.exists():
                 final_pdf = preview_pdf
 
+        # log_file: the on-disk log path if it exists, else None.
+        log_file: Optional[Path] = log_path if log_path.exists() else None
+
         if compile_result.returncode == 0 and pdf_file.exists():
-            return {
-                "success": True,
-                "output_pdf": str(final_pdf),
-                "temp_dir": str(temp_dir),
-                "color_mode": color_mode,
-                "log": log_content,
-                "message": f"Content compiled successfully: {name}",
-            }
-        else:
-            return {
-                "success": False,
-                "output_pdf": None,
-                "temp_dir": str(temp_dir),
-                "color_mode": color_mode,
-                "log": log_content,
-                "stdout": _truncate(compile_result.stdout),
-                "stderr": _truncate(compile_result.stderr),
-                "error": f"Compilation failed with exit code {compile_result.returncode}",
-            }
+            return CompilationResult(
+                success=True,
+                exit_code=0,
+                stdout=_truncate(compile_result.stdout),
+                stderr=_truncate(compile_result.stderr),
+                output_pdf=final_pdf,
+                log_file=log_file,
+                color_mode=color_mode,
+                temp_dir=temp_dir,
+                message=f"Content compiled successfully: {name}",
+            )
+        return CompilationResult(
+            success=False,
+            exit_code=compile_result.returncode,
+            stdout=_truncate(compile_result.stdout),
+            stderr=_truncate(compile_result.stderr),
+            output_pdf=None,
+            log_file=log_file,
+            color_mode=color_mode,
+            temp_dir=temp_dir,
+            message=f"Compilation failed with exit code {compile_result.returncode}",
+        )
 
     except subprocess.TimeoutExpired:
-        return {
-            "success": False,
-            "error": f"Content compilation timed out after {timeout} seconds",
-        }
+        # exit_code 124 is the POSIX `timeout(1)` convention; preserves
+        # caller's ability to distinguish "took too long" from "latexmk
+        # rejected the source" (which surfaces as 1 / 12 etc.).
+        return CompilationResult(
+            success=False,
+            exit_code=124,
+            stdout="",
+            stderr=f"Content compilation timed out after {timeout} seconds",
+            output_pdf=None,
+            log_file=None,
+            color_mode=color_mode,
+            temp_dir=None,
+            message=f"Content compilation timed out after {timeout} seconds",
+        )
     except Exception as e:
-        return {
-            "success": False,
-            "error": str(e),
-        }
-
-
-def _read_log(temp_dir: Path, name: str) -> str:
-    """Read and truncate log file."""
-    log_file = temp_dir / f"{name}.log"
-    if log_file.exists():
-        content = log_file.read_text(encoding="utf-8", errors="replace")
-        return content[-5000:] if len(content) > 5000 else content
-    return ""
+        # exit_code -1 = our own internal error wrapper, never produced
+        # by latexmk or `timeout`. Lets the Django view branch on
+        # `exit_code == -1` to render "internal error, retry" rather
+        # than the latexmk-flavoured failure UX.
+        return CompilationResult(
+            success=False,
+            exit_code=-1,
+            stdout="",
+            stderr=str(e),
+            output_pdf=None,
+            log_file=None,
+            color_mode=color_mode,
+            temp_dir=None,
+            message=str(e),
+        )
 
 
 def _truncate(text: str, limit: int = 2000) -> str:
-    """Truncate text to limit."""
+    """Truncate text to limit. Used for stdout/stderr capture so the
+    CompilationResult never carries multi-MB blobs through the Django
+    JSON layer. The full latexmk log stays available via
+    ``CompilationResult.log_file`` (path to the on-disk .log)."""
     return text[-limit:] if len(text) > limit else text
 
 

--- a/src/scitex_writer/_dataclasses/results/_CompilationResult.py
+++ b/src/scitex_writer/_dataclasses/results/_CompilationResult.py
@@ -47,6 +47,32 @@ class CompilationResult:
     warnings: List[str] = field(default_factory=list)
     """Parsed LaTeX warnings (if any)"""
 
+    color_mode: Optional[str] = None
+    """Color theme used for the compilation ('light' / 'dark' / None).
+
+    Populated by the content/preview compile path so the UI knows which
+    theme the rendered PDF belongs to. The manuscript / supplementary /
+    revision compile paths leave this as None.
+    """
+
+    temp_dir: Optional[Path] = None
+    """Temporary build directory the compilation ran in.
+
+    Populated by the content/preview compile path so callers can clean
+    up the scratch area after consuming the PDF. The manuscript /
+    supplementary / revision paths leave this as None (they build
+    in-place inside the project tree).
+    """
+
+    message: Optional[str] = None
+    """Free-form human-readable summary line.
+
+    Filled with a 'Content compiled successfully: ...' line on success
+    and 'Compilation failed with exit code N' / 'timed out' / etc. on
+    failure paths, so the Django consumer can surface a single status
+    string without re-deriving it from ``success`` + ``exit_code``.
+    """
+
     def __str__(self):
         """Human-readable summary."""
         status = "SUCCESS" if self.success else "FAILED"

--- a/src/scitex_writer/compile.py
+++ b/src/scitex_writer/compile.py
@@ -27,6 +27,7 @@ Usage::
     )
 """
 
+from ._dataclasses import CompilationResult
 from ._mcp.handlers import compile_manuscript as _compile_manuscript
 from ._mcp.handlers import compile_revision as _compile_revision
 from ._mcp.handlers import compile_supplementary as _compile_supplementary
@@ -164,7 +165,7 @@ def content(
     name: str = "content",
     timeout: int = 60,
     keep_aux: bool = False,
-) -> "CompilationResult":
+) -> CompilationResult:
     """Compile raw LaTeX content to PDF.
 
     Creates a standalone document from the provided LaTeX content and compiles

--- a/src/scitex_writer/compile.py
+++ b/src/scitex_writer/compile.py
@@ -164,7 +164,7 @@ def content(
     name: str = "content",
     timeout: int = 60,
     keep_aux: bool = False,
-) -> dict:
+) -> "CompilationResult":
     """Compile raw LaTeX content to PDF.
 
     Creates a standalone document from the provided LaTeX content and compiles
@@ -182,7 +182,14 @@ def content(
         keep_aux: Keep auxiliary files (.aux, .log, etc.) after compilation.
 
     Returns:
-        Dict with success status, output_pdf path, log, and any errors.
+        ``CompilationResult`` dataclass. Always carries ``success`` /
+        ``exit_code`` / ``stdout`` / ``stderr`` / ``output_pdf`` /
+        ``log_file`` / ``color_mode`` / ``temp_dir`` / ``message`` —
+        unified across success / latexmk-fail / timeout / internal-
+        exception paths. Migrated from the legacy ad-hoc dict return in
+        2026-06-10 (G1 follow-up to G2 atomic publish + G3 flock).
+        Dict-shape JSON callers can serialize via
+        ``dataclasses.asdict(result)``.
 
     Example::
 

--- a/tests/scripts/python/test_compile_content.py
+++ b/tests/scripts/python/test_compile_content.py
@@ -269,8 +269,14 @@ _REQUIRES_LATEXMK = pytest.mark.skipif(
 
 
 def _cleanup_temp_dir(result):
-    temp = result.get("temp_dir")
-    if temp:
+    # `result` is a CompilationResult dataclass (G1 unification,
+    # 2026-06-10) — drop the legacy `.get("temp_dir")` dict access in
+    # favour of attribute access. CompilationResult.temp_dir is
+    # Optional[Path]; None when the compile path is not the preview
+    # path (e.g. manuscript / supplementary / revision compiles build
+    # in-place, no scratch dir to clean up).
+    temp = getattr(result, "temp_dir", None)
+    if temp is not None:
         temp_dir = Path(temp)
         if temp_dir.exists():
             shutil.rmtree(temp_dir)
@@ -296,7 +302,7 @@ class TestContentCompilation:
         result = compile.content(content, name="test_simple")
         _cleanup_temp_dir(result)
         # Assert
-        assert result["success"] is True
+        assert result.success is True
 
     @_REQUIRES_LATEXMK
     def test_compile_simple_content_writes_pdf_on_disk(self):
@@ -314,7 +320,7 @@ class TestContentCompilation:
         # Act
         result = compile.content(content, name="test_simple")
         pdf_exists = (
-            result["output_pdf"] is not None and Path(result["output_pdf"]).exists()
+            result.output_pdf is not None and Path(result.output_pdf).exists()
         )
         _cleanup_temp_dir(result)
         # Assert
@@ -330,7 +336,7 @@ class TestContentCompilation:
         result = compile.content(content, name="test_body")
         _cleanup_temp_dir(result)
         # Assert
-        assert result["success"] is True
+        assert result.success is True
 
     @_REQUIRES_LATEXMK
     def test_compile_dark_mode_reports_dark_color_mode(self):
@@ -353,7 +359,7 @@ class TestContentCompilation:
         result = compile.content(content, color_mode="dark", name="test_dark")
         _cleanup_temp_dir(result)
         # Assert
-        assert result["color_mode"] == "dark"
+        assert result.color_mode == "dark"
 
     @_REQUIRES_LATEXMK
     def test_compile_invalid_latex_reports_failure(self):
@@ -374,7 +380,7 @@ class TestContentCompilation:
         result = compile.content(content, name="test_invalid")
         _cleanup_temp_dir(result)
         # Assert
-        assert result["success"] is False
+        assert result.success is False
 
     @_REQUIRES_LATEXMK
     def test_compile_returns_success_key_regardless_of_timeout(self):
@@ -391,11 +397,13 @@ class TestContentCompilation:
         )
         # Act
         # timeout=1 may or may not trip depending on machine speed; the
-        # contract under test is only that a 'success' key is always set.
+        # contract under test is only that the result carries a `success`
+        # attribute and an `exit_code` attribute regardless of which
+        # branch (success / latexmk-fail / TimeoutExpired) it hit.
         result = compile.content(content, timeout=1, name="test_timeout")
         _cleanup_temp_dir(result)
         # Assert
-        assert "success" in result
+        assert hasattr(result, "success") and hasattr(result, "exit_code")
 
 
 class TestMcpToolRegistration:


### PR DESCRIPTION
## Summary

G1 of the proj-scitex-hub triage (follow-up to G2 #124 atomic publish + G3 #125 flock serialization). Migrates `compile_content()`'s return shape from an ad-hoc `dict` to the existing `CompilationResult` dataclass so every preview compile produces a single, typed, exhaustively-populated result regardless of which branch (success / latexmk-fail / TimeoutExpired / internal exception) it took.

## Why

`compile_content()` previously returned a `dict` whose shape *depended on which branch* the call hit:

```
success path  : { success, output_pdf, temp_dir, color_mode, log, message }
latexmk-fail  : { success, output_pdf, temp_dir, color_mode, log, stdout, stderr, error }
TimeoutExpired: { success, error }
Exception     : { success, error }
```

- The exit code was *stringified* into the `error` message (`"Compilation failed with exit code N"`) on the failure branch and **disappeared entirely on every other branch**.
- `stdout` / `stderr` were only populated on the latexmk-fail branch.
- The Django consumer at `content.py:186` therefore could not distinguish "latexmk crashed with exit 12 because of a race" from "latexmk crashed with exit 1 because of bad LaTeX" — both surface through the same `error` string. (This is exactly what made the G2 race so opaque to operator-visible diagnostics.)

## Fix

Return `CompilationResult` on every branch:

| Field | Always | Notes |
|---|---|---|
| `success: bool` | yes | |
| `exit_code: int` | yes | `0` on success / latexmk's `rc` on fail / `124` on TimeoutExpired / `-1` on internal exception |
| `stdout: str` | yes | truncated to 2000 chars |
| `stderr: str` | yes | truncated to 2000 chars |
| `output_pdf: Optional[Path]` | yes | |
| `log_file: Optional[Path]` | yes | path to the on-disk `.log`; callers read it for content (avoids piping multi-MB blobs through JSON) |
| `color_mode: Optional[str]` | yes | new field on CompilationResult |
| `temp_dir: Optional[Path]` | yes | new field on CompilationResult |
| `message: Optional[str]` | yes | new field on CompilationResult |

## Why three new fields on CompilationResult

- `color_mode` and `temp_dir` are preview-specific metadata that the manuscript / supplementary / revision paths do not produce (they compile in-place, no scratch dir; no light/dark theme). Defaulting both to `None` keeps those constructor calls unchanged — verified by spot-grep on the existing `_runner.py` / `manuscript.py` / `supplementary.py` / `revision.py` constructor sites.
- `message` is a free-form summary line that the Django UI previously read from the dict's `message` or `error` keys; surfacing it as a typed `Optional[str]` on CompilationResult lets the UI keep showing a single status string without re-deriving from `success` + `exit_code`.

## Callers

Internal Python callers (`compile.py`, `_mcp/content.py`, `_mcp/tools/compile.py`) are already thin pass-throughs and need no change. The test helper `_cleanup_temp_dir(result)` swaps `result.get("temp_dir")` for `getattr(result, "temp_dir", None)`. The 5 `TestContentCompilation` test assertions swap `result["X"]` for `result.X`.

**External consumers** (notably the Django consumer in `scitex-cloud` at the `compile_content()` call site) need to either:

1. Use attribute access: `result.success`, `result.exit_code`, ...
2. Or serialize to dict at the boundary: `from dataclasses import asdict; asdict(result)`

Coordinated with proj-scitex-hub's pending pin-bump PR — the aggregate scitex-writer release (G2 + G3 + G1 in one PATCH bump) will be the version that flips this schema, so the Django consumer can adopt the new shape in one shot.

## Test plan

- [x] Local pytest (`tests/scripts/python/test_compile_content.py`): 11 pass + 6 latexmk-required skipped + 1 unrelated env fail (`fastmcp` not installed locally; CI has it).
- [ ] CI matrix green on this PR.
- [ ] Post-merge prod observational check (alongside the aggregate scitex-writer release + scitex-cloud pin-bump + image rebuild): the Django response payload should now consistently expose `exit_code` for every failure mode, replacing the previous "Compilation failed with exit code N"-as-string surface.

## Scope (per 1 WI = 1 PR doctrine, lead-routed 2026-06-10)

- **G2** atomic publish: #124, merged.
- **G3** flock serialization: #125, merged.
- **G1** schema unification: this PR.
- **Aggregate scitex-writer PATCH release** covers all three (NAS OOM avoidance — 1 deploy step instead of 3); proj-scitex-hub then opens the single scitex-cloud pin-bump PR.

## References

- proj-scitex-hub diagnosis a2a (`msg_id 7b085c50346c439ab2f63e99403d5cf2`).
- Lead routing GO + aggregate-release policy (2026-06-10).
- Companion PRs: #124 (G2 — merged), #125 (G3 — merged).
- Companion G4: https://github.com/ywatanabe1989/scitex-hub/pull/252 (proj-scitex-hub, parallel scope).
