### PR TITLE
release: v2.17.4 — preview compile race-fixes (G2+G3+G1 aggregate)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.17.3"
+version = "2.17.4"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
PATCH bump 2.17.3 → 2.17.4 covering the three landed preview-compile race fixes:

- #124 (G2) atomic .preview/<name>.pdf publish
- #125 (G3) per-(project, section, color_mode) flock serialization
- #126 (G1) compile.content returns CompilationResult (drops ad-hoc dict)

Lead-routed aggregate-release policy (2026-06-10, NAS OOM avoidance — 1 deploy step instead of 3). After merge:

1. Tag v2.17.4 on the merge commit → push tag → on-tag CI publishes to PyPI.
2. proj-scitex-hub then opens the single scitex-cloud pin-bump PR (Dockerfile.prod pin to 2.17.4 + Django consumer dict→attribute migration via dataclasses.asdict() at JSON boundary + tests). Lead-mandated gate: that PR's CI green BEFORE prod image rebuild.

External consumers must adopt attribute access (or asdict() at the JSON boundary) for the CompilationResult return — G1 is the breaking part of this aggregate.