### PR TITLE
refactor(_compile/tests): NM real-collaborator rewrite + TQ003/002/007

### DIFF
--- a/src/scitex_writer/_compile/_runner.py
+++ b/src/scitex_writer/_compile/_runner.py
@@ -276,6 +276,11 @@ def run_compile(
     force: bool = False,
     log_callback: Optional[Callable[[str], None]] = None,
     progress_callback: Optional[Callable[[int, str], None]] = None,
+    *,
+    runner_fn: Optional[Callable[..., dict]] = None,
+    validator_fn: Optional[Callable[[Path], None]] = None,
+    output_finder_fn: Optional[Callable[[Path, str], tuple]] = None,
+    script_resolver_fn: Optional[Callable[[Path, str], Path]] = None,
 ) -> CompilationResult:
     """
     Run compilation script and parse results with optional callbacks.
@@ -315,6 +320,16 @@ def run_compile(
     start_time = datetime.now()
     project_dir = Path(project_dir).absolute()
 
+    # Resolve injectable collaborators (default to real implementations)
+    _runner = runner_fn if runner_fn is not None else _run_sh_command
+    _validator = validator_fn if validator_fn is not None else validate_before_compile
+    _find_outputs = (
+        output_finder_fn if output_finder_fn is not None else _find_output_files
+    )
+    _resolve_script = (
+        script_resolver_fn if script_resolver_fn is not None else _get_compile_script
+    )
+
     # Helper for progress tracking
     def progress(percent: int, step: str):
         if progress_callback:
@@ -334,7 +349,7 @@ def run_compile(
     # Validate project structure before compilation
     try:
         progress(5, "Validating project structure...")
-        validate_before_compile(project_dir)
+        _validator(project_dir)
         log("[INFO] Project structure validated")
     except Exception as e:
         error_msg = f"[ERROR] Validation failed: {e}"
@@ -348,7 +363,7 @@ def run_compile(
         )
 
     # Get compile script
-    compile_script = _get_compile_script(project_dir, doc_type)
+    compile_script = _resolve_script(project_dir, doc_type)
     if not compile_script or not compile_script.exists():
         error_msg = f"[ERROR] Compilation script not found: {compile_script}"
         log(error_msg)
@@ -404,8 +419,8 @@ def run_compile(
         try:
             progress(15, "Executing LaTeX compilation...")
 
-            # Use callbacks version if callbacks provided
-            if log_callback:
+            # Use callbacks version if callbacks provided (and no custom runner injected)
+            if log_callback and runner_fn is None:
                 result_dict = _execute_with_callbacks(
                     command=cmd,
                     cwd=project_dir,
@@ -413,8 +428,8 @@ def run_compile(
                     log_callback=log_callback,
                 )
             else:
-                # Use simple subprocess execution
-                result_dict = _run_sh_command(
+                # Use simple subprocess execution (or injected runner)
+                result_dict = _runner(
                     cmd,
                     verbose=True,
                     timeout=timeout,
@@ -439,7 +454,7 @@ def run_compile(
         if result.returncode == 0:
             progress(90, "Compilation successful, locating output files...")
             log("[INFO] Compilation succeeded, checking output files...")
-            output_pdf, diff_pdf, log_file = _find_output_files(project_dir, doc_type)
+            output_pdf, diff_pdf, log_file = _find_outputs(project_dir, doc_type)
             if output_pdf:
                 log(f"[SUCCESS] PDF generated: {output_pdf}")
         else:

--- a/src/scitex_writer/_compile/manuscript.py
+++ b/src/scitex_writer/_compile/manuscript.py
@@ -33,6 +33,11 @@ def compile_manuscript(
     force: bool = False,
     log_callback: Optional[Callable[[str], None]] = None,
     progress_callback: Optional[Callable[[int, str], None]] = None,
+    *,
+    runner_fn: Optional[Callable[..., dict]] = None,
+    validator_fn: Optional[Callable[[Path], None]] = None,
+    output_finder_fn: Optional[Callable[[Path, str], tuple]] = None,
+    script_resolver_fn: Optional[Callable[[Path, str], Path]] = None,
 ) -> CompilationResult:
     """
     Compile manuscript document with optional callbacks.
@@ -97,6 +102,10 @@ def compile_manuscript(
         force=force,
         log_callback=log_callback,
         progress_callback=progress_callback,
+        runner_fn=runner_fn,
+        validator_fn=validator_fn,
+        output_finder_fn=output_finder_fn,
+        script_resolver_fn=script_resolver_fn,
     )
 
 

--- a/src/scitex_writer/_compile/revision.py
+++ b/src/scitex_writer/_compile/revision.py
@@ -24,6 +24,11 @@ def compile_revision(
     timeout: int = 300,
     log_callback: Optional[Callable[[str], None]] = None,
     progress_callback: Optional[Callable[[int, str], None]] = None,
+    *,
+    runner_fn: Optional[Callable[..., dict]] = None,
+    validator_fn: Optional[Callable[[Path], None]] = None,
+    output_finder_fn: Optional[Callable[[Path, str], tuple]] = None,
+    script_resolver_fn: Optional[Callable[[Path, str], Path]] = None,
 ) -> CompilationResult:
     """
     Compile revision responses with optional callbacks.
@@ -69,6 +74,10 @@ def compile_revision(
         track_changes=track_changes,
         log_callback=log_callback,
         progress_callback=progress_callback,
+        runner_fn=runner_fn,
+        validator_fn=validator_fn,
+        output_finder_fn=output_finder_fn,
+        script_resolver_fn=script_resolver_fn,
     )
 
 

--- a/src/scitex_writer/_compile/supplementary.py
+++ b/src/scitex_writer/_compile/supplementary.py
@@ -30,6 +30,11 @@ def compile_supplementary(
     quiet: bool = False,
     log_callback: Optional[Callable[[str], None]] = None,
     progress_callback: Optional[Callable[[int, str], None]] = None,
+    *,
+    runner_fn: Optional[Callable[..., dict]] = None,
+    validator_fn: Optional[Callable[[Path], None]] = None,
+    output_finder_fn: Optional[Callable[[Path, str], tuple]] = None,
+    script_resolver_fn: Optional[Callable[[Path, str], Path]] = None,
 ) -> CompilationResult:
     """
     Compile supplementary materials with optional callbacks.
@@ -87,6 +92,10 @@ def compile_supplementary(
         quiet=quiet,
         log_callback=log_callback,
         progress_callback=progress_callback,
+        runner_fn=runner_fn,
+        validator_fn=validator_fn,
+        output_finder_fn=output_finder_fn,
+        script_resolver_fn=script_resolver_fn,
     )
 
 

--- a/tests/scitex_writer/_compile/test__runner.py
+++ b/tests/scitex_writer/_compile/test__runner.py
@@ -4,318 +4,573 @@
 Tests for compilation script runner.
 
 Tests run_compile function with various options and document types.
+
+NM-rewrite (2026-06-13): replaced unittest.mock.patch with injected real fakes
+that record the command passed to the runner. The fakes are plain Python
+functions, not Mocks — they expose observable side-effects (recorded calls)
+that the tests then assert on, matching the no-mocks doctrine.
 """
+
+from pathlib import Path
 
 import pytest
 
 pytest.importorskip("git")
-from pathlib import Path
-from unittest.mock import patch
 
-from scitex_writer._compile._runner import _get_compile_script, run_compile
+from scitex_writer._compile._runner import (
+    _find_output_files,
+    _get_compile_script,
+    run_compile,
+)
+
+# ---------------------------------------------------------------------------
+# Real recording fakes (drop-in replacements for the mocked collaborators).
+# ---------------------------------------------------------------------------
+
+
+class _RecordingRunner:
+    """Real fake for the shell-command runner.
+
+    Records the command list it was invoked with and returns a fixed
+    success result so run_compile can complete without spawning a real
+    subprocess. Not a Mock — just a plain class with a __call__ method.
+    """
+
+    def __init__(self, exit_code: int = 0, stdout: str = "", stderr: str = ""):
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, *args, **kwargs):
+        self.calls.append(list(cmd))
+        return {
+            "exit_code": self.exit_code,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "success": self.exit_code == 0,
+        }
+
+
+def _noop_validator(project_dir: Path) -> None:
+    """Real fake for validator: accepts any project dir without checking."""
+    return None
+
+
+def _empty_output_finder(project_dir: Path, doc_type: str):
+    """Real fake for output finder: pretends no output was produced."""
+    return (None, None, None)
+
+
+def _make_script_resolver(script_path: Path):
+    """Build a real script-resolver that returns a path that exists."""
+
+    def _resolver(project_dir: Path, doc_type: str) -> Path:
+        return script_path
+
+    return _resolver
+
+
+def _setup_existing_script(tmp_path: Path, doc_type: str) -> Path:
+    """Write a real (empty, executable-bit not required) script file on disk."""
+    script_dir = tmp_path / "scripts" / "shell"
+    script_dir.mkdir(parents=True, exist_ok=True)
+    script = script_dir / f"compile_{doc_type}.sh"
+    script.write_text("#!/bin/sh\nexit 0\n")
+    return script
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
 
 
 class TestGetCompileScript:
     """Test suite for _get_compile_script helper function."""
 
-    def test_manuscript_script_path(self):
-        """Test manuscript script path generation."""
+    def test_manuscript_script_path_under_scripts_shell(self):
+        # Arrange
         project_dir = Path("/tmp/test-project")
+        expected = project_dir / "scripts" / "shell" / "compile_manuscript.sh"
+        # Act
         script = _get_compile_script(project_dir, "manuscript")
-        assert script == project_dir / "scripts" / "shell" / "compile_manuscript.sh"
+        # Assert
+        assert script == expected
 
-    def test_supplementary_script_path(self):
-        """Test supplementary script path generation."""
+    def test_supplementary_script_path_under_scripts_shell(self):
+        # Arrange
         project_dir = Path("/tmp/test-project")
+        expected = project_dir / "scripts" / "shell" / "compile_supplementary.sh"
+        # Act
         script = _get_compile_script(project_dir, "supplementary")
-        assert script == project_dir / "scripts" / "shell" / "compile_supplementary.sh"
+        # Assert
+        assert script == expected
 
-    def test_revision_script_path(self):
-        """Test revision script path generation."""
+    def test_revision_script_path_under_scripts_shell(self):
+        # Arrange
         project_dir = Path("/tmp/test-project")
+        expected = project_dir / "scripts" / "shell" / "compile_revision.sh"
+        # Act
         script = _get_compile_script(project_dir, "revision")
-        assert script == project_dir / "scripts" / "shell" / "compile_revision.sh"
+        # Assert
+        assert script == expected
 
 
-class TestRunCompile:
-    """Test suite for run_compile function."""
+class TestRunCompileSignature:
+    """Signature/contract tests for run_compile.
 
-    def test_signature(self):
-        """Test function signature has expected parameters."""
+    Each test asserts ONE observable contract attribute.
+    """
+
+    def test_signature_includes_doc_type_parameter(self):
+        # Arrange
         import inspect
 
-        sig = inspect.signature(run_compile)
-        params = list(sig.parameters.keys())
-
+        # Act
+        params = list(inspect.signature(run_compile).parameters.keys())
+        # Assert
         assert "doc_type" in params
+
+    def test_signature_includes_project_dir_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(run_compile).parameters.keys())
+        # Assert
         assert "project_dir" in params
+
+    def test_signature_includes_timeout_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(run_compile).parameters.keys())
+        # Assert
         assert "timeout" in params
+
+    def test_signature_includes_track_changes_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(run_compile).parameters.keys())
+        # Assert
         assert "track_changes" in params
+
+    def test_signature_includes_no_figs_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(run_compile).parameters.keys())
+        # Assert
         assert "no_figs" in params
+
+    def test_signature_includes_ppt2tif_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(run_compile).parameters.keys())
+        # Assert
         assert "ppt2tif" in params
+
+    def test_signature_includes_crop_tif_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(run_compile).parameters.keys())
+        # Assert
         assert "crop_tif" in params
+
+    def test_signature_includes_quiet_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(run_compile).parameters.keys())
+        # Assert
         assert "quiet" in params
+
+    def test_signature_includes_verbose_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(run_compile).parameters.keys())
+        # Assert
         assert "verbose" in params
+
+    def test_signature_includes_force_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(run_compile).parameters.keys())
+        # Assert
         assert "force" in params
+
+    def test_signature_includes_log_callback_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(run_compile).parameters.keys())
+        # Assert
         assert "log_callback" in params
+
+    def test_signature_includes_progress_callback_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(run_compile).parameters.keys())
+        # Assert
         assert "progress_callback" in params
 
-    def test_default_parameters(self):
-        """Test default parameter values."""
+
+class TestRunCompileDefaults:
+    """Default-value contract tests for run_compile."""
+
+    def test_default_timeout_is_300_seconds(self):
+        # Arrange
         import inspect
 
-        sig = inspect.signature(run_compile)
+        # Act
+        default = inspect.signature(run_compile).parameters["timeout"].default
+        # Assert
+        assert default == 300
 
-        assert sig.parameters["timeout"].default == 300
-        assert sig.parameters["track_changes"].default is False
-        assert sig.parameters["no_figs"].default is False
-        assert sig.parameters["ppt2tif"].default is False
-        assert sig.parameters["crop_tif"].default is False
-        assert sig.parameters["quiet"].default is False
-        assert sig.parameters["verbose"].default is False
-        assert sig.parameters["force"].default is False
-        assert sig.parameters["log_callback"].default is None
-        assert sig.parameters["progress_callback"].default is None
+    def test_default_track_changes_is_false(self):
+        # Arrange
+        import inspect
 
-    @patch("scitex_writer._compile._runner.validate_before_compile")
-    @patch("scitex_writer._compile._runner._get_compile_script")
-    @patch("scitex_writer._compile._runner._run_sh_command")
-    @patch("scitex_writer._compile._runner._find_output_files")
-    @patch("scitex_writer._compile._runner.parse_output")
-    def test_manuscript_with_no_figs_option(
-        self,
-        mock_parse,
-        mock_find_files,
-        mock_run_sh,
-        mock_get_script,
-        mock_validate,
-    ):
-        """Test manuscript compilation with no_figs option."""
-        project_dir = Path("/tmp/test-project")
-        script_path = project_dir / "scripts" / "shell" / "compile_manuscript.sh"
+        # Act
+        default = inspect.signature(run_compile).parameters["track_changes"].default
+        # Assert
+        assert default is False
 
-        mock_get_script.return_value = script_path
-        mock_find_files.return_value = (None, None, None)
-        mock_parse.return_value = ([], [])
-        mock_run_sh.return_value = {
-            "exit_code": 0,
-            "stdout": "",
-            "stderr": "",
-        }
+    def test_default_no_figs_is_false(self):
+        # Arrange
+        import inspect
 
-        with patch("pathlib.Path.exists", return_value=True):
-            with patch("os.chdir"):
-                with patch("pathlib.Path.cwd", return_value=project_dir):
-                    run_compile(
-                        "manuscript",
-                        project_dir,
-                        no_figs=True,
-                    )
+        # Act
+        default = inspect.signature(run_compile).parameters["no_figs"].default
+        # Assert
+        assert default is False
 
-        # Verify _run_sh_command was called with correct command
-        mock_run_sh.assert_called_once()
-        call_args = mock_run_sh.call_args[0][0]
-        assert str(script_path) in call_args
-        assert "--no_figs" in call_args
+    def test_default_ppt2tif_is_false(self):
+        # Arrange
+        import inspect
 
-    @patch("scitex_writer._compile._runner.validate_before_compile")
-    @patch("scitex_writer._compile._runner._get_compile_script")
-    @patch("scitex_writer._compile._runner._run_sh_command")
-    @patch("scitex_writer._compile._runner._find_output_files")
-    @patch("scitex_writer._compile._runner.parse_output")
-    def test_manuscript_with_multiple_options(
-        self,
-        mock_parse,
-        mock_find_files,
-        mock_run_sh,
-        mock_get_script,
-        mock_validate,
-    ):
-        """Test manuscript compilation with multiple options."""
-        project_dir = Path("/tmp/test-project")
-        script_path = project_dir / "scripts" / "shell" / "compile_manuscript.sh"
+        # Act
+        default = inspect.signature(run_compile).parameters["ppt2tif"].default
+        # Assert
+        assert default is False
 
-        mock_get_script.return_value = script_path
-        mock_find_files.return_value = (None, None, None)
-        mock_parse.return_value = ([], [])
-        mock_run_sh.return_value = {
-            "exit_code": 0,
-            "stdout": "",
-            "stderr": "",
-        }
+    def test_default_crop_tif_is_false(self):
+        # Arrange
+        import inspect
 
-        with patch("pathlib.Path.exists", return_value=True):
-            with patch("os.chdir"):
-                with patch("pathlib.Path.cwd", return_value=project_dir):
-                    run_compile(
-                        "manuscript",
-                        project_dir,
-                        no_figs=True,
-                        ppt2tif=True,
-                        crop_tif=True,
-                        verbose=True,
-                        force=True,
-                    )
+        # Act
+        default = inspect.signature(run_compile).parameters["crop_tif"].default
+        # Assert
+        assert default is False
 
-        # Verify _run_sh_command was called with all options
-        call_args = mock_run_sh.call_args[0][0]
-        assert "--no_figs" in call_args
-        assert "--ppt2tif" in call_args
-        assert "--crop_tif" in call_args
-        assert "--verbose" in call_args
-        assert "--force" in call_args
+    def test_default_quiet_is_false(self):
+        # Arrange
+        import inspect
 
-    @patch("scitex_writer._compile._runner.validate_before_compile")
-    @patch("scitex_writer._compile._runner._get_compile_script")
-    @patch("scitex_writer._compile._runner._run_sh_command")
-    @patch("scitex_writer._compile._runner._find_output_files")
-    @patch("scitex_writer._compile._runner.parse_output")
-    def test_supplementary_with_figs_option(
-        self,
-        mock_parse,
-        mock_find_files,
-        mock_run_sh,
-        mock_get_script,
-        mock_validate,
-    ):
-        """Test supplementary compilation with figs option."""
-        project_dir = Path("/tmp/test-project")
-        script_path = project_dir / "scripts" / "shell" / "compile_supplementary.sh"
+        # Act
+        default = inspect.signature(run_compile).parameters["quiet"].default
+        # Assert
+        assert default is False
 
-        mock_get_script.return_value = script_path
-        mock_find_files.return_value = (None, None, None)
-        mock_parse.return_value = ([], [])
-        mock_run_sh.return_value = {
-            "exit_code": 0,
-            "stdout": "",
-            "stderr": "",
-        }
+    def test_default_verbose_is_false(self):
+        # Arrange
+        import inspect
 
-        with patch("pathlib.Path.exists", return_value=True):
-            with patch("os.chdir"):
-                with patch("pathlib.Path.cwd", return_value=project_dir):
-                    run_compile(
-                        "supplementary",
-                        project_dir,
-                        no_figs=False,  # Include figures
-                    )
+        # Act
+        default = inspect.signature(run_compile).parameters["verbose"].default
+        # Assert
+        assert default is False
 
-        # Verify _run_sh_command was called with --figs option
-        call_args = mock_run_sh.call_args[0][0]
-        assert "--figs" in call_args
+    def test_default_force_is_false(self):
+        # Arrange
+        import inspect
 
-    @patch("scitex_writer._compile._runner.validate_before_compile")
-    @patch("scitex_writer._compile._runner._get_compile_script")
-    @patch("scitex_writer._compile._runner._run_sh_command")
-    @patch("scitex_writer._compile._runner._find_output_files")
-    @patch("scitex_writer._compile._runner.parse_output")
-    def test_revision_with_track_changes(
-        self,
-        mock_parse,
-        mock_find_files,
-        mock_run_sh,
-        mock_get_script,
-        mock_validate,
-    ):
-        """Test revision compilation with track_changes option."""
-        project_dir = Path("/tmp/test-project")
-        script_path = project_dir / "scripts" / "shell" / "compile_revision.sh"
+        # Act
+        default = inspect.signature(run_compile).parameters["force"].default
+        # Assert
+        assert default is False
 
-        mock_get_script.return_value = script_path
-        mock_find_files.return_value = (None, None, None)
-        mock_parse.return_value = ([], [])
-        mock_run_sh.return_value = {
-            "exit_code": 0,
-            "stdout": "",
-            "stderr": "",
-        }
+    def test_default_log_callback_is_none(self):
+        # Arrange
+        import inspect
 
-        with patch("pathlib.Path.exists", return_value=True):
-            with patch("os.chdir"):
-                with patch("pathlib.Path.cwd", return_value=project_dir):
-                    run_compile(
-                        "revision",
-                        project_dir,
-                        track_changes=True,
-                    )
+        # Act
+        default = inspect.signature(run_compile).parameters["log_callback"].default
+        # Assert
+        assert default is None
 
-        # Verify _run_sh_command was called with --track-changes option
-        call_args = mock_run_sh.call_args[0][0]
-        assert "--track-changes" in call_args
+    def test_default_progress_callback_is_none(self):
+        # Arrange
+        import inspect
+
+        # Act
+        default = inspect.signature(run_compile).parameters["progress_callback"].default
+        # Assert
+        assert default is None
+
+
+class TestRunCompileCommandConstruction:
+    """Run run_compile with real injected fakes and assert on the
+    command list it constructed."""
+
+    def test_manuscript_no_figs_appends_no_figs_flag(self, tmp_path):
+        # Arrange
+        script = _setup_existing_script(tmp_path, "manuscript")
+        runner = _RecordingRunner()
+        # Act
+        run_compile(
+            "manuscript",
+            tmp_path,
+            no_figs=True,
+            runner_fn=runner,
+            validator_fn=_noop_validator,
+            output_finder_fn=_empty_output_finder,
+            script_resolver_fn=_make_script_resolver(script),
+        )
+        # Assert
+        assert "--no_figs" in runner.calls[0]
+
+    def test_manuscript_records_script_path_in_command(self, tmp_path):
+        # Arrange
+        script = _setup_existing_script(tmp_path, "manuscript")
+        runner = _RecordingRunner()
+        # Act
+        run_compile(
+            "manuscript",
+            tmp_path,
+            no_figs=True,
+            runner_fn=runner,
+            validator_fn=_noop_validator,
+            output_finder_fn=_empty_output_finder,
+            script_resolver_fn=_make_script_resolver(script),
+        )
+        # Assert
+        assert str(script.absolute()) in runner.calls[0]
+
+    def test_manuscript_runner_invoked_exactly_once(self, tmp_path):
+        # Arrange
+        script = _setup_existing_script(tmp_path, "manuscript")
+        runner = _RecordingRunner()
+        # Act
+        run_compile(
+            "manuscript",
+            tmp_path,
+            no_figs=True,
+            runner_fn=runner,
+            validator_fn=_noop_validator,
+            output_finder_fn=_empty_output_finder,
+            script_resolver_fn=_make_script_resolver(script),
+        )
+        # Assert
+        assert len(runner.calls) == 1
+
+    def test_manuscript_with_ppt2tif_includes_flag(self, tmp_path):
+        # Arrange
+        script = _setup_existing_script(tmp_path, "manuscript")
+        runner = _RecordingRunner()
+        # Act
+        run_compile(
+            "manuscript",
+            tmp_path,
+            ppt2tif=True,
+            runner_fn=runner,
+            validator_fn=_noop_validator,
+            output_finder_fn=_empty_output_finder,
+            script_resolver_fn=_make_script_resolver(script),
+        )
+        # Assert
+        assert "--ppt2tif" in runner.calls[0]
+
+    def test_manuscript_with_crop_tif_includes_flag(self, tmp_path):
+        # Arrange
+        script = _setup_existing_script(tmp_path, "manuscript")
+        runner = _RecordingRunner()
+        # Act
+        run_compile(
+            "manuscript",
+            tmp_path,
+            crop_tif=True,
+            runner_fn=runner,
+            validator_fn=_noop_validator,
+            output_finder_fn=_empty_output_finder,
+            script_resolver_fn=_make_script_resolver(script),
+        )
+        # Assert
+        assert "--crop_tif" in runner.calls[0]
+
+    def test_manuscript_with_verbose_includes_flag(self, tmp_path):
+        # Arrange
+        script = _setup_existing_script(tmp_path, "manuscript")
+        runner = _RecordingRunner()
+        # Act
+        run_compile(
+            "manuscript",
+            tmp_path,
+            verbose=True,
+            runner_fn=runner,
+            validator_fn=_noop_validator,
+            output_finder_fn=_empty_output_finder,
+            script_resolver_fn=_make_script_resolver(script),
+        )
+        # Assert
+        assert "--verbose" in runner.calls[0]
+
+    def test_manuscript_with_force_includes_flag(self, tmp_path):
+        # Arrange
+        script = _setup_existing_script(tmp_path, "manuscript")
+        runner = _RecordingRunner()
+        # Act
+        run_compile(
+            "manuscript",
+            tmp_path,
+            force=True,
+            runner_fn=runner,
+            validator_fn=_noop_validator,
+            output_finder_fn=_empty_output_finder,
+            script_resolver_fn=_make_script_resolver(script),
+        )
+        # Assert
+        assert "--force" in runner.calls[0]
+
+    def test_supplementary_with_figures_uses_figs_flag(self, tmp_path):
+        # Arrange
+        script = _setup_existing_script(tmp_path, "supplementary")
+        runner = _RecordingRunner()
+        # Act
+        run_compile(
+            "supplementary",
+            tmp_path,
+            no_figs=False,
+            runner_fn=runner,
+            validator_fn=_noop_validator,
+            output_finder_fn=_empty_output_finder,
+            script_resolver_fn=_make_script_resolver(script),
+        )
+        # Assert
+        assert "--figs" in runner.calls[0]
+
+    def test_revision_with_track_changes_includes_flag(self, tmp_path):
+        # Arrange
+        script = _setup_existing_script(tmp_path, "revision")
+        runner = _RecordingRunner()
+        # Act
+        run_compile(
+            "revision",
+            tmp_path,
+            track_changes=True,
+            runner_fn=runner,
+            validator_fn=_noop_validator,
+            output_finder_fn=_empty_output_finder,
+            script_resolver_fn=_make_script_resolver(script),
+        )
+        # Assert
+        assert "--track-changes" in runner.calls[0]
 
 
 class TestFindOutputFiles:
-    """Test _find_output_files does not produce false positives (issue #76)."""
+    """Test _find_output_files does not produce false positives (issue #76).
 
-    def test_returns_none_when_no_pdf_exists(self, tmp_path):
-        """When no PDF exists, returns None for output_pdf."""
-        from scitex_writer._compile._runner import _find_output_files
+    Uses real tmp_path with real files; no mocks required.
+    """
 
-        # Create minimal project dir structure
+    def test_returns_none_for_output_pdf_when_no_pdf_exists(self, tmp_path):
+        # Arrange
         doc_dir = tmp_path / "01_manuscript"
         doc_dir.mkdir()
-
-        output_pdf, diff_pdf, log_file = _find_output_files(tmp_path, "manuscript")
+        # Act
+        output_pdf, _, _ = _find_output_files(tmp_path, "manuscript")
+        # Assert
         assert output_pdf is None
+
+    def test_returns_none_for_diff_pdf_when_no_diff_exists(self, tmp_path):
+        # Arrange
+        doc_dir = tmp_path / "01_manuscript"
+        doc_dir.mkdir()
+        # Act
+        _, diff_pdf, _ = _find_output_files(tmp_path, "manuscript")
+        # Assert
         assert diff_pdf is None
 
-    def test_finds_existing_pdf(self, tmp_path):
-        """When PDF exists, returns its path."""
-        from scitex_writer._compile._runner import _find_output_files
-
+    def test_finds_existing_manuscript_pdf_file(self, tmp_path):
+        # Arrange
         doc_dir = tmp_path / "01_manuscript"
         doc_dir.mkdir()
         pdf = doc_dir / "manuscript.pdf"
         pdf.write_bytes(b"%PDF-1.4 test")
-
-        output_pdf, diff_pdf, log_file = _find_output_files(tmp_path, "manuscript")
+        # Act
+        output_pdf, _, _ = _find_output_files(tmp_path, "manuscript")
+        # Assert
         assert output_pdf == pdf
 
-    def test_finds_diff_pdf_separately(self, tmp_path):
-        """Diff PDF is found independently of main PDF."""
-        from scitex_writer._compile._runner import _find_output_files
-
+    def test_finds_diff_pdf_when_only_diff_exists(self, tmp_path):
+        # Arrange
         doc_dir = tmp_path / "01_manuscript"
         doc_dir.mkdir()
         diff = doc_dir / "manuscript_diff.pdf"
         diff.write_bytes(b"%PDF-1.4 diff")
-
-        output_pdf, diff_pdf, log_file = _find_output_files(tmp_path, "manuscript")
-        assert output_pdf is None
+        # Act
+        _, diff_pdf, _ = _find_output_files(tmp_path, "manuscript")
+        # Assert
         assert diff_pdf == diff
 
-    def test_stale_pdf_detected_by_caller_exit_code(self, tmp_path):
+    def test_main_pdf_is_none_when_only_diff_pdf_exists(self, tmp_path):
+        # Arrange
+        doc_dir = tmp_path / "01_manuscript"
+        doc_dir.mkdir()
+        diff = doc_dir / "manuscript_diff.pdf"
+        diff.write_bytes(b"%PDF-1.4 diff")
+        # Act
+        output_pdf, _, _ = _find_output_files(tmp_path, "manuscript")
+        # Assert
+        assert output_pdf is None
+
+    def test_stale_pdf_returned_when_file_still_present(self, tmp_path):
         """Caller must check exit code — stale PDF alone is not proof of success.
 
         This verifies the contract: _find_output_files only checks existence,
         so the caller (run_compile) must gate on subprocess exit code first.
         """
-        from scitex_writer._compile._runner import _find_output_files
-
+        # Arrange
         doc_dir = tmp_path / "01_manuscript"
         doc_dir.mkdir()
-        # Stale PDF from previous build
         stale = doc_dir / "manuscript.pdf"
         stale.write_bytes(b"%PDF-1.4 stale")
-
+        # Act
         output_pdf, _, _ = _find_output_files(tmp_path, "manuscript")
-        # File exists — but this is meaningless without exit code check
+        # Assert
         assert output_pdf is not None
-        # The fix in process_diff.sh and compiled_tex_to_compiled_pdf.sh
-        # ensures the shell scripts check exit code BEFORE reporting success
 
 
 class TestShellCleanupBehavior:
-    """Test that shell cleanup scripts propagate exit codes correctly (issue #76)."""
+    """Test that shell cleanup scripts propagate exit codes correctly (issue #76).
 
-    def test_process_diff_cleanup_removes_stale_on_failure(self, tmp_path):
-        """cleanup() in process_diff.sh should remove stale PDF when compile fails."""
+    These use real bash subprocess invocations against real temp PDFs — no
+    mocking. The behavioural assertion is on the real on-disk side-effect
+    after cleanup runs.
+    """
+
+    def test_process_diff_cleanup_removes_stale_pdf_on_failure(self, tmp_path):
+        # Arrange
         import subprocess
 
         stale_pdf = tmp_path / "diff.pdf"
         stale_pdf.write_bytes(b"%PDF stale")
-
-        # Simulate: cleanup is called with non-zero compile_result
         script = f"""
         SCITEX_WRITER_DIFF_PDF="{stale_pdf}"
         LOG_DIR="{tmp_path}"
@@ -346,22 +601,46 @@ class TestShellCleanupBehavior:
 
         cleanup 1
         """
-        result = subprocess.run(
-            ["bash", "-c", script],
-            capture_output=True,
-            text=True,
-        )
+        # Act
+        subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+        # Assert
+        assert not stale_pdf.exists()
 
-        assert not stale_pdf.exists(), "Stale PDF should be removed on failure"
+    def test_process_diff_cleanup_returns_nonzero_on_failure(self, tmp_path):
+        # Arrange
+        import subprocess
+
+        stale_pdf = tmp_path / "diff.pdf"
+        stale_pdf.write_bytes(b"%PDF stale")
+        script = f"""
+        SCITEX_WRITER_DIFF_PDF="{stale_pdf}"
+        LOG_DIR="{tmp_path}"
+        echo_error() {{ echo "ERROR: $*" >&2; }}
+        echo_success() {{ echo "OK: $*"; }}
+        echo_info() {{ echo "INFO: $*"; }}
+
+        cleanup() {{
+            local compile_result=${{1:-1}}
+            if [ "$compile_result" -ne 0 ]; then
+                [ -f "$SCITEX_WRITER_DIFF_PDF" ] && rm -f "$SCITEX_WRITER_DIFF_PDF"
+                return 1
+            fi
+            return 0
+        }}
+
+        cleanup 1
+        """
+        # Act
+        result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+        # Assert
         assert result.returncode != 0
 
     def test_process_diff_cleanup_keeps_pdf_on_success(self, tmp_path):
-        """cleanup() should keep PDF when compile succeeds."""
+        # Arrange
         import subprocess
 
         pdf = tmp_path / "diff.pdf"
         pdf.write_bytes(b"%PDF fresh")
-
         script = f"""
         SCITEX_WRITER_DIFF_PDF="{pdf}"
         LOG_DIR="{tmp_path}/logs"
@@ -393,21 +672,49 @@ class TestShellCleanupBehavior:
 
         cleanup 0
         """
-        result = subprocess.run(
-            ["bash", "-c", script],
-            capture_output=True,
-            text=True,
-        )
+        # Act
+        subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+        # Assert
+        assert pdf.exists()
 
-        assert pdf.exists(), "PDF should be kept on success"
+    def test_process_diff_cleanup_returns_zero_on_success(self, tmp_path):
+        # Arrange
+        import subprocess
+
+        pdf = tmp_path / "diff.pdf"
+        pdf.write_bytes(b"%PDF fresh")
+        script = f"""
+        SCITEX_WRITER_DIFF_PDF="{pdf}"
+        echo_error() {{ echo "ERROR: $*" >&2; }}
+        echo_success() {{ echo "OK: $*"; }}
+
+        cleanup() {{
+            local compile_result=${{1:-1}}
+            if [ "$compile_result" -ne 0 ]; then
+                [ -f "$SCITEX_WRITER_DIFF_PDF" ] && rm -f "$SCITEX_WRITER_DIFF_PDF"
+                return 1
+            fi
+            if [ -f "$SCITEX_WRITER_DIFF_PDF" ]; then
+                echo_success "ready"
+                return 0
+            else
+                return 1
+            fi
+        }}
+
+        cleanup 0
+        """
+        # Act
+        result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+        # Assert
         assert result.returncode == 0
 
 
 class TestLatexdiffType:
     """Verify latexdiff uses UNDERLINE type instead of CULINECHBAR (issue #76)."""
 
-    def test_process_diff_uses_underline_type(self):
-        """process_diff.sh should use --type=UNDERLINE, not CULINECHBAR."""
+    def test_process_diff_script_uses_underline_type_flag(self):
+        # Arrange
         script_path = (
             Path(__file__).resolve().parents[3]
             / "scripts"
@@ -415,8 +722,23 @@ class TestLatexdiffType:
             / "modules"
             / "process_diff.sh"
         )
+        # Act
         content = script_path.read_text()
+        # Assert
         assert "--type=UNDERLINE" in content
+
+    def test_process_diff_script_does_not_use_culinechbar_type(self):
+        # Arrange
+        script_path = (
+            Path(__file__).resolve().parents[3]
+            / "scripts"
+            / "shell"
+            / "modules"
+            / "process_diff.sh"
+        )
+        # Act
+        content = script_path.read_text()
+        # Assert
         assert "--type=CULINECHBAR" not in content
 
 
@@ -424,7 +746,5 @@ class TestLatexdiffType:
 
 if __name__ == "__main__":
     import os
-
-    import pytest
 
     pytest.main([os.path.abspath(__file__)])

--- a/tests/scitex_writer/_compile/test_manuscript.py
+++ b/tests/scitex_writer/_compile/test_manuscript.py
@@ -11,261 +11,401 @@ Tests compile_manuscript function with various options:
 - force: Force recompilation
 - log_callback: Live logging
 - progress_callback: Progress tracking
+
+NM-rewrite (2026-06-13): replaced unittest.mock.patch/Mock with real
+recording-fake collaborators that are injected into compile_manuscript
+through the new public runner_fn/validator_fn/output_finder_fn/
+script_resolver_fn kwargs. Tests then assert on the recorded command
+list (real observable side-effect) instead of mock_calls.
 """
+
+from pathlib import Path
 
 import pytest
 
 pytest.importorskip("git")
-from pathlib import Path
-from unittest.mock import Mock, patch
 
 from scitex_writer._compile.manuscript import compile_manuscript
-from scitex_writer._dataclasses import CompilationResult
+
+# ---------------------------------------------------------------------------
+# Real fakes (no unittest.mock).
+# ---------------------------------------------------------------------------
 
 
-class TestCompileManuscript:
-    """Test suite for compile_manuscript function."""
+class _RecordingRunner:
+    """Real fake recording the cmd list and returning a fixed result."""
 
-    def test_import(self):
-        """Test that compile_manuscript can be imported."""
+    def __init__(self):
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, *args, **kwargs):
+        self.calls.append(list(cmd))
+        return {"exit_code": 0, "stdout": "", "stderr": "", "success": True}
+
+
+def _noop_validator(project_dir: Path) -> None:
+    return None
+
+
+def _empty_output_finder(project_dir: Path, doc_type: str):
+    return (None, None, None)
+
+
+def _make_script_resolver(script_path: Path):
+    def _resolver(project_dir: Path, doc_type: str) -> Path:
+        return script_path
+
+    return _resolver
+
+
+def _setup_existing_script(tmp_path: Path) -> Path:
+    script_dir = tmp_path / "scripts" / "shell"
+    script_dir.mkdir(parents=True, exist_ok=True)
+    script = script_dir / "compile_manuscript.sh"
+    script.write_text("#!/bin/sh\nexit 0\n")
+    return script
+
+
+def _run(tmp_path: Path, runner: _RecordingRunner, **kwargs):
+    script = _setup_existing_script(tmp_path)
+    return compile_manuscript(
+        tmp_path,
+        runner_fn=runner,
+        validator_fn=_noop_validator,
+        output_finder_fn=_empty_output_finder,
+        script_resolver_fn=_make_script_resolver(script),
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompileManuscriptImport:
+    """Module-level import contract."""
+
+    def test_compile_manuscript_is_callable_after_import(self):
+        # Arrange
         from scitex_writer._compile import compile_manuscript as cm
 
-        assert callable(cm)
+        # Act
+        result = callable(cm)
+        # Assert
+        assert result is True
 
-    def test_signature(self):
-        """Test function signature has expected parameters."""
+
+class TestCompileManuscriptSignature:
+    """Signature contract — one assertion per test."""
+
+    def test_signature_includes_project_dir_parameter(self):
+        # Arrange
         import inspect
 
-        sig = inspect.signature(compile_manuscript)
-        params = list(sig.parameters.keys())
-
+        # Act
+        params = list(inspect.signature(compile_manuscript).parameters.keys())
+        # Assert
         assert "project_dir" in params
+
+    def test_signature_includes_timeout_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_manuscript).parameters.keys())
+        # Assert
         assert "timeout" in params
+
+    def test_signature_includes_no_figs_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_manuscript).parameters.keys())
+        # Assert
         assert "no_figs" in params
+
+    def test_signature_includes_ppt2tif_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_manuscript).parameters.keys())
+        # Assert
         assert "ppt2tif" in params
+
+    def test_signature_includes_crop_tif_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_manuscript).parameters.keys())
+        # Assert
         assert "crop_tif" in params
+
+    def test_signature_includes_quiet_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_manuscript).parameters.keys())
+        # Assert
         assert "quiet" in params
+
+    def test_signature_includes_verbose_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_manuscript).parameters.keys())
+        # Assert
         assert "verbose" in params
+
+    def test_signature_includes_force_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_manuscript).parameters.keys())
+        # Assert
         assert "force" in params
+
+    def test_signature_includes_log_callback_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_manuscript).parameters.keys())
+        # Assert
         assert "log_callback" in params
+
+    def test_signature_includes_progress_callback_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_manuscript).parameters.keys())
+        # Assert
         assert "progress_callback" in params
 
-    def test_default_parameters(self):
-        """Test default parameter values."""
+
+class TestCompileManuscriptDefaults:
+    """Default-value contract — one assertion per test."""
+
+    def test_default_timeout_is_300_seconds(self):
+        # Arrange
         import inspect
 
-        sig = inspect.signature(compile_manuscript)
+        # Act
+        default = inspect.signature(compile_manuscript).parameters["timeout"].default
+        # Assert
+        assert default == 300
 
-        assert sig.parameters["timeout"].default == 300
-        assert sig.parameters["no_figs"].default is False
-        assert sig.parameters["ppt2tif"].default is False
-        assert sig.parameters["crop_tif"].default is False
-        assert sig.parameters["quiet"].default is False
-        assert sig.parameters["verbose"].default is False
-        assert sig.parameters["force"].default is False
-        assert sig.parameters["log_callback"].default is None
-        assert sig.parameters["progress_callback"].default is None
+    def test_default_no_figs_is_false(self):
+        # Arrange
+        import inspect
 
-    @patch("scitex_writer._compile.manuscript.run_compile")
-    def test_calls_run_compile_with_manuscript_type(self, mock_run_compile):
-        """Test that compile_manuscript calls run_compile with 'manuscript' doc_type."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
+        # Act
+        default = inspect.signature(compile_manuscript).parameters["no_figs"].default
+        # Assert
+        assert default is False
+
+    def test_default_ppt2tif_is_false(self):
+        # Arrange
+        import inspect
+
+        # Act
+        default = inspect.signature(compile_manuscript).parameters["ppt2tif"].default
+        # Assert
+        assert default is False
+
+    def test_default_crop_tif_is_false(self):
+        # Arrange
+        import inspect
+
+        # Act
+        default = inspect.signature(compile_manuscript).parameters["crop_tif"].default
+        # Assert
+        assert default is False
+
+    def test_default_quiet_is_false(self):
+        # Arrange
+        import inspect
+
+        # Act
+        default = inspect.signature(compile_manuscript).parameters["quiet"].default
+        # Assert
+        assert default is False
+
+    def test_default_verbose_is_false(self):
+        # Arrange
+        import inspect
+
+        # Act
+        default = inspect.signature(compile_manuscript).parameters["verbose"].default
+        # Assert
+        assert default is False
+
+    def test_default_force_is_false(self):
+        # Arrange
+        import inspect
+
+        # Act
+        default = inspect.signature(compile_manuscript).parameters["force"].default
+        # Assert
+        assert default is False
+
+    def test_default_log_callback_is_none(self):
+        # Arrange
+        import inspect
+
+        # Act
+        default = (
+            inspect.signature(compile_manuscript).parameters["log_callback"].default
         )
+        # Assert
+        assert default is None
 
-        project_dir = Path("/tmp/test-project")
-        compile_manuscript(project_dir)
+    def test_default_progress_callback_is_none(self):
+        # Arrange
+        import inspect
 
-        mock_run_compile.assert_called_once()
-        args, kwargs = mock_run_compile.call_args
-        assert args[0] == "manuscript"
-        assert args[1] == project_dir
-
-    @patch("scitex_writer._compile.manuscript.run_compile")
-    def test_passes_no_figs_option(self, mock_run_compile):
-        """Test that no_figs option is passed to run_compile."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
+        # Act
+        default = (
+            inspect.signature(compile_manuscript)
+            .parameters["progress_callback"]
+            .default
         )
+        # Assert
+        assert default is None
 
-        project_dir = Path("/tmp/test-project")
-        compile_manuscript(project_dir, no_figs=True)
 
-        _, kwargs = mock_run_compile.call_args
-        assert kwargs["no_figs"] is True
+class TestCompileManuscriptBehavior:
+    """Behavioural tests — exercise compile_manuscript end-to-end with
+    real recording fakes. Each test asserts ONE observable contract
+    fact, derived from the side-effects captured by the fake."""
 
-    @patch("scitex_writer._compile.manuscript.run_compile")
-    def test_passes_ppt2tif_option(self, mock_run_compile):
-        """Test that ppt2tif option is passed to run_compile."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
-        )
+    def test_runner_called_exactly_once_for_default_invocation(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner)
+        # Assert
+        assert len(runner.calls) == 1
 
-        project_dir = Path("/tmp/test-project")
-        compile_manuscript(project_dir, ppt2tif=True)
+    def test_command_invokes_manuscript_compile_script_path(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner)
+        # Assert
+        assert any("compile_manuscript.sh" in arg for arg in runner.calls[0])
 
-        _, kwargs = mock_run_compile.call_args
-        assert kwargs["ppt2tif"] is True
+    def test_no_figs_option_appends_no_figs_flag(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner, no_figs=True)
+        # Assert
+        assert "--no_figs" in runner.calls[0]
 
-    @patch("scitex_writer._compile.manuscript.run_compile")
-    def test_passes_crop_tif_option(self, mock_run_compile):
-        """Test that crop_tif option is passed to run_compile."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
-        )
+    def test_ppt2tif_option_appends_ppt2tif_flag(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner, ppt2tif=True)
+        # Assert
+        assert "--ppt2tif" in runner.calls[0]
 
-        project_dir = Path("/tmp/test-project")
-        compile_manuscript(project_dir, crop_tif=True)
+    def test_crop_tif_option_appends_crop_tif_flag(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner, crop_tif=True)
+        # Assert
+        assert "--crop_tif" in runner.calls[0]
 
-        _, kwargs = mock_run_compile.call_args
-        assert kwargs["crop_tif"] is True
+    def test_quiet_option_appends_quiet_flag(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner, quiet=True)
+        # Assert
+        assert "--quiet" in runner.calls[0]
 
-    @patch("scitex_writer._compile.manuscript.run_compile")
-    def test_passes_quiet_option(self, mock_run_compile):
-        """Test that quiet option is passed to run_compile."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
-        )
+    def test_verbose_option_appends_verbose_flag(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner, verbose=True)
+        # Assert
+        assert "--verbose" in runner.calls[0]
 
-        project_dir = Path("/tmp/test-project")
-        compile_manuscript(project_dir, quiet=True)
+    def test_force_option_appends_force_flag(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner, force=True)
+        # Assert
+        assert "--force" in runner.calls[0]
 
-        _, kwargs = mock_run_compile.call_args
-        assert kwargs["quiet"] is True
-
-    @patch("scitex_writer._compile.manuscript.run_compile")
-    def test_passes_verbose_option(self, mock_run_compile):
-        """Test that verbose option is passed to run_compile."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
-        )
-
-        project_dir = Path("/tmp/test-project")
-        compile_manuscript(project_dir, verbose=True)
-
-        _, kwargs = mock_run_compile.call_args
-        assert kwargs["verbose"] is True
-
-    @patch("scitex_writer._compile.manuscript.run_compile")
-    def test_passes_force_option(self, mock_run_compile):
-        """Test that force option is passed to run_compile."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
-        )
-
-        project_dir = Path("/tmp/test-project")
-        compile_manuscript(project_dir, force=True)
-
-        _, kwargs = mock_run_compile.call_args
-        assert kwargs["force"] is True
-
-    @patch("scitex_writer._compile.manuscript.run_compile")
-    def test_passes_callbacks(self, mock_run_compile):
-        """Test that callbacks are passed to run_compile."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
-        )
-
-        log_callback = Mock()
-        progress_callback = Mock()
-
-        project_dir = Path("/tmp/test-project")
-        compile_manuscript(
-            project_dir,
-            log_callback=log_callback,
-            progress_callback=progress_callback,
-        )
-
-        _, kwargs = mock_run_compile.call_args
-        assert kwargs["log_callback"] is log_callback
-        assert kwargs["progress_callback"] is progress_callback
-
-    @patch("scitex_writer._compile.manuscript.run_compile")
-    def test_passes_multiple_options(self, mock_run_compile):
-        """Test that multiple options are passed correctly."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
-        )
-
-        project_dir = Path("/tmp/test-project")
-        compile_manuscript(
-            project_dir,
+    def test_multiple_options_all_present_in_command(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(
+            tmp_path,
+            runner,
             no_figs=True,
             ppt2tif=True,
             crop_tif=True,
             verbose=True,
             force=True,
         )
+        # Assert
+        cmd = runner.calls[0]
+        assert {
+            "--no_figs",
+            "--ppt2tif",
+            "--crop_tif",
+            "--verbose",
+            "--force",
+        }.issubset(set(cmd))
 
-        _, kwargs = mock_run_compile.call_args
-        assert kwargs["no_figs"] is True
-        assert kwargs["ppt2tif"] is True
-        assert kwargs["crop_tif"] is True
-        assert kwargs["verbose"] is True
-        assert kwargs["force"] is True
-
-    @patch("scitex_writer._compile.manuscript.run_compile")
-    def test_returns_compilation_result(self, mock_run_compile):
-        """Test that function returns CompilationResult."""
-        expected_result = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="Test output",
-            stderr="",
-            duration=2.5,
-        )
-        mock_run_compile.return_value = expected_result
-
-        project_dir = Path("/tmp/test-project")
-        result = compile_manuscript(project_dir)
-
-        assert result is expected_result
+    def test_returns_compilation_result_with_success_true_on_zero_exit(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        result = _run(tmp_path, runner)
+        # Assert
         assert result.success is True
+
+    def test_returns_compilation_result_with_exit_code_zero_on_success(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        result = _run(tmp_path, runner)
+        # Assert
         assert result.exit_code == 0
-        assert result.duration == 2.5
+
+    def test_progress_callback_receives_completion_update(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        progress_events: list[tuple[int, str]] = []
+
+        def record_progress(pct: int, step: str) -> None:
+            progress_events.append((pct, step))
+
+        # Act
+        _run(tmp_path, runner, progress_callback=record_progress)
+        # Assert
+        assert any(pct == 100 for pct, _ in progress_events)
 
 
 # EOF
 
 if __name__ == "__main__":
     import os
-
-    import pytest
 
     pytest.main([os.path.abspath(__file__)])

--- a/tests/scitex_writer/_compile/test_revision.py
+++ b/tests/scitex_writer/_compile/test_revision.py
@@ -7,155 +7,232 @@ Tests compile_revision function with various options:
 - track_changes: Enable change tracking (diff highlighting)
 - log_callback: Live logging
 - progress_callback: Progress tracking
+
+NM-rewrite (2026-06-13): replaced unittest.mock.patch/Mock with real
+recording-fake collaborators injected through the new public
+runner_fn/validator_fn/output_finder_fn/script_resolver_fn kwargs.
 """
+
+from pathlib import Path
 
 import pytest
 
 pytest.importorskip("git")
-from pathlib import Path
-from unittest.mock import Mock, patch
 
 from scitex_writer._compile.revision import compile_revision
-from scitex_writer._dataclasses import CompilationResult
+
+# ---------------------------------------------------------------------------
+# Real fakes
+# ---------------------------------------------------------------------------
 
 
-class TestCompileRevision:
-    """Test suite for compile_revision function."""
+class _RecordingRunner:
+    def __init__(self):
+        self.calls: list[list[str]] = []
 
-    def test_import(self):
-        """Test that compile_revision can be imported."""
+    def __call__(self, cmd, *args, **kwargs):
+        self.calls.append(list(cmd))
+        return {"exit_code": 0, "stdout": "", "stderr": "", "success": True}
+
+
+def _noop_validator(project_dir: Path) -> None:
+    return None
+
+
+def _empty_output_finder(project_dir: Path, doc_type: str):
+    return (None, None, None)
+
+
+def _make_script_resolver(script_path: Path):
+    def _resolver(project_dir: Path, doc_type: str) -> Path:
+        return script_path
+
+    return _resolver
+
+
+def _setup_existing_script(tmp_path: Path) -> Path:
+    script_dir = tmp_path / "scripts" / "shell"
+    script_dir.mkdir(parents=True, exist_ok=True)
+    script = script_dir / "compile_revision.sh"
+    script.write_text("#!/bin/sh\nexit 0\n")
+    return script
+
+
+def _run(tmp_path: Path, runner: _RecordingRunner, **kwargs):
+    script = _setup_existing_script(tmp_path)
+    return compile_revision(
+        tmp_path,
+        runner_fn=runner,
+        validator_fn=_noop_validator,
+        output_finder_fn=_empty_output_finder,
+        script_resolver_fn=_make_script_resolver(script),
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompileRevisionImport:
+    def test_compile_revision_is_callable_after_import(self):
+        # Arrange
         from scitex_writer._compile import compile_revision as cr
 
-        assert callable(cr)
+        # Act
+        result = callable(cr)
+        # Assert
+        assert result is True
 
-    def test_signature(self):
-        """Test function signature has expected parameters."""
+
+class TestCompileRevisionSignature:
+    def test_signature_includes_project_dir_parameter(self):
+        # Arrange
         import inspect
 
-        sig = inspect.signature(compile_revision)
-        params = list(sig.parameters.keys())
-
+        # Act
+        params = list(inspect.signature(compile_revision).parameters.keys())
+        # Assert
         assert "project_dir" in params
+
+    def test_signature_includes_track_changes_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_revision).parameters.keys())
+        # Assert
         assert "track_changes" in params
+
+    def test_signature_includes_timeout_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_revision).parameters.keys())
+        # Assert
         assert "timeout" in params
+
+    def test_signature_includes_log_callback_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_revision).parameters.keys())
+        # Assert
         assert "log_callback" in params
+
+    def test_signature_includes_progress_callback_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_revision).parameters.keys())
+        # Assert
         assert "progress_callback" in params
 
-    def test_default_parameters(self):
-        """Test default parameter values."""
+
+class TestCompileRevisionDefaults:
+    def test_default_track_changes_is_false(self):
+        # Arrange
         import inspect
 
-        sig = inspect.signature(compile_revision)
-
-        assert sig.parameters["track_changes"].default is False
-        assert sig.parameters["timeout"].default == 300
-        assert sig.parameters["log_callback"].default is None
-        assert sig.parameters["progress_callback"].default is None
-
-    @patch("scitex_writer._compile.revision.run_compile")
-    def test_calls_run_compile_with_revision_type(self, mock_run_compile):
-        """Test that compile_revision calls run_compile with 'revision' doc_type."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
+        # Act
+        default = (
+            inspect.signature(compile_revision).parameters["track_changes"].default
         )
+        # Assert
+        assert default is False
 
-        project_dir = Path("/tmp/test-project")
-        compile_revision(project_dir)
+    def test_default_timeout_is_300_seconds(self):
+        # Arrange
+        import inspect
 
-        mock_run_compile.assert_called_once()
-        args, kwargs = mock_run_compile.call_args
-        assert args[0] == "revision"
-        assert args[1] == project_dir
+        # Act
+        default = inspect.signature(compile_revision).parameters["timeout"].default
+        # Assert
+        assert default == 300
 
-    @patch("scitex_writer._compile.revision.run_compile")
-    def test_passes_track_changes_option(self, mock_run_compile):
-        """Test that track_changes option is passed to run_compile."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
+    def test_default_log_callback_is_none(self):
+        # Arrange
+        import inspect
+
+        # Act
+        default = inspect.signature(compile_revision).parameters["log_callback"].default
+        # Assert
+        assert default is None
+
+    def test_default_progress_callback_is_none(self):
+        # Arrange
+        import inspect
+
+        # Act
+        default = (
+            inspect.signature(compile_revision).parameters["progress_callback"].default
         )
+        # Assert
+        assert default is None
 
-        project_dir = Path("/tmp/test-project")
-        compile_revision(project_dir, track_changes=True)
 
-        _, kwargs = mock_run_compile.call_args
-        assert kwargs["track_changes"] is True
+class TestCompileRevisionBehavior:
+    def test_runner_called_exactly_once_for_default_invocation(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner)
+        # Assert
+        assert len(runner.calls) == 1
 
-    @patch("scitex_writer._compile.revision.run_compile")
-    def test_passes_callbacks(self, mock_run_compile):
-        """Test that callbacks are passed to run_compile."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
-        )
+    def test_command_invokes_revision_compile_script_path(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner)
+        # Assert
+        assert any("compile_revision.sh" in arg for arg in runner.calls[0])
 
-        log_callback = Mock()
-        progress_callback = Mock()
+    def test_track_changes_option_appends_track_changes_flag(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner, track_changes=True)
+        # Assert
+        assert "--track-changes" in runner.calls[0]
 
-        project_dir = Path("/tmp/test-project")
-        compile_revision(
-            project_dir,
-            log_callback=log_callback,
-            progress_callback=progress_callback,
-        )
+    def test_progress_callback_receives_completion_update(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        progress_events: list[tuple[int, str]] = []
 
-        _, kwargs = mock_run_compile.call_args
-        assert kwargs["log_callback"] is log_callback
-        assert kwargs["progress_callback"] is progress_callback
+        def record_progress(pct: int, step: str) -> None:
+            progress_events.append((pct, step))
 
-    @patch("scitex_writer._compile.revision.run_compile")
-    def test_passes_timeout(self, mock_run_compile):
-        """Test that timeout is passed to run_compile."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
-        )
+        # Act
+        _run(tmp_path, runner, progress_callback=record_progress)
+        # Assert
+        assert any(pct == 100 for pct, _ in progress_events)
 
-        project_dir = Path("/tmp/test-project")
-        compile_revision(project_dir, timeout=600)
-
-        _, kwargs = mock_run_compile.call_args
-        assert kwargs["timeout"] == 600
-
-    @patch("scitex_writer._compile.revision.run_compile")
-    def test_returns_compilation_result(self, mock_run_compile):
-        """Test that function returns CompilationResult."""
-        expected_result = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="Test output",
-            stderr="",
-            duration=2.5,
-        )
-        mock_run_compile.return_value = expected_result
-
-        project_dir = Path("/tmp/test-project")
-        result = compile_revision(project_dir)
-
-        assert result is expected_result
+    def test_returns_compilation_result_with_success_true_on_zero_exit(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        result = _run(tmp_path, runner)
+        # Assert
         assert result.success is True
+
+    def test_returns_compilation_result_with_exit_code_zero_on_success(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        result = _run(tmp_path, runner)
+        # Assert
         assert result.exit_code == 0
-        assert result.duration == 2.5
 
 
 # EOF
 
 if __name__ == "__main__":
     import os
-
-    import pytest
 
     pytest.main([os.path.abspath(__file__)])

--- a/tests/scitex_writer/_compile/test_supplementary.py
+++ b/tests/scitex_writer/_compile/test_supplementary.py
@@ -10,219 +10,332 @@ Tests compile_supplementary function with various options:
 - quiet: Output verbosity
 - log_callback: Live logging
 - progress_callback: Progress tracking
+
+NM-rewrite (2026-06-13): replaced unittest.mock.patch/Mock with real
+recording-fake collaborators injected through the new public
+runner_fn/validator_fn/output_finder_fn/script_resolver_fn kwargs.
 """
+
+from pathlib import Path
 
 import pytest
 
 pytest.importorskip("git")
-from pathlib import Path
-from unittest.mock import Mock, patch
 
 from scitex_writer._compile.supplementary import compile_supplementary
-from scitex_writer._dataclasses import CompilationResult
+
+# ---------------------------------------------------------------------------
+# Real fakes
+# ---------------------------------------------------------------------------
 
 
-class TestCompileSupplementary:
-    """Test suite for compile_supplementary function."""
+class _RecordingRunner:
+    def __init__(self):
+        self.calls: list[list[str]] = []
 
-    def test_import(self):
-        """Test that compile_supplementary can be imported."""
+    def __call__(self, cmd, *args, **kwargs):
+        self.calls.append(list(cmd))
+        return {"exit_code": 0, "stdout": "", "stderr": "", "success": True}
+
+
+def _noop_validator(project_dir: Path) -> None:
+    return None
+
+
+def _empty_output_finder(project_dir: Path, doc_type: str):
+    return (None, None, None)
+
+
+def _make_script_resolver(script_path: Path):
+    def _resolver(project_dir: Path, doc_type: str) -> Path:
+        return script_path
+
+    return _resolver
+
+
+def _setup_existing_script(tmp_path: Path) -> Path:
+    script_dir = tmp_path / "scripts" / "shell"
+    script_dir.mkdir(parents=True, exist_ok=True)
+    script = script_dir / "compile_supplementary.sh"
+    script.write_text("#!/bin/sh\nexit 0\n")
+    return script
+
+
+def _run(tmp_path: Path, runner: _RecordingRunner, **kwargs):
+    script = _setup_existing_script(tmp_path)
+    return compile_supplementary(
+        tmp_path,
+        runner_fn=runner,
+        validator_fn=_noop_validator,
+        output_finder_fn=_empty_output_finder,
+        script_resolver_fn=_make_script_resolver(script),
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCompileSupplementaryImport:
+    def test_compile_supplementary_is_callable_after_import(self):
+        # Arrange
         from scitex_writer._compile import compile_supplementary as cs
 
-        assert callable(cs)
+        # Act
+        result = callable(cs)
+        # Assert
+        assert result is True
 
-    def test_signature(self):
-        """Test function signature has expected parameters."""
+
+class TestCompileSupplementarySignature:
+    def test_signature_includes_project_dir_parameter(self):
+        # Arrange
         import inspect
 
-        sig = inspect.signature(compile_supplementary)
-        params = list(sig.parameters.keys())
-
+        # Act
+        params = list(inspect.signature(compile_supplementary).parameters.keys())
+        # Assert
         assert "project_dir" in params
+
+    def test_signature_includes_timeout_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_supplementary).parameters.keys())
+        # Assert
         assert "timeout" in params
+
+    def test_signature_includes_no_figs_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_supplementary).parameters.keys())
+        # Assert
         assert "no_figs" in params
+
+    def test_signature_includes_ppt2tif_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_supplementary).parameters.keys())
+        # Assert
         assert "ppt2tif" in params
+
+    def test_signature_includes_crop_tif_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_supplementary).parameters.keys())
+        # Assert
         assert "crop_tif" in params
+
+    def test_signature_includes_quiet_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_supplementary).parameters.keys())
+        # Assert
         assert "quiet" in params
+
+    def test_signature_includes_log_callback_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_supplementary).parameters.keys())
+        # Assert
         assert "log_callback" in params
+
+    def test_signature_includes_progress_callback_parameter(self):
+        # Arrange
+        import inspect
+
+        # Act
+        params = list(inspect.signature(compile_supplementary).parameters.keys())
+        # Assert
         assert "progress_callback" in params
 
-    def test_default_parameters(self):
-        """Test default parameter values."""
+
+class TestCompileSupplementaryDefaults:
+    def test_default_timeout_is_300_seconds(self):
+        # Arrange
         import inspect
 
-        sig = inspect.signature(compile_supplementary)
+        # Act
+        default = inspect.signature(compile_supplementary).parameters["timeout"].default
+        # Assert
+        assert default == 300
 
-        assert sig.parameters["timeout"].default == 300
-        assert sig.parameters["no_figs"].default is False
-        assert sig.parameters["ppt2tif"].default is False
-        assert sig.parameters["crop_tif"].default is False
-        assert sig.parameters["quiet"].default is False
-        assert sig.parameters["log_callback"].default is None
-        assert sig.parameters["progress_callback"].default is None
+    def test_default_no_figs_is_false(self):
+        # Arrange
+        import inspect
 
-    @patch("scitex_writer._compile.supplementary.run_compile")
-    def test_calls_run_compile_with_supplementary_type(self, mock_run_compile):
-        """Test that compile_supplementary calls run_compile with 'supplementary' doc_type."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
+        # Act
+        default = inspect.signature(compile_supplementary).parameters["no_figs"].default
+        # Assert
+        assert default is False
+
+    def test_default_ppt2tif_is_false(self):
+        # Arrange
+        import inspect
+
+        # Act
+        default = inspect.signature(compile_supplementary).parameters["ppt2tif"].default
+        # Assert
+        assert default is False
+
+    def test_default_crop_tif_is_false(self):
+        # Arrange
+        import inspect
+
+        # Act
+        default = (
+            inspect.signature(compile_supplementary).parameters["crop_tif"].default
         )
+        # Assert
+        assert default is False
 
-        project_dir = Path("/tmp/test-project")
-        compile_supplementary(project_dir)
+    def test_default_quiet_is_false(self):
+        # Arrange
+        import inspect
 
-        mock_run_compile.assert_called_once()
-        args, kwargs = mock_run_compile.call_args
-        assert args[0] == "supplementary"
-        assert args[1] == project_dir
+        # Act
+        default = inspect.signature(compile_supplementary).parameters["quiet"].default
+        # Assert
+        assert default is False
 
-    @patch("scitex_writer._compile.supplementary.run_compile")
-    def test_passes_no_figs_option(self, mock_run_compile):
-        """Test that no_figs option is passed to run_compile."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
+    def test_default_log_callback_is_none(self):
+        # Arrange
+        import inspect
+
+        # Act
+        default = (
+            inspect.signature(compile_supplementary).parameters["log_callback"].default
         )
+        # Assert
+        assert default is None
 
-        project_dir = Path("/tmp/test-project")
-        compile_supplementary(project_dir, no_figs=True)
+    def test_default_progress_callback_is_none(self):
+        # Arrange
+        import inspect
 
-        _, kwargs = mock_run_compile.call_args
-        assert kwargs["no_figs"] is True
-
-    @patch("scitex_writer._compile.supplementary.run_compile")
-    def test_passes_ppt2tif_option(self, mock_run_compile):
-        """Test that ppt2tif option is passed to run_compile."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
+        # Act
+        default = (
+            inspect.signature(compile_supplementary)
+            .parameters["progress_callback"]
+            .default
         )
+        # Assert
+        assert default is None
 
-        project_dir = Path("/tmp/test-project")
-        compile_supplementary(project_dir, ppt2tif=True)
 
-        _, kwargs = mock_run_compile.call_args
-        assert kwargs["ppt2tif"] is True
+class TestCompileSupplementaryBehavior:
+    def test_runner_called_exactly_once_for_default_invocation(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner)
+        # Assert
+        assert len(runner.calls) == 1
 
-    @patch("scitex_writer._compile.supplementary.run_compile")
-    def test_passes_crop_tif_option(self, mock_run_compile):
-        """Test that crop_tif option is passed to run_compile."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
-        )
+    def test_command_invokes_supplementary_compile_script_path(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner)
+        # Assert
+        assert any("compile_supplementary.sh" in arg for arg in runner.calls[0])
 
-        project_dir = Path("/tmp/test-project")
-        compile_supplementary(project_dir, crop_tif=True)
+    def test_default_invocation_includes_figs_flag(self, tmp_path):
+        """Supplementary defaults to figures included → --figs flag present."""
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner)
+        # Assert
+        assert "--figs" in runner.calls[0]
 
-        _, kwargs = mock_run_compile.call_args
-        assert kwargs["crop_tif"] is True
+    def test_no_figs_option_suppresses_figs_flag(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner, no_figs=True)
+        # Assert
+        assert "--figs" not in runner.calls[0]
 
-    @patch("scitex_writer._compile.supplementary.run_compile")
-    def test_passes_quiet_option(self, mock_run_compile):
-        """Test that quiet option is passed to run_compile."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
-        )
+    def test_ppt2tif_option_appends_ppt2tif_flag(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner, ppt2tif=True)
+        # Assert
+        assert "--ppt2tif" in runner.calls[0]
 
-        project_dir = Path("/tmp/test-project")
-        compile_supplementary(project_dir, quiet=True)
+    def test_crop_tif_option_appends_crop_tif_flag(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner, crop_tif=True)
+        # Assert
+        assert "--crop_tif" in runner.calls[0]
 
-        _, kwargs = mock_run_compile.call_args
-        assert kwargs["quiet"] is True
+    def test_quiet_option_appends_quiet_flag(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner, quiet=True)
+        # Assert
+        assert "--quiet" in runner.calls[0]
 
-    @patch("scitex_writer._compile.supplementary.run_compile")
-    def test_passes_callbacks(self, mock_run_compile):
-        """Test that callbacks are passed to run_compile."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
-        )
+    def test_multiple_options_all_present_in_command(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        _run(tmp_path, runner, ppt2tif=True, crop_tif=True, quiet=True)
+        # Assert
+        cmd = runner.calls[0]
+        assert {"--ppt2tif", "--crop_tif", "--quiet"}.issubset(set(cmd))
 
-        log_callback = Mock()
-        progress_callback = Mock()
+    def test_progress_callback_receives_completion_update(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        progress_events: list[tuple[int, str]] = []
 
-        project_dir = Path("/tmp/test-project")
-        compile_supplementary(
-            project_dir,
-            log_callback=log_callback,
-            progress_callback=progress_callback,
-        )
+        def record_progress(pct: int, step: str) -> None:
+            progress_events.append((pct, step))
 
-        _, kwargs = mock_run_compile.call_args
-        assert kwargs["log_callback"] is log_callback
-        assert kwargs["progress_callback"] is progress_callback
+        # Act
+        _run(tmp_path, runner, progress_callback=record_progress)
+        # Assert
+        assert any(pct == 100 for pct, _ in progress_events)
 
-    @patch("scitex_writer._compile.supplementary.run_compile")
-    def test_passes_multiple_options(self, mock_run_compile):
-        """Test that multiple options are passed correctly."""
-        mock_run_compile.return_value = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="",
-            stderr="",
-            duration=1.0,
-        )
-
-        project_dir = Path("/tmp/test-project")
-        compile_supplementary(
-            project_dir,
-            ppt2tif=True,
-            crop_tif=True,
-            quiet=True,
-        )
-
-        _, kwargs = mock_run_compile.call_args
-        assert kwargs["ppt2tif"] is True
-        assert kwargs["crop_tif"] is True
-        assert kwargs["quiet"] is True
-
-    @patch("scitex_writer._compile.supplementary.run_compile")
-    def test_returns_compilation_result(self, mock_run_compile):
-        """Test that function returns CompilationResult."""
-        expected_result = CompilationResult(
-            success=True,
-            exit_code=0,
-            stdout="Test output",
-            stderr="",
-            duration=2.5,
-        )
-        mock_run_compile.return_value = expected_result
-
-        project_dir = Path("/tmp/test-project")
-        result = compile_supplementary(project_dir)
-
-        assert result is expected_result
+    def test_returns_compilation_result_with_success_true_on_zero_exit(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        result = _run(tmp_path, runner)
+        # Assert
         assert result.success is True
+
+    def test_returns_compilation_result_with_exit_code_zero_on_success(self, tmp_path):
+        # Arrange
+        runner = _RecordingRunner()
+        # Act
+        result = _run(tmp_path, runner)
+        # Assert
         assert result.exit_code == 0
-        assert result.duration == 2.5
 
 
 # EOF
 
 if __name__ == "__main__":
     import os
-
-    import pytest
 
     pytest.main([os.path.abspath(__file__)])


### PR DESCRIPTION
## Summary

Careful no-mocks rewrite for the 4 mock-heavy `_compile/` test files (~158 PA-306/PA-307 violations cleared in this cluster). Real-collaborator pattern: **inject+fake → real → delete**.

### Test files rewritten
- `tests/scitex_writer/_compile/test__runner.py`
- `tests/scitex_writer/_compile/test_manuscript.py`
- `tests/scitex_writer/_compile/test_revision.py`
- `tests/scitex_writer/_compile/test_supplementary.py`

### Backwards-compatible src/ changes (collaborator defaults to real)
- `src/scitex_writer/_compile/_runner.py`: `run_compile` now accepts keyword-only injectables — `runner_fn`, `validator_fn`, `output_finder_fn`, `script_resolver_fn`. Each defaults to `None`, in which case the existing real implementation (`_run_sh_command`, `validate_before_compile`, `_find_output_files`, `_get_compile_script`) is used — no behaviour change for existing callers.
- `src/scitex_writer/_compile/manuscript.py`, `revision.py`, `supplementary.py`: pass-through of the new kwargs.

### Test rewrite pattern (no mocks, no monkeypatch)
- `unittest.mock.patch` / `MagicMock` / `Mock` → `_RecordingRunner` and `_noop_validator` / `_empty_output_finder` / `_make_script_resolver` plain Python recording fakes, injected through the new public kwargs.
- `mock.assert_called` / `call_args` → `assert "--flag" in runner.calls[0]` on the recorded real command list.
- One assertion per test (STX-TQ007) — signature/defaults split into per-parameter cases.
- AAA marker comments on every test body (STX-TQ002).
- Descriptive test names (>=3 word tokens after `test_`) (STX-TQ003).

### Verification
- `nice -n19 /opt/venv-sac/bin/python -m pytest tests/scitex_writer/_compile/test__runner.py tests/scitex_writer/_compile/test_manuscript.py tests/scitex_writer/_compile/test_revision.py tests/scitex_writer/_compile/test_supplementary.py -q` → **121 passed**.
- `scitex-dev linter check-files tests/scitex_writer/_compile/` → **0 errors** in the 4 target files (down from 158).

Wave 2 / `_compile` cluster of campaign-scitex-writer.

## Test plan
- [x] Targeted pytest green (121 passed)
- [x] Linter shows 0 errors in 4 target files (pre: 158)
- [x] Backwards-compatible src/ surface (new params keyword-only, all default to None → real impl)