### PR TITLE
release: v2.17.5 — re-roll past orphan v2.17.4 tag (same G2+G3+G1 payload)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.17.4"
+version = "2.17.5"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
v2.17.4 was already tagged on origin (points to a non-existent commit `d018f0de...` — an aborted prior release; PyPI never published 2.17.4, verified `/pypi/scitex-writer/2.17.4/json → 404`). Stepping one PATCH past it (rather than force-overwriting an already-published tag name) keeps lockfile/cache identity stable.

v2.17.5 carries the same payload that PR #127 (merged as `f9b88dd`) declared for the aggregate release:

- #124 (G2) atomic .preview/<name>.pdf publish
- #125 (G3) per-(project, section, color_mode) flock serialization
- #126 (G1) compile.content returns CompilationResult (drops ad-hoc dict)

After merge: tag v2.17.5 on the merge commit → push tag → on-tag CI publishes to PyPI. proj-scitex-hub then opens the single scitex-cloud pin-bump PR (Dockerfile.prod pin to **2.17.5** + Django consumer dict→attribute migration via `dataclasses.asdict()` + tests; lead-mandated CI-green gate before prod image rebuild).