### PR TITLE
fix(mermaid): crash-early precheck for mmdc (libnspr4 / apptainer SIGSEGV)

### DIFF
--- a/scripts/shell/modules/mmd2png_all.sh
+++ b/scripts/shell/modules/mmd2png_all.sh
@@ -68,6 +68,20 @@ mmd2png() {
         return 1
     fi
 
+    # Crash-early dependency check: if `mmdc` is on PATH but its
+    # headless-chromium dep is broken (missing libnspr4, apptainer
+    # sandbox SIGSEGV, etc.), fail LOUD here with an actionable hint
+    # rather than letting mmdc silently write a corrupted PNG.
+    if command -v python3 &>/dev/null; then
+        if ! python3 -c "from scitex_writer._utils._mermaid_precheck import check_mmdc_or_raise; check_mmdc_or_raise()" 2>/tmp/.mmdc_precheck.$$.err; then
+            echo_error "    mmdc precheck failed:"
+            sed 's/^/        /' /tmp/.mmdc_precheck.$$.err >&2
+            rm -f /tmp/.mmdc_precheck.$$.err
+            return 1
+        fi
+        rm -f /tmp/.mmdc_precheck.$$.err
+    fi
+
     # Process .mmd files - handle both hidden and numbered files
     for mmd_file in "$SCITEX_WRITER_FIGURE_CAPTION_MEDIA_DIR"/.*.mmd "$SCITEX_WRITER_FIGURE_CAPTION_MEDIA_DIR"/[0-9]*.mmd; do
         [ -e "$mmd_file" ] || continue

--- a/src/scitex_writer/_utils/__init__.py
+++ b/src/scitex_writer/_utils/__init__.py
@@ -6,10 +6,13 @@
 
 from ._csv_latex import csv2latex, latex2csv
 from ._figures import convert_figure, list_figures
+from ._mermaid_precheck import MermaidDependencyError, check_mmdc_or_raise
 from ._pdf_images import pdf_thumbnail, pdf_to_images
 from ._verify_tree_structure import verify_tree_structure
 
 __all__ = [
+    "MermaidDependencyError",
+    "check_mmdc_or_raise",
     "convert_figure",
     "csv2latex",
     "latex2csv",

--- a/src/scitex_writer/_utils/_mermaid_precheck.py
+++ b/src/scitex_writer/_utils/_mermaid_precheck.py
@@ -70,7 +70,7 @@ _SIGSEGV_HINT = (
     "chromium. This is a known Apptainer/Singularity gap: the "
     "container's chromium cannot create its sandbox. Re-run mmdc "
     "with '--puppeteerConfigFile' pointing at a config that sets "
-    "'args: [\"--no-sandbox\", \"--disable-dev-shm-usage\"]', or "
+    '\'args: ["--no-sandbox", "--disable-dev-shm-usage"]\', or '
     "pull a mermaid-cli image rebuilt with the sandbox-friendly "
     "options."
 )
@@ -151,8 +151,7 @@ def check_mmdc_or_raise(
 
     raise MermaidDependencyError(
         f"mmdc --version exited with code {result.returncode}. "
-        f"stderr: {combined_err.strip() or '<empty>'}. "
-        + _NOT_INSTALLED_HINT
+        f"stderr: {combined_err.strip() or '<empty>'}. " + _NOT_INSTALLED_HINT
     )
 
 

--- a/src/scitex_writer/_utils/_mermaid_precheck.py
+++ b/src/scitex_writer/_utils/_mermaid_precheck.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_utils/_mermaid_precheck.py
+
+"""Crash-early dependency check for the mermaid CLI (mmdc).
+
+Background
+----------
+``mmdc`` (``@mermaid-js/mermaid-cli``) drives a headless Chromium under
+the hood (via puppeteer). On stock Linux hosts and inside thin
+Apptainer/Singularity images, that Chromium needs a handful of shared
+libraries that are NOT always present even when ``mmdc`` itself is on
+PATH. The two most common failure modes we have seen in the wild:
+
+1. ``libnspr4.so`` missing — common on minimal Linux images and inside
+   Apptainer/Singularity containers built without the NSS/NSPR stack.
+2. A puppeteer-launched chromium subprocess dying with SIGSEGV /
+   "Aborted (core dumped)" — typically inside Apptainer where shared
+   memory or sandbox flags trip the renderer.
+
+Either failure makes ``mmdc`` exit non-zero AFTER it has already
+written a half-baked / corrupted output file. The downstream LaTeX
+build then either silently embeds garbage or fails much later with an
+opaque error far from the real root cause.
+
+This module fails LOUD, EARLY, with an install hint:
+
+  >>> from scitex_writer._utils._mermaid_precheck import check_mmdc_or_raise
+  >>> check_mmdc_or_raise()
+  scitex_writer._utils._mermaid_precheck.MermaidDependencyError:
+  mmdc is installed but cannot start: missing libnspr4. Install it
+  with: sudo apt install libnspr4 libnss3
+  (or rebuild your apptainer image with the NSPR/NSS libs included).
+
+The intent: call this at the top of any entrypoint that shells out to
+``mmdc`` (the mmd2png shell helper, a future python wrapper, an MCP
+tool, etc.). The check is cheap (single subprocess call) and runs
+exactly once per process.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from typing import Optional
+
+
+class MermaidDependencyError(RuntimeError):
+    """Raised when the mermaid CLI (mmdc) cannot be invoked safely.
+
+    Distinct from FileNotFoundError so callers can tell "user has not
+    installed mmdc at all" apart from "mmdc is installed but the
+    runtime environment is broken (missing libnspr4 / chromium SIGSEGV
+    inside apptainer)". Inherits RuntimeError because both are runtime
+    environment problems, not programmer errors.
+    """
+
+
+_LIBNSPR4_HINT = (
+    "mmdc is installed but its headless-chromium dependency cannot "
+    "start: 'libnspr4' is missing. On Debian/Ubuntu install with "
+    "'sudo apt install libnspr4 libnss3'. Inside an Apptainer/"
+    "Singularity image, rebuild the container with the NSPR/NSS "
+    "stack baked in (libnspr4, libnss3, libatk1.0, libxcomposite1, "
+    "libxdamage1, libxrandr2, libgbm1, libasound2)."
+)
+
+_SIGSEGV_HINT = (
+    "mmdc crashed (SIGSEGV / Aborted) while launching its headless "
+    "chromium. This is a known Apptainer/Singularity gap: the "
+    "container's chromium cannot create its sandbox. Re-run mmdc "
+    "with '--puppeteerConfigFile' pointing at a config that sets "
+    "'args: [\"--no-sandbox\", \"--disable-dev-shm-usage\"]', or "
+    "pull a mermaid-cli image rebuilt with the sandbox-friendly "
+    "options."
+)
+
+_NOT_INSTALLED_HINT = (
+    "mmdc (mermaid-cli) is not installed or not on PATH. Install "
+    "with: 'npm install -g @mermaid-js/mermaid-cli' "
+    "(requires node>=18). For HPC/Apptainer environments without "
+    "npm, pull the prebuilt image: "
+    "'apptainer pull docker://minlag/mermaid-cli:latest'."
+)
+
+
+def _detect_libnspr4(stderr: str) -> bool:
+    return "libnspr4" in stderr or "libnspr4.so" in stderr
+
+
+def _detect_apptainer_segfault(stderr: str) -> bool:
+    needles = ("SIGSEGV", "Aborted", "segmentation fault", "core dumped")
+    low = stderr.lower()
+    return any(n.lower() in low for n in needles)
+
+
+def check_mmdc_or_raise(
+    mmdc_path: Optional[str] = None,
+    timeout: float = 10.0,
+) -> str:
+    """Crash-early check that the mermaid CLI (mmdc) is actually usable.
+
+    Parameters
+    ----------
+    mmdc_path:
+        Override the discovered path (mainly for testing). If None,
+        ``shutil.which("mmdc")`` is used.
+    timeout:
+        Seconds to wait for ``mmdc --version`` to return. Default 10s
+        — the goal is to fail fast, not hang CI.
+
+    Returns
+    -------
+    The resolved path to a working ``mmdc`` binary.
+
+    Raises
+    ------
+    MermaidDependencyError
+        ``mmdc`` is not on PATH, or it is on PATH but cannot start
+        because of a missing system library / sandbox failure.
+    """
+    resolved = mmdc_path if mmdc_path is not None else shutil.which("mmdc")
+    if not resolved:
+        raise MermaidDependencyError(_NOT_INSTALLED_HINT)
+
+    try:
+        result = subprocess.run(
+            [resolved, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError as exc:
+        # Race: which() saw the binary but it disappeared (or perm bits flipped).
+        raise MermaidDependencyError(_NOT_INSTALLED_HINT) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise MermaidDependencyError(
+            "mmdc --version timed out after "
+            f"{timeout:g}s — its headless chromium is likely hanging "
+            "on a missing sandbox. " + _SIGSEGV_HINT
+        ) from exc
+
+    if result.returncode == 0:
+        return resolved
+
+    combined_err = (result.stderr or "") + (result.stdout or "")
+    if _detect_libnspr4(combined_err):
+        raise MermaidDependencyError(_LIBNSPR4_HINT)
+    if _detect_apptainer_segfault(combined_err):
+        raise MermaidDependencyError(_SIGSEGV_HINT)
+
+    raise MermaidDependencyError(
+        f"mmdc --version exited with code {result.returncode}. "
+        f"stderr: {combined_err.strip() or '<empty>'}. "
+        + _NOT_INSTALLED_HINT
+    )
+
+
+# EOF

--- a/tests/scitex_writer/_utils/test__mermaid_precheck.py
+++ b/tests/scitex_writer/_utils/test__mermaid_precheck.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_writer/_utils/test__mermaid_precheck.py
+
+"""Tests for scitex_writer._utils._mermaid_precheck.check_mmdc_or_raise.
+
+These tests use tmp_path PATH manipulation (not unittest.mock) to
+exercise the precheck without requiring a real mmdc install on the
+CI runner.
+"""
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from scitex_writer._utils._mermaid_precheck import (
+    MermaidDependencyError,
+    check_mmdc_or_raise,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers (testing infrastructure — write a fake mmdc into tmp_path)
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_mmdc(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    body: str,
+) -> Path:
+    """Drop a fake mmdc shell-script into tmp_path and put it on PATH.
+
+    Returns the path to the fake mmdc binary.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake = bin_dir / "mmdc"
+    fake.write_text(body)
+    fake.chmod(fake.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    monkeypatch.setenv("PATH", str(bin_dir), prepend=os.pathsep)
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# mmdc not on PATH
+# ---------------------------------------------------------------------------
+
+
+class TestMmdcMissing:
+    """mmdc binary is not present anywhere on PATH."""
+
+    def test_raises_mermaid_dependency_error_when_mmdc_missing(
+        self, tmp_path, monkeypatch
+    ):
+        # Arrange
+        monkeypatch.setenv("PATH", str(tmp_path / "empty"))
+        # Act / Assert
+        with pytest.raises(MermaidDependencyError):
+            check_mmdc_or_raise()
+
+    def test_error_message_mentions_install_hint_when_missing(
+        self, tmp_path, monkeypatch
+    ):
+        # Arrange
+        monkeypatch.setenv("PATH", str(tmp_path / "empty"))
+        # Act
+        with pytest.raises(MermaidDependencyError) as exc_info:
+            check_mmdc_or_raise()
+        # Assert
+        assert "mermaid-cli" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# mmdc present but libnspr4 missing (most common Linux gap)
+# ---------------------------------------------------------------------------
+
+
+class TestMmdcLibnspr4Missing:
+    """mmdc is on PATH but its chromium dep is missing libnspr4."""
+
+    def test_raises_mermaid_dependency_error_when_libnspr4_missing(
+        self, tmp_path, monkeypatch
+    ):
+        # Arrange
+        _install_fake_mmdc(
+            tmp_path,
+            monkeypatch,
+            body=(
+                "#!/bin/sh\n"
+                "echo 'error while loading shared libraries: libnspr4.so:"
+                " cannot open shared object file' >&2\n"
+                "exit 127\n"
+            ),
+        )
+        # Act / Assert
+        with pytest.raises(MermaidDependencyError):
+            check_mmdc_or_raise()
+
+    def test_error_message_mentions_libnspr4_install_hint(
+        self, tmp_path, monkeypatch
+    ):
+        # Arrange
+        _install_fake_mmdc(
+            tmp_path,
+            monkeypatch,
+            body=(
+                "#!/bin/sh\n"
+                "echo 'error while loading shared libraries: libnspr4.so:"
+                " cannot open shared object file' >&2\n"
+                "exit 127\n"
+            ),
+        )
+        # Act
+        with pytest.raises(MermaidDependencyError) as exc_info:
+            check_mmdc_or_raise()
+        # Assert
+        assert "libnspr4" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# mmdc present but chromium SIGSEGVs (apptainer / singularity gap)
+# ---------------------------------------------------------------------------
+
+
+class TestMmdcApptainerSegfault:
+    """mmdc on PATH, but headless chromium SIGSEGVs (typical apptainer)."""
+
+    def test_raises_mermaid_dependency_error_on_sigsegv(
+        self, tmp_path, monkeypatch
+    ):
+        # Arrange
+        _install_fake_mmdc(
+            tmp_path,
+            monkeypatch,
+            body=(
+                "#!/bin/sh\n"
+                "echo 'Aborted (core dumped) SIGSEGV in chromium' >&2\n"
+                "exit 139\n"
+            ),
+        )
+        # Act / Assert
+        with pytest.raises(MermaidDependencyError):
+            check_mmdc_or_raise()
+
+    def test_error_message_mentions_sandbox_hint_on_sigsegv(
+        self, tmp_path, monkeypatch
+    ):
+        # Arrange
+        _install_fake_mmdc(
+            tmp_path,
+            monkeypatch,
+            body=(
+                "#!/bin/sh\n"
+                "echo 'Aborted (core dumped) SIGSEGV in chromium' >&2\n"
+                "exit 139\n"
+            ),
+        )
+        # Act
+        with pytest.raises(MermaidDependencyError) as exc_info:
+            check_mmdc_or_raise()
+        # Assert
+        assert "sandbox" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# mmdc present and working
+# ---------------------------------------------------------------------------
+
+
+class TestMmdcWorking:
+    """mmdc is on PATH and runs --version successfully."""
+
+    def test_returns_resolved_mmdc_path_when_working(
+        self, tmp_path, monkeypatch
+    ):
+        # Arrange
+        fake = _install_fake_mmdc(
+            tmp_path,
+            monkeypatch,
+            body="#!/bin/sh\necho '10.0.0'\nexit 0\n",
+        )
+        # Act
+        resolved = check_mmdc_or_raise()
+        # Assert
+        assert resolved == str(fake)
+
+
+# ---------------------------------------------------------------------------
+# Explicit override path
+# ---------------------------------------------------------------------------
+
+
+class TestMmdcExplicitOverride:
+    """Caller passes mmdc_path explicitly (bypassing shutil.which)."""
+
+    def test_raises_when_explicit_path_does_not_exist(self, tmp_path):
+        # Arrange
+        bogus = str(tmp_path / "does-not-exist" / "mmdc")
+        # Act / Assert
+        with pytest.raises(MermaidDependencyError):
+            check_mmdc_or_raise(mmdc_path=bogus)
+
+
+if __name__ == "__main__":
+    import os as _os
+
+    pytest.main([_os.path.abspath(__file__)])
+
+# EOF

--- a/tests/scitex_writer/_utils/test__mermaid_precheck.py
+++ b/tests/scitex_writer/_utils/test__mermaid_precheck.py
@@ -15,8 +15,10 @@ from pathlib import Path
 
 import pytest
 
-from scitex_writer._utils._mermaid_precheck import MermaidDependencyError, check_mmdc_or_raise
-
+from scitex_writer._utils._mermaid_precheck import (
+    MermaidDependencyError,
+    check_mmdc_or_raise,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers (testing infrastructure — drop a fake mmdc shim into tmp_path)
@@ -127,9 +129,7 @@ class TestMmdcGenericFailure:
         # Arrange
         fake = _write_fake_mmdc(
             tmp_path,
-            body=(
-                "#!/bin/sh\necho 'some unrelated error message' >&2\nexit 2\n"
-            ),
+            body=("#!/bin/sh\necho 'some unrelated error message' >&2\nexit 2\n"),
         )
         # Act / Assert
         with pytest.raises(MermaidDependencyError, match="exited with code 2"):

--- a/tests/scitex_writer/_utils/test__mermaid_precheck.py
+++ b/tests/scitex_writer/_utils/test__mermaid_precheck.py
@@ -4,17 +4,17 @@
 
 """Tests for scitex_writer._utils._mermaid_precheck.check_mmdc_or_raise.
 
-These tests use tmp_path PATH manipulation (not unittest.mock) to
-exercise the precheck without requiring a real mmdc install on the
-CI runner.
+These tests use ``tmp_path`` + the explicit ``mmdc_path`` override on
+``check_mmdc_or_raise`` so we never touch ``shutil.which`` / PATH and
+never need the ``monkeypatch`` fixture (PA-306 no-mocks doctrine).
+A fake ``mmdc`` is written into ``tmp_path`` as a tiny shell script
+with controlled exit code / stderr to simulate each failure mode.
 """
 
-import os
 import stat
 from pathlib import Path
 
 import pytest
-
 from scitex_writer._utils._mermaid_precheck import (
     MermaidDependencyError,
     check_mmdc_or_raise,
@@ -22,55 +22,32 @@ from scitex_writer._utils._mermaid_precheck import (
 
 
 # ---------------------------------------------------------------------------
-# Helpers (testing infrastructure — write a fake mmdc into tmp_path)
+# Helpers (testing infrastructure — drop a fake mmdc shim into tmp_path)
 # ---------------------------------------------------------------------------
 
 
-def _install_fake_mmdc(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    body: str,
-) -> Path:
-    """Drop a fake mmdc shell-script into tmp_path and put it on PATH.
-
-    Returns the path to the fake mmdc binary.
-    """
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    fake = bin_dir / "mmdc"
+def _write_fake_mmdc(tmp_path: Path, body: str) -> Path:
+    """Write an executable shim at ``tmp_path/mmdc`` and return its path."""
+    fake = tmp_path / "mmdc"
     fake.write_text(body)
     fake.chmod(fake.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
-    monkeypatch.setenv("PATH", str(bin_dir), prepend=os.pathsep)
     return fake
 
 
 # ---------------------------------------------------------------------------
-# mmdc not on PATH
+# mmdc not on PATH (caller passes an explicit nonexistent path)
 # ---------------------------------------------------------------------------
 
 
 class TestMmdcMissing:
-    """mmdc binary is not present anywhere on PATH."""
+    """No mmdc binary exists at the given path."""
 
-    def test_raises_mermaid_dependency_error_when_mmdc_missing(
-        self, tmp_path, monkeypatch
-    ):
+    def test_raises_mermaid_dependency_error_when_mmdc_missing(self, tmp_path):
         # Arrange
-        monkeypatch.setenv("PATH", str(tmp_path / "empty"))
+        bogus = str(tmp_path / "does-not-exist" / "mmdc")
         # Act / Assert
-        with pytest.raises(MermaidDependencyError):
-            check_mmdc_or_raise()
-
-    def test_error_message_mentions_install_hint_when_missing(
-        self, tmp_path, monkeypatch
-    ):
-        # Arrange
-        monkeypatch.setenv("PATH", str(tmp_path / "empty"))
-        # Act
-        with pytest.raises(MermaidDependencyError) as exc_info:
-            check_mmdc_or_raise()
-        # Assert
-        assert "mermaid-cli" in str(exc_info.value)
+        with pytest.raises(MermaidDependencyError, match="mermaid-cli"):
+            check_mmdc_or_raise(mmdc_path=bogus)
 
 
 # ---------------------------------------------------------------------------
@@ -79,15 +56,12 @@ class TestMmdcMissing:
 
 
 class TestMmdcLibnspr4Missing:
-    """mmdc is on PATH but its chromium dep is missing libnspr4."""
+    """mmdc binary exists but its chromium dep is missing libnspr4."""
 
-    def test_raises_mermaid_dependency_error_when_libnspr4_missing(
-        self, tmp_path, monkeypatch
-    ):
+    def test_raises_with_libnspr4_install_hint(self, tmp_path):
         # Arrange
-        _install_fake_mmdc(
+        fake = _write_fake_mmdc(
             tmp_path,
-            monkeypatch,
             body=(
                 "#!/bin/sh\n"
                 "echo 'error while loading shared libraries: libnspr4.so:"
@@ -96,28 +70,8 @@ class TestMmdcLibnspr4Missing:
             ),
         )
         # Act / Assert
-        with pytest.raises(MermaidDependencyError):
-            check_mmdc_or_raise()
-
-    def test_error_message_mentions_libnspr4_install_hint(
-        self, tmp_path, monkeypatch
-    ):
-        # Arrange
-        _install_fake_mmdc(
-            tmp_path,
-            monkeypatch,
-            body=(
-                "#!/bin/sh\n"
-                "echo 'error while loading shared libraries: libnspr4.so:"
-                " cannot open shared object file' >&2\n"
-                "exit 127\n"
-            ),
-        )
-        # Act
-        with pytest.raises(MermaidDependencyError) as exc_info:
-            check_mmdc_or_raise()
-        # Assert
-        assert "libnspr4" in str(exc_info.value)
+        with pytest.raises(MermaidDependencyError, match="libnspr4"):
+            check_mmdc_or_raise(mmdc_path=str(fake))
 
 
 # ---------------------------------------------------------------------------
@@ -126,15 +80,12 @@ class TestMmdcLibnspr4Missing:
 
 
 class TestMmdcApptainerSegfault:
-    """mmdc on PATH, but headless chromium SIGSEGVs (typical apptainer)."""
+    """mmdc binary exists, but its headless chromium SIGSEGVs."""
 
-    def test_raises_mermaid_dependency_error_on_sigsegv(
-        self, tmp_path, monkeypatch
-    ):
+    def test_raises_with_sandbox_hint_on_sigsegv(self, tmp_path):
         # Arrange
-        _install_fake_mmdc(
+        fake = _write_fake_mmdc(
             tmp_path,
-            monkeypatch,
             body=(
                 "#!/bin/sh\n"
                 "echo 'Aborted (core dumped) SIGSEGV in chromium' >&2\n"
@@ -142,27 +93,8 @@ class TestMmdcApptainerSegfault:
             ),
         )
         # Act / Assert
-        with pytest.raises(MermaidDependencyError):
-            check_mmdc_or_raise()
-
-    def test_error_message_mentions_sandbox_hint_on_sigsegv(
-        self, tmp_path, monkeypatch
-    ):
-        # Arrange
-        _install_fake_mmdc(
-            tmp_path,
-            monkeypatch,
-            body=(
-                "#!/bin/sh\n"
-                "echo 'Aborted (core dumped) SIGSEGV in chromium' >&2\n"
-                "exit 139\n"
-            ),
-        )
-        # Act
-        with pytest.raises(MermaidDependencyError) as exc_info:
-            check_mmdc_or_raise()
-        # Assert
-        assert "sandbox" in str(exc_info.value).lower()
+        with pytest.raises(MermaidDependencyError, match="sandbox"):
+            check_mmdc_or_raise(mmdc_path=str(fake))
 
 
 # ---------------------------------------------------------------------------
@@ -171,42 +103,44 @@ class TestMmdcApptainerSegfault:
 
 
 class TestMmdcWorking:
-    """mmdc is on PATH and runs --version successfully."""
+    """mmdc binary exists and ``mmdc --version`` succeeds."""
 
-    def test_returns_resolved_mmdc_path_when_working(
-        self, tmp_path, monkeypatch
-    ):
+    def test_returns_resolved_mmdc_path_when_working(self, tmp_path):
         # Arrange
-        fake = _install_fake_mmdc(
+        fake = _write_fake_mmdc(
             tmp_path,
-            monkeypatch,
             body="#!/bin/sh\necho '10.0.0'\nexit 0\n",
         )
         # Act
-        resolved = check_mmdc_or_raise()
+        resolved = check_mmdc_or_raise(mmdc_path=str(fake))
         # Assert
         assert resolved == str(fake)
 
 
 # ---------------------------------------------------------------------------
-# Explicit override path
+# mmdc present but a generic non-zero exit (not libnspr4 / not SIGSEGV)
 # ---------------------------------------------------------------------------
 
 
-class TestMmdcExplicitOverride:
-    """Caller passes mmdc_path explicitly (bypassing shutil.which)."""
+class TestMmdcGenericFailure:
+    """mmdc exits non-zero with stderr that matches neither known needle."""
 
-    def test_raises_when_explicit_path_does_not_exist(self, tmp_path):
+    def test_raises_with_install_hint_on_generic_failure(self, tmp_path):
         # Arrange
-        bogus = str(tmp_path / "does-not-exist" / "mmdc")
+        fake = _write_fake_mmdc(
+            tmp_path,
+            body=(
+                "#!/bin/sh\necho 'some unrelated error message' >&2\nexit 2\n"
+            ),
+        )
         # Act / Assert
-        with pytest.raises(MermaidDependencyError):
-            check_mmdc_or_raise(mmdc_path=bogus)
+        with pytest.raises(MermaidDependencyError, match="exited with code 2"):
+            check_mmdc_or_raise(mmdc_path=str(fake))
 
 
 if __name__ == "__main__":
-    import os as _os
+    import os
 
-    pytest.main([_os.path.abspath(__file__)])
+    pytest.main([os.path.abspath(__file__)])
 
 # EOF

--- a/tests/scitex_writer/_utils/test__mermaid_precheck.py
+++ b/tests/scitex_writer/_utils/test__mermaid_precheck.py
@@ -4,17 +4,17 @@
 
 """Tests for scitex_writer._utils._mermaid_precheck.check_mmdc_or_raise.
 
-These tests use ``tmp_path`` + the explicit ``mmdc_path`` override on
-``check_mmdc_or_raise`` so we never touch ``shutil.which`` / PATH and
-never need the ``monkeypatch`` fixture (PA-306 no-mocks doctrine).
+These tests use ``tmp_path`` plus the explicit ``mmdc_path`` override
+on ``check_mmdc_or_raise`` so we never touch ``shutil.which`` / PATH
+and never need the ``monkeypatch`` fixture (PA-306 no-mocks doctrine).
 A fake ``mmdc`` is written into ``tmp_path`` as a tiny shell script
 with controlled exit code / stderr to simulate each failure mode.
 """
 
-import stat
 from pathlib import Path
 
 import pytest
+
 from scitex_writer._utils._mermaid_precheck import (
     MermaidDependencyError,
     check_mmdc_or_raise,
@@ -30,7 +30,8 @@ def _write_fake_mmdc(tmp_path: Path, body: str) -> Path:
     """Write an executable shim at ``tmp_path/mmdc`` and return its path."""
     fake = tmp_path / "mmdc"
     fake.write_text(body)
-    fake.chmod(fake.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    # chmod +rwx for owner / group / world (0o755)
+    fake.chmod(0o755)
     return fake
 
 

--- a/tests/scitex_writer/_utils/test__mermaid_precheck.py
+++ b/tests/scitex_writer/_utils/test__mermaid_precheck.py
@@ -15,10 +15,7 @@ from pathlib import Path
 
 import pytest
 
-from scitex_writer._utils._mermaid_precheck import (
-    MermaidDependencyError,
-    check_mmdc_or_raise,
-)
+from scitex_writer._utils._mermaid_precheck import MermaidDependencyError, check_mmdc_or_raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scitex_writer/_utils/test__mermaid_precheck.py
+++ b/tests/scitex_writer/_utils/test__mermaid_precheck.py
@@ -45,7 +45,8 @@ class TestMmdcMissing:
     def test_raises_mermaid_dependency_error_when_mmdc_missing(self, tmp_path):
         # Arrange
         bogus = str(tmp_path / "does-not-exist" / "mmdc")
-        # Act / Assert
+        # Act
+        # Assert
         with pytest.raises(MermaidDependencyError, match="mermaid-cli"):
             check_mmdc_or_raise(mmdc_path=bogus)
 
@@ -69,7 +70,8 @@ class TestMmdcLibnspr4Missing:
                 "exit 127\n"
             ),
         )
-        # Act / Assert
+        # Act
+        # Assert
         with pytest.raises(MermaidDependencyError, match="libnspr4"):
             check_mmdc_or_raise(mmdc_path=str(fake))
 
@@ -92,7 +94,8 @@ class TestMmdcApptainerSegfault:
                 "exit 139\n"
             ),
         )
-        # Act / Assert
+        # Act
+        # Assert
         with pytest.raises(MermaidDependencyError, match="sandbox"):
             check_mmdc_or_raise(mmdc_path=str(fake))
 
@@ -131,7 +134,8 @@ class TestMmdcGenericFailure:
             tmp_path,
             body=("#!/bin/sh\necho 'some unrelated error message' >&2\nexit 2\n"),
         )
-        # Act / Assert
+        # Act
+        # Assert
         with pytest.raises(MermaidDependencyError, match="exited with code 2"):
             check_mmdc_or_raise(mmdc_path=str(fake))
 


### PR DESCRIPTION
## Summary

- Add scitex_writer._utils._mermaid_precheck.check_mmdc_or_raise() that fails LOUD when mmdc is on PATH but its headless-chromium dep is broken (missing libnspr4, apptainer SIGSEGV / Aborted).
- Wire the precheck into scripts/shell/modules/mmd2png_all.sh BEFORE the render call, so we never produce a half-baked / corrupted PNG that the downstream LaTeX build silently embeds.
- Raises MermaidDependencyError with an actionable install hint per failure mode (not installed -> npm install or pull docker container; libnspr4 missing -> apt install libnspr4 libnss3; chromium SIGSEGV -> --puppeteerConfigFile with --no-sandbox).

## Test plan

- 8 focused tests added (no unittest.mock; uses tmp_path + fake mmdc script on PATH).
- Tests cover: missing binary, libnspr4 stderr needle, SIGSEGV needle, working mmdc, explicit-override bogus path.