### PR TITLE
test(_ports): NM+TQ002+TQ003+TQ007 cleanup

### DIFF
--- a/tests/scitex_writer/_ports/test_scholar.py
+++ b/tests/scitex_writer/_ports/test_scholar.py
@@ -30,51 +30,89 @@ def _write_metadata(root: Path, paper_id: str, **ids) -> None:
     (entry / "metadata.json").write_text(json.dumps(md))
 
 
-def test_library_root_returns_none_on_dangle(tmp_path: Path):
-    # No symlink, no library
-    assert scholar.scholar_library_root(tmp_path) is None
+def test_library_root_returns_none_when_no_symlink_present(tmp_path: Path):
+    """Verify scholar_library_root returns None when there's no symlink at all."""
+    # Arrange
+    # tmp_path has no symlink
+    # Act
+    result = scholar.scholar_library_root(tmp_path)
+    # Assert
+    assert result is None
 
 
-def test_library_root_resolves_valid_symlink(tmp_path: Path):
+def test_library_root_resolves_valid_symlink_target(tmp_path: Path):
+    """Verify scholar_library_root resolves a valid library symlink."""
+    # Arrange
     home_lib = tmp_path / "home"
     home_lib.mkdir()
     (home_lib / "MASTER").mkdir()
     link_parent = tmp_path / "proj" / "00_shared" / "scholar"
     link_parent.mkdir(parents=True)
     (link_parent / "library").symlink_to(home_lib)
+    # Act
     resolved = scholar.scholar_library_root(tmp_path / "proj")
+    # Assert
     assert resolved == home_lib.resolve()
 
 
-def test_library_root_dangling_symlink_returns_none(tmp_path: Path):
+def test_library_root_returns_none_for_dangling_symlink(tmp_path: Path):
+    """Verify a dangling library symlink yields None."""
+    # Arrange
     link_parent = tmp_path / "proj" / "00_shared" / "scholar"
     link_parent.mkdir(parents=True)
     (link_parent / "library").symlink_to(tmp_path / "does-not-exist")
-    assert scholar.scholar_library_root(tmp_path / "proj") is None
+    # Act
+    result = scholar.scholar_library_root(tmp_path / "proj")
+    # Assert
+    assert result is None
 
 
-def test_metadata_for_doi_via_master_scan(tmp_path: Path):
+def test_metadata_for_doi_returns_match_via_master_scan(tmp_path: Path):
+    """Verify metadata_for_doi locates an entry via MASTER scan (non-None)."""
+    # Arrange
     _write_metadata(tmp_path, "AAA", doi="10.1/aaa")
     _write_metadata(tmp_path, "BBB", doi="10.2/bbb")
-    md = scholar.metadata_for_doi(tmp_path, "10.1/AAA")  # case-insensitive
+    # Act
+    md = scholar.metadata_for_doi(tmp_path, "10.1/AAA")
+    # Assert
     assert md is not None
+
+
+def test_metadata_for_doi_paper_id_matches_master_scan(tmp_path: Path):
+    """Verify metadata_for_doi returns the correct paper id (case-insensitive)."""
+    # Arrange
+    _write_metadata(tmp_path, "AAA", doi="10.1/aaa")
+    _write_metadata(tmp_path, "BBB", doi="10.2/bbb")
+    # Act
+    md = scholar.metadata_for_doi(tmp_path, "10.1/AAA")
+    # Assert
     assert md["_paper_id"] == "AAA"
 
 
-def test_metadata_for_doi_none_when_missing(tmp_path: Path):
+def test_metadata_for_doi_returns_none_when_missing(tmp_path: Path):
+    """Verify metadata_for_doi returns None when DOI is not present."""
+    # Arrange
     _write_metadata(tmp_path, "AAA", doi="10.1/aaa")
-    assert scholar.metadata_for_doi(tmp_path, "10.99/nope") is None
+    # Act
+    result = scholar.metadata_for_doi(tmp_path, "10.99/nope")
+    # Assert
+    assert result is None
 
 
-def test_iter_library_cards_sorted_by_year_desc(tmp_path: Path):
+def test_iter_library_cards_returned_order_sorted_by_year_desc(tmp_path: Path):
+    """Verify iter_library_cards yields cards sorted by year descending."""
+    # Arrange
     _write_metadata(tmp_path, "OLD", doi="10.1/o", year=2010, title="old")
     _write_metadata(tmp_path, "NEW", doi="10.1/n", year=2025, title="new")
+    # Act
     cards = scholar.iter_library_cards(tmp_path)
+    # Assert
     assert [c["paper_id"] for c in cards] == ["NEW", "OLD"]
 
 
-def test_prefers_index_db_when_present(tmp_path: Path):
+def test_prefers_index_db_when_present_for_iter_library_cards(tmp_path: Path):
     """If index.db exists, iter_library_cards reads it directly."""
+    # Arrange
     import sqlite3
 
     _write_metadata(tmp_path, "AAA", doi="10.1/a", year=2024, title="alpha")
@@ -90,10 +128,17 @@ def test_prefers_index_db_when_present(tmp_path: Path):
     )
     conn.commit()
     conn.close()
-
+    # Act
     cards = scholar.iter_library_cards(tmp_path)
+    # Assert
     assert any(c["paper_id"] == "ZZZ" for c in cards)
 
 
-def test_scholar_available_flag_is_bool():
-    assert isinstance(scholar.SCHOLAR_AVAILABLE, bool)
+def test_scholar_available_flag_is_bool_type():
+    """Verify the SCHOLAR_AVAILABLE module flag is a bool."""
+    # Arrange
+    # constant defined at module level
+    # Act
+    flag = scholar.SCHOLAR_AVAILABLE
+    # Assert
+    assert isinstance(flag, bool)

--- a/tests/scitex_writer/_ports/test_scholar_cli.py
+++ b/tests/scitex_writer/_ports/test_scholar_cli.py
@@ -4,30 +4,84 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest import mock
+
+import pytest
 
 from scitex_writer._ports import scholar_cli
 
 
-def test_scholar_cli_on_path_checks_which_first():
-    with mock.patch.object(scholar_cli.shutil, "which", return_value="/usr/bin/stub"):
-        assert scholar_cli.scholar_cli_on_path() is True
+@pytest.fixture
+def stub_which():
+    """Replace shutil.which on the scholar_cli module; restore on teardown."""
+    original = scholar_cli.shutil.which
+    state = {"return": None}
+
+    def _which(_name):
+        return state["return"]
+
+    scholar_cli.shutil.which = _which
+    try:
+        yield state
+    finally:
+        scholar_cli.shutil.which = original
 
 
-def test_scholar_cli_falls_back_to_python_module():
-    with mock.patch.object(scholar_cli.shutil, "which", return_value=None):
-        # If scitex_scholar is importable, fallback succeeds
-        if scholar_cli._python_module_available():
-            assert scholar_cli.scholar_cli_on_path() is True
-        else:
-            assert scholar_cli.scholar_cli_on_path() is False
+@pytest.fixture
+def stub_python_module():
+    """Replace _python_module_available; restore on teardown."""
+    original = scholar_cli._python_module_available
+    state = {"return": False}
+
+    def _avail():
+        return state["return"]
+
+    scholar_cli._python_module_available = _avail
+    try:
+        yield state
+    finally:
+        scholar_cli._python_module_available = original
 
 
-def test_enrich_bib_when_no_cli_returns_install_message():
-    with (
-        mock.patch.object(scholar_cli.shutil, "which", return_value=None),
-        mock.patch.object(scholar_cli, "_python_module_available", return_value=False),
-    ):
-        ok, msg = scholar_cli.enrich_bib(Path("/tmp/x.bib"), "proj")
-        assert ok is False
-        assert "pip install" in msg
+def test_scholar_cli_on_path_returns_true_when_binary_present(stub_which):
+    """Verify scholar_cli_on_path returns True when which() finds the binary."""
+    # Arrange
+    stub_which["return"] = "/usr/bin/stub"
+    # Act
+    result = scholar_cli.scholar_cli_on_path()
+    # Assert
+    assert result is True
+
+
+def test_scholar_cli_on_path_falls_back_to_module_when_binary_missing(stub_which):
+    """Verify the python-module fallback decides the result when which() is None."""
+    # Arrange
+    stub_which["return"] = None
+    expected = scholar_cli._python_module_available()
+    # Act
+    result = scholar_cli.scholar_cli_on_path()
+    # Assert
+    assert result is expected
+
+
+def test_enrich_bib_returns_false_when_cli_unavailable(stub_which, stub_python_module):
+    """Verify enrich_bib returns ok=False when neither CLI nor module is available."""
+    # Arrange
+    stub_which["return"] = None
+    stub_python_module["return"] = False
+    # Act
+    ok, _msg = scholar_cli.enrich_bib(Path("/tmp/x.bib"), "proj")
+    # Assert
+    assert ok is False
+
+
+def test_enrich_bib_install_message_mentions_pip_install(
+    stub_which, stub_python_module
+):
+    """Verify enrich_bib install hint mentions 'pip install' when no CLI."""
+    # Arrange
+    stub_which["return"] = None
+    stub_python_module["return"] = False
+    # Act
+    _ok, msg = scholar_cli.enrich_bib(Path("/tmp/x.bib"), "proj")
+    # Assert
+    assert "pip install" in msg

--- a/tests/scitex_writer/_ports/test_thumbnails.py
+++ b/tests/scitex_writer/_ports/test_thumbnails.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import csv
+import sys
 from pathlib import Path
-from unittest import mock
 
 from PIL import Image
 
@@ -17,15 +17,21 @@ def _make_png(path: Path, size: tuple[int, int] = (800, 600)) -> None:
     img.save(path, format="PNG")
 
 
-def test_thumbnail_key_stable(tmp_path: Path):
+def test_thumbnail_key_is_stable_for_unchanged_file(tmp_path: Path):
+    """Verify thumbnail_key returns the same value for two calls without changes."""
+    # Arrange
     src = tmp_path / "a.png"
     _make_png(src)
+    # Act
     k1 = thumbnails.thumbnail_key(src)
     k2 = thumbnails.thumbnail_key(src)
+    # Assert
     assert k1 == k2
 
 
-def test_thumbnail_key_changes_on_mtime(tmp_path: Path):
+def test_thumbnail_key_changes_when_mtime_changes(tmp_path: Path):
+    """Verify thumbnail_key changes when the source mtime is bumped."""
+    # Arrange
     src = tmp_path / "a.png"
     _make_png(src)
     k1 = thumbnails.thumbnail_key(src)
@@ -34,98 +40,197 @@ def test_thumbnail_key_changes_on_mtime(tmp_path: Path):
 
     time.sleep(0.01)
     os.utime(src, None)  # bump mtime
+    # Act
     k2 = thumbnails.thumbnail_key(src)
+    # Assert
     assert k1 != k2
 
 
-def test_renders_png_image(tmp_path: Path):
+def test_ensure_thumbnail_writes_existing_png_file(tmp_path: Path):
+    """Verify ensure_thumbnail produces a thumbnail file for a PNG source."""
+    # Arrange
     src = tmp_path / "fig.png"
     _make_png(src, (800, 600))
+    # Act
     thumb = thumbnails.ensure_thumbnail(tmp_path, "figures", src)
-    assert thumb is not None
-    assert thumb.is_file()
+    # Assert
+    assert thumb is not None and thumb.is_file()
+
+
+def test_ensure_thumbnail_png_respects_max_edge(tmp_path: Path):
+    """Verify thumbnail size respects THUMB_EDGE bound for PNG source."""
+    # Arrange
+    src = tmp_path / "fig.png"
+    _make_png(src, (800, 600))
+    # Act
+    thumb = thumbnails.ensure_thumbnail(tmp_path, "figures", src)
+    # Assert
     with Image.open(thumb) as img:
         assert max(img.size) <= thumbnails.THUMB_EDGE
 
 
-def test_renders_csv_preview(tmp_path: Path):
+def test_ensure_thumbnail_csv_produces_file(tmp_path: Path):
+    """Verify ensure_thumbnail produces a thumbnail for a CSV source."""
+    # Arrange
     src = tmp_path / "data.csv"
     with src.open("w") as f:
         w = csv.writer(f)
         w.writerow(["cond", "mean", "sd", "n"])
         for i in range(10):
             w.writerow([f"g{i}", i * 1.5, i * 0.2, i])
+    # Act
     thumb = thumbnails.ensure_thumbnail(tmp_path, "tables", src)
+    # Assert
     assert thumb is not None and thumb.is_file()
-    assert thumb.stat().st_size > 1000  # real rendered PNG, not placeholder
 
 
-def test_cached_thumbnail_is_reused(tmp_path: Path):
+def test_ensure_thumbnail_csv_size_exceeds_one_kilobyte(tmp_path: Path):
+    """Verify CSV thumbnail is a real rendered PNG (not placeholder size)."""
+    # Arrange
+    src = tmp_path / "data.csv"
+    with src.open("w") as f:
+        w = csv.writer(f)
+        w.writerow(["cond", "mean", "sd", "n"])
+        for i in range(10):
+            w.writerow([f"g{i}", i * 1.5, i * 0.2, i])
+    # Act
+    thumb = thumbnails.ensure_thumbnail(tmp_path, "tables", src)
+    # Assert
+    assert thumb.stat().st_size > 1000
+
+
+def test_cached_thumbnail_path_is_reused_on_second_call(tmp_path: Path):
+    """Verify second call returns identical thumbnail path."""
+    # Arrange
     src = tmp_path / "a.png"
     _make_png(src)
     first = thumbnails.ensure_thumbnail(tmp_path, "figures", src)
-    assert first is not None
-    mtime_first = first.stat().st_mtime
-    # Call again — should hit cache, not re-render
+    # Act
     second = thumbnails.ensure_thumbnail(tmp_path, "figures", src)
+    # Assert
     assert second == first
+
+
+def test_cached_thumbnail_mtime_is_reused_on_second_call(tmp_path: Path):
+    """Verify second call does not rewrite the thumbnail file."""
+    # Arrange
+    src = tmp_path / "a.png"
+    _make_png(src)
+    first = thumbnails.ensure_thumbnail(tmp_path, "figures", src)
+    mtime_first = first.stat().st_mtime
+    # Act
+    second = thumbnails.ensure_thumbnail(tmp_path, "figures", src)
+    # Assert
     assert second.stat().st_mtime == mtime_first
 
 
-def test_find_media_for_stem_prefers_raster(tmp_path: Path):
+def test_find_media_for_stem_returns_match(tmp_path: Path):
+    """Verify find_media_for_stem returns a result when raster file is present."""
+    # Arrange
     (tmp_path / "fig.pdf").write_bytes(b"%PDF-stub")
     _make_png(tmp_path / "fig.png")
     (tmp_path / "fig.svg").write_text("<svg/>")
+    # Act
     match = thumbnails.find_media_for_stem(tmp_path, "fig")
+    # Assert
     assert match is not None
-    assert match.suffix == ".png"  # raster beats vector
 
 
-def test_find_media_walks_subdirs(tmp_path: Path):
+def test_find_media_for_stem_prefers_raster_extension(tmp_path: Path):
+    """Verify raster (.png) beats vector (.pdf/.svg) when both are present."""
+    # Arrange
+    (tmp_path / "fig.pdf").write_bytes(b"%PDF-stub")
+    _make_png(tmp_path / "fig.png")
+    (tmp_path / "fig.svg").write_text("<svg/>")
+    # Act
+    match = thumbnails.find_media_for_stem(tmp_path, "fig")
+    # Assert
+    assert match.suffix == ".png"
+
+
+def test_find_media_walks_into_subdirectories(tmp_path: Path):
+    """Verify find_media_for_stem locates files inside subdirectories."""
+    # Arrange
     sub = tmp_path / "jpg_for_compilation"
     sub.mkdir()
     _make_png(sub / "fig01.png")
+    # Act
     match = thumbnails.find_media_for_stem(tmp_path, "fig01")
-    assert match is not None
-    assert match.parent == sub
+    # Assert
+    assert match is not None and match.parent == sub
 
 
-def test_find_media_returns_none_when_missing(tmp_path: Path):
-    assert thumbnails.find_media_for_stem(tmp_path, "nope") is None
+def test_find_media_returns_none_when_no_match_found(tmp_path: Path):
+    """Verify find_media_for_stem returns None when nothing matches."""
+    # Arrange
+    # tmp_path is empty
+    # Act
+    result = thumbnails.find_media_for_stem(tmp_path, "nope")
+    # Assert
+    assert result is None
 
 
-def test_placeholder_rendered_for_unknown_format(tmp_path: Path):
+def test_placeholder_rendered_for_unknown_extension(tmp_path: Path):
+    """Verify placeholder thumbnail is generated for unknown extension."""
+    # Arrange
     src = tmp_path / "x.xyz"
     src.write_bytes(b"unknown binary")
+    # Act
     thumb = thumbnails.ensure_thumbnail(tmp_path, "figures", src)
-    # Unknown extensions aren't in IMAGE/VECTOR/DATA ext lists, so
-    # `_render_thumbnail` hits the placeholder branch.
+    # Assert
     assert thumb is not None and thumb.is_file()
+
+
+def test_placeholder_dimensions_use_thumb_edge_square(tmp_path: Path):
+    """Verify placeholder thumbnail uses THUMB_EDGE square dimensions."""
+    # Arrange
+    src = tmp_path / "x.xyz"
+    src.write_bytes(b"unknown binary")
+    # Act
+    thumb = thumbnails.ensure_thumbnail(tmp_path, "figures", src)
+    # Assert
     with Image.open(thumb) as img:
         assert img.size == (thumbnails.THUMB_EDGE, thumbnails.THUMB_EDGE)
 
 
-def test_pillow_failure_returns_none(tmp_path: Path):
+def test_pillow_failure_returns_none_for_corrupt_png(tmp_path: Path):
     """If Pillow raises on an image, ensure_thumbnail logs and returns None."""
+    # Arrange
     src = tmp_path / "broken.png"
     src.write_bytes(b"not actually a PNG")
-    # Pillow raises UnidentifiedImageError; our wrapper logs and returns None
+    # Act
     thumb = thumbnails.ensure_thumbnail(tmp_path, "figures", src)
+    # Assert
     assert thumb is None
 
 
 def test_missing_pandas_falls_back_to_placeholder(tmp_path: Path):
+    """If pandas is unavailable, ensure_thumbnail still produces a PNG."""
+    # Arrange
     src = tmp_path / "data.csv"
     src.write_text("a,b\n1,2\n")
-    # Simulate pandas not being installed by patching the import
-    with mock.patch.dict("sys.modules", {"pandas": None, "matplotlib": None}):
+    saved = {k: sys.modules.get(k) for k in ("pandas", "matplotlib")}
+    sys.modules["pandas"] = None
+    sys.modules["matplotlib"] = None
+    try:
+        # Act
         thumb = thumbnails.ensure_thumbnail(tmp_path, "tables", src)
-    # Fallback placeholder still generates a PNG
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+    # Assert
     assert thumb is not None and thumb.is_file()
 
 
-def test_thumbnail_cache_dir_created(tmp_path: Path):
+def test_thumbnail_cache_directory_is_created(tmp_path: Path):
+    """Verify the thumbnail cache directory is created when needed."""
+    # Arrange
     src = tmp_path / "a.png"
     _make_png(src)
+    # Act
     thumbnails.ensure_thumbnail(tmp_path, "figures", src)
+    # Assert
     assert (tmp_path / "00_shared" / "thumbnails" / "figures").is_dir()

--- a/tests/scitex_writer/_ports/test_workspace.py
+++ b/tests/scitex_writer/_ports/test_workspace.py
@@ -8,35 +8,102 @@ from pathlib import Path
 from scitex_writer._ports.workspace import ensure_scholar_library_link
 
 
-def test_creates_symlink(tmp_path: Path):
+def test_creates_symlink_returns_non_none_path(tmp_path: Path):
+    """Verify ensure_scholar_library_link returns a non-None path."""
+    # Arrange
+    # tmp_path provided by fixture
+    # Act
     link = ensure_scholar_library_link(tmp_path)
+    # Assert
     assert link is not None
+
+
+def test_creates_symlink_path_is_symlink(tmp_path: Path):
+    """Verify returned link is a symlink."""
+    # Arrange
+    # tmp_path provided by fixture
+    # Act
+    link = ensure_scholar_library_link(tmp_path)
+    # Assert
     assert link.is_symlink()
+
+
+def test_creates_symlink_path_uses_canonical_location(tmp_path: Path):
+    """Verify symlink is created at <root>/00_shared/scholar/library."""
+    # Arrange
+    # tmp_path provided by fixture
+    # Act
+    link = ensure_scholar_library_link(tmp_path)
+    # Assert
     assert link == tmp_path / "00_shared" / "scholar" / "library"
+
+
+def test_creates_symlink_targets_user_scitex_scholar_library(tmp_path: Path):
+    """Verify symlink target resolves to ~/.scitex/scholar/library."""
+    # Arrange
+    # tmp_path provided by fixture
+    # Act
+    link = ensure_scholar_library_link(tmp_path)
+    # Assert
     assert link.readlink() == Path("~/.scitex/scholar/library").expanduser()
 
 
-def test_idempotent(tmp_path: Path):
+def test_idempotent_returns_same_path_for_repeated_calls(tmp_path: Path):
+    """Verify ensure_scholar_library_link is idempotent."""
+    # Arrange
     first = ensure_scholar_library_link(tmp_path)
+    # Act
     second = ensure_scholar_library_link(tmp_path)
+    # Assert
     assert first == second
 
 
-def test_refuses_to_replace_real_directory(tmp_path: Path):
+def test_refuses_to_replace_real_directory_returns_none(tmp_path: Path):
+    """Verify None is returned when a real directory occupies the link path."""
+    # Arrange
     (tmp_path / "00_shared" / "scholar" / "library").mkdir(parents=True)
     (tmp_path / "00_shared" / "scholar" / "library" / "sentinel").write_text("x")
+    # Act
     link = ensure_scholar_library_link(tmp_path)
+    # Assert
     assert link is None
-    assert (tmp_path / "00_shared" / "scholar" / "library" / "sentinel").exists()
 
 
-def test_replaces_stale_symlink(tmp_path: Path):
+def test_refuses_to_replace_real_directory_preserves_contents(tmp_path: Path):
+    """Verify pre-existing files inside the real directory are kept intact."""
+    # Arrange
+    (tmp_path / "00_shared" / "scholar" / "library").mkdir(parents=True)
+    sentinel = tmp_path / "00_shared" / "scholar" / "library" / "sentinel"
+    sentinel.write_text("x")
+    # Act
+    ensure_scholar_library_link(tmp_path)
+    # Assert
+    assert sentinel.exists()
+
+
+def test_replaces_stale_symlink_returns_non_none(tmp_path: Path):
+    """Verify a stale symlink is replaced and a new link path is returned."""
+    # Arrange
     other = tmp_path / "other"
     other.mkdir()
     scholar_dir = tmp_path / "00_shared" / "scholar"
     scholar_dir.mkdir(parents=True)
     (scholar_dir / "library").symlink_to(other)
-
+    # Act
     link = ensure_scholar_library_link(tmp_path)
+    # Assert
     assert link is not None
+
+
+def test_replaces_stale_symlink_uses_canonical_target(tmp_path: Path):
+    """Verify replacement symlink points to ~/.scitex/scholar/library."""
+    # Arrange
+    other = tmp_path / "other"
+    other.mkdir()
+    scholar_dir = tmp_path / "00_shared" / "scholar"
+    scholar_dir.mkdir(parents=True)
+    (scholar_dir / "library").symlink_to(other)
+    # Act
+    link = ensure_scholar_library_link(tmp_path)
+    # Assert
     assert link.readlink() == Path("~/.scitex/scholar/library").expanduser()


### PR DESCRIPTION
Part of broader campaign-scitex-writer audit cleanup. Module _ports: 43 PA-306/307 violations cleared (NM+TQ002+TQ003+TQ007). Targeted pytest: 22 passed (PIL-dependent thumbnail tests rewritten; will be exercised on CI which has PIL).