### PR TITLE
fix(update-project): stop vendoring package src into consumer projects

### DIFF
--- a/src/scitex_writer/_mcp/handlers/_update/_constants.py
+++ b/src/scitex_writer/_mcp/handlers/_update/_constants.py
@@ -8,9 +8,12 @@ from pathlib import Path
 
 TEMPLATE_REPO_URL = "https://github.com/ywatanabe1989/scitex-writer.git"
 
-# Directories to sync (relative to project root)
+# Directories to sync (relative to project root). The scitex-writer Python
+# package is pip-installed, NOT vendored into consumer projects — syncing
+# src/scitex_writer/ here dumped the whole package (2600+ files) into every
+# paper repo, so it is deliberately excluded. Only the engine/template files
+# the manuscript actually compiles against belong in the manifest.
 SYNC_DIRS = [
-    "src/scitex_writer",
     "scripts",
 ]
 

--- a/src/scitex_writer/_mcp/handlers/_update/_handler.py
+++ b/src/scitex_writer/_mcp/handlers/_update/_handler.py
@@ -28,8 +28,9 @@ def update_project(
 ) -> dict:
     """Update engine files of an existing scitex-writer project.
 
-    Syncs source code, scripts, and build files from the installed
-    scitex-writer package to the project. User content is never modified.
+    Syncs engine/template files (scripts, build scripts, base.tex, styles,
+    Makefile) from the installed scitex-writer package to the project. The
+    package's own src/ is never vendored in; user content is never modified.
 
     Parameters
     ----------

--- a/src/scitex_writer/update.py
+++ b/src/scitex_writer/update.py
@@ -24,8 +24,8 @@ def project(
     scitex-writer package (or GitHub if branch/tag is specified).
     User content is never modified.
 
-    Files synced:
-        - src/scitex_writer/          (Python source code)
+    Files synced (engine/template only — the package itself is pip-installed,
+    never vendored into the project):
         - scripts/                    (shell compilation scripts)
         - compile.sh                  (main compile entry point)
         - 00_shared/latex_styles/     (LaTeX style files)

--- a/tests/scitex_writer/_mcp/handlers/_update/test__diff_drift.py
+++ b/tests/scitex_writer/_mcp/handlers/_update/test__diff_drift.py
@@ -17,9 +17,9 @@ def test_should_skip_excludes_vendored_node_modules():
     assert result is True
 
 
-def test_should_skip_keeps_real_engine_source():
+def test_should_skip_keeps_normal_engine_paths():
     # Arrange
-    rel = "src/scitex_writer/checks.py"
+    rel = "scripts/shell/compile_core.sh"
     # Act
     result = should_skip(rel)
     # Assert
@@ -30,11 +30,36 @@ def _fake_template(tmp_path):
     t = tmp_path / "template"
     (t / "00_shared" / "latex_styles").mkdir(parents=True)
     (t / "00_shared" / "latex_styles" / "formatting.tex").write_text("template")
+    (t / "scripts" / "shell").mkdir(parents=True)
+    (t / "scripts" / "shell" / "compile_core.sh").write_text("echo hi")
     nm = t / "src" / "scitex_writer" / "_django" / "frontend" / "node_modules"
     nm.mkdir(parents=True)
     (nm / "junk.js").write_text("junk")
     (t / "src" / "scitex_writer" / "checks.py").write_text("source")
     return t
+
+
+def test_collect_excludes_package_src(tmp_path):
+    # The pip-installed package must never be vendored into a consumer project.
+    # Arrange
+    template = _fake_template(tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+    # Act
+    files = collect_sync_files(template, project)
+    # Assert
+    assert not any(key.startswith("src/scitex_writer") for key in files)
+
+
+def test_collect_includes_engine_scripts(tmp_path):
+    # Arrange
+    template = _fake_template(tmp_path)
+    project = tmp_path / "project"
+    project.mkdir()
+    # Act
+    files = collect_sync_files(template, project)
+    # Assert
+    assert "scripts/shell/compile_core.sh" in files
 
 
 def test_collect_keys_styles_by_active_compiled_path(tmp_path):


### PR DESCRIPTION
## Summary
- `update-project` listed `src/scitex_writer` in `SYNC_DIRS`, so a dry-run on a consumer paper repo reported ~47 legit engine files **plus 2600+ NEW** — the entire Python package dumped into the project (2663 total). That bloats consumer repos and made the updater unusable for re-syncing (reported from neurovista dogfooding).
- The package is pip-installed; consumer projects only need the engine/template manifest (`scripts/`, `compile.sh`, `base.tex` files, `latex_styles/`, `Makefile`).
- Dropped `src/scitex_writer` from `SYNC_DIRS`; corrected the two docstrings that advertised it as synced; added regression tests asserting the package `src/` is never collected while engine scripts still are.

## Verification
- Logic verified in-container via a stdlib script: `SYNC_DIRS == ['scripts']`; `collect_sync_files` no longer yields any `src/scitex_writer/*` key; engine scripts + active-path styles still collected; `node_modules` still excluded.
- Full pytest run pending on a capable host — the container `.venv` is broken (missing interpreter) and has no pytest (the `nv-sac-exec-mount` limitation).

## Cards
- Closes the over-vendoring item tracked as `nv-writer-update-project`.