### PR TITLE
chore(linguist): exclude src/*/_sphinx_html/ from language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Sphinx-generated docs bundle — exclude from GitHub language stats.
+src/*/_sphinx_html/** linguist-generated


### PR DESCRIPTION
Ecosystem-wide `.gitattributes` sweep tracked at ywatanabe1989/scitex-dev#168.

Adds the canonical 2-line Linguist exclusion for the Sphinx HTML bundle, identical to the rule already present in 47 other scitex-* repos:

```
# Sphinx-generated docs bundle — exclude from GitHub language stats.
src/*/_sphinx_html/** linguist-generated
```

Without it, GitHub Linguist counts the pre-built HTML in `src/<pkg>/_sphinx_html/` (the path scitex-cloud serves docs from per audit-project PS-121, so it cannot be `.gitignore`-d) and reports the repo as 'HTML' in the repo language bar.

Operator-directed + lead-approved + charter cross-pkg exception logged for this narrow `.gitattributes`-only scope. CI runs are pro-forma — this changes zero code paths.