### PR TITLE
feat(checks): paper-symlink enforcement with user-level severity knob

### DIFF
--- a/scripts/python/check_paper_symlink.py
+++ b/scripts/python/check_paper_symlink.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/check_paper_symlink.py
+# Purpose: Detect (and optionally repair) drift in the top-level `paper`
+#          convenience symlink that should point at the canonical manuscript
+#          at `<project>/.scitex/writer`.
+#
+#          scitex-writer projects keep the canonical manuscript at
+#          `<project>/.scitex/writer/` and expose a convenience symlink
+#          `paper -> .scitex/writer`. When `paper` silently becomes a REAL
+#          directory it diverges into two manuscript copies (this bit the
+#          "neurovista" project). This check finds that drift and -- only when
+#          explicitly asked -- repairs it WITHOUT ever destroying diverged
+#          content.
+#
+#          `paper -> .scitex/writer` is a PRIVATE convention. It is NOT
+#          enforced by default. Severity is a user-level knob with four levels:
+#            off    -- check disabled, zero noise (DEFAULT for the public pkg)
+#            warn   -- report drift as a warning (exit 0)
+#            error  -- report drift as an error (exit 1)
+#            repair -- actively fix safe cases; refuse to destroy diverged data
+#
+#          Severity precedence (highest -> lowest), mirroring the package's
+#          documented config precedence:
+#            1. --level {off,warn,error,repair} CLI flag
+#            2. env SCITEX_WRITER_PAPER_SYMLINK
+#            3. project ./config.yaml key paper_symlink.level
+#            4. user-wide ~/.scitex/writer/config.yaml key paper_symlink.level
+#            5. default off
+#
+#          SAFETY: on repair, if `paper/` is a real dir whose content is NOT
+#          fully present (same path + same SHA-256) under `.scitex/writer/`,
+#          conversion is REFUSED -- the directory is preserved, never deleted
+#          or overwritten -- unless --force-after-backup is given, which still
+#          moves `paper/` to a timestamped backup first. Diverged content is
+#          NEVER silently overwritten or deleted.
+#
+# Usage:
+#   python check_paper_symlink.py [project_dir]
+#                                 [--level off|warn|error|repair]
+#                                 [--force-after-backup]
+#
+# Self-contained: stdlib + optional PyYAML (only needed to read config files).
+
+import argparse
+import datetime
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+# ANSI colors (match check_overflow.py / check_limits.py)
+GREEN = "\033[0;32m"
+YELLOW = "\033[1;33m"
+RED = "\033[0;31m"
+DIM = "\033[0;90m"
+BOLD = "\033[1m"
+NC = "\033[0m"
+
+PASS_COUNT = 0
+WARN_COUNT = 0
+FAIL_COUNT = 0
+
+_LEVELS = ("off", "warn", "error", "repair")
+_DEFAULT_LEVEL = "off"
+_CANONICAL_REL = ".scitex/writer"
+
+# How many diverged file paths to print before truncating.
+_MAX_LIST = 20
+
+
+def log_pass(msg):
+    global PASS_COUNT
+    print(f"  {GREEN}[PASS]{NC} {msg}")
+    PASS_COUNT += 1
+
+
+def log_warn(msg):
+    global WARN_COUNT
+    print(f"  {YELLOW}[WARN]{NC} {msg}")
+    WARN_COUNT += 1
+
+
+def log_fail(msg):
+    global FAIL_COUNT
+    print(f"  {RED}[FAIL]{NC} {msg}")
+    FAIL_COUNT += 1
+
+
+def log_detail(msg):
+    print(f"    {DIM}{msg}{NC}")
+
+
+def _read_config_level(config_path):
+    """Read ``paper_symlink.level`` from a YAML config, or None.
+
+    Returns the level string when present and valid, else None. A missing
+    file or missing key is simply None (not an error). PyYAML is optional --
+    if it is absent we silently skip config files (env + CLI still work).
+    """
+    if not config_path.exists():
+        return None
+    try:
+        import yaml
+    except ImportError:
+        return None
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    block = data.get("paper_symlink")
+    if not isinstance(block, dict):
+        return None
+    level = block.get("level")
+    if isinstance(level, str) and level.lower() in _LEVELS:
+        return level.lower()
+    return None
+
+
+def resolve_level(cli_level, project_dir):
+    """Resolve the effective severity level via the documented precedence.
+
+    1. CLI --level
+    2. env SCITEX_WRITER_PAPER_SYMLINK
+    3. project ./config.yaml -> paper_symlink.level
+    4. user ~/.scitex/writer/config.yaml -> paper_symlink.level
+    5. default off
+    """
+    if cli_level:
+        return cli_level.lower()
+
+    env = os.environ.get("SCITEX_WRITER_PAPER_SYMLINK", "").strip().lower()
+    if env in _LEVELS:
+        return env
+
+    proj_level = _read_config_level(Path(project_dir) / "config.yaml")
+    if proj_level:
+        return proj_level
+
+    user_level = _read_config_level(
+        Path.home() / ".scitex" / "writer" / "config.yaml"
+    )
+    if user_level:
+        return user_level
+
+    return _DEFAULT_LEVEL
+
+
+def _sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def compute_divergence(link, canonical):
+    """Return the list of files under ``link`` that are missing from or differ
+    in content against ``canonical``.
+
+    A file is "diverged" when no file with the same relative path AND the same
+    SHA-256 exists under ``canonical``. ``.git`` directories are skipped. The
+    returned paths are relative to ``link`` (sorted).
+    """
+    diverged = []
+    for root, dirs, files in os.walk(link):
+        if ".git" in dirs:
+            dirs.remove(".git")
+        for name in files:
+            src = Path(root) / name
+            rel = src.relative_to(link)
+            dst = canonical / rel
+            if not dst.is_file():
+                diverged.append(str(rel))
+                continue
+            try:
+                if _sha256(src) != _sha256(dst):
+                    diverged.append(str(rel))
+            except OSError:
+                diverged.append(str(rel))
+    return sorted(diverged)
+
+
+def _make_relative_symlink(link):
+    """Create the relative symlink ``paper -> .scitex/writer`` at ``link``."""
+    os.symlink(_CANONICAL_REL, link, target_is_directory=True)
+
+
+def _backup_dir(project_dir):
+    stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    return Path(project_dir) / ".scitex" / f"writer-paper-backup-{stamp}"
+
+
+def _backup_and_link(link, project_dir):
+    """Move ``link`` (a real dir) to a timestamped backup, then symlink.
+
+    Returns the backup path. Uses ``shutil.move`` -- the directory is
+    preserved, never deleted.
+    """
+    import shutil
+
+    backup = _backup_dir(project_dir)
+    backup.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(link), str(backup))
+    _make_relative_symlink(link)
+    return backup
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Detect/repair drift in the top-level `paper` symlink that "
+        "should point at `.scitex/writer`. Private convention -- disabled "
+        "(off) by default; severity is a user-level knob."
+    )
+    parser.add_argument("project_dir", nargs="?", default=".")
+    parser.add_argument(
+        "--level",
+        choices=list(_LEVELS),
+        default=None,
+        help="Severity: off (default), warn, error, or repair. Overrides env "
+        "and config.",
+    )
+    parser.add_argument(
+        "--force-after-backup",
+        action="store_true",
+        help="On repair, convert even diverged `paper/` -- but always back it "
+        "up first (move to a timestamped dir). Never deletes content.",
+    )
+    args = parser.parse_args()
+
+    project_dir = Path(args.project_dir).resolve()
+    link = project_dir / "paper"
+    canonical = project_dir / _CANONICAL_REL
+
+    level = resolve_level(args.level, project_dir)
+
+    print(f"\n{BOLD}=== Paper Symlink Check (level={level}) ==={NC}\n")
+
+    if level == "off":
+        print(
+            f"  {DIM}[INFO]{NC} paper-symlink check is disabled (level=off). "
+            f"Set paper_symlink.level or --level to enable."
+        )
+        print(
+            f"\n{BOLD}Summary:{NC} {GREEN}0 passed{NC}, "
+            f"{YELLOW}0 warnings{NC}, {RED}0 errors{NC}"
+        )
+        return 0
+
+    # --- Case: link is a symlink -------------------------------------------
+    if link.is_symlink():
+        try:
+            resolved = link.resolve()
+        except OSError:
+            resolved = None
+        if resolved is not None and resolved == canonical.resolve():
+            log_pass("`paper` is a symlink -> .scitex/writer (canonical)")
+        else:
+            # Wrong-target symlink. Repointing is data-safe.
+            target = os.readlink(link)
+            if level == "repair":
+                link.unlink()
+                _make_relative_symlink(link)
+                log_pass(
+                    f"repaired `paper` symlink: was -> {target}, now "
+                    f"-> .scitex/writer"
+                )
+            else:
+                report = log_fail if level == "error" else log_warn
+                report(f"`paper` symlink points elsewhere (-> {target})")
+                log_detail(
+                    "hint: re-run with --level repair to repoint it to "
+                    ".scitex/writer (data-safe)."
+                )
+
+    # --- Case: link is a real directory (the drift case) -------------------
+    elif link.is_dir():
+        if not canonical.exists():
+            # Cannot safely convert: no canonical target exists. Never delete.
+            report = log_fail if level in ("error", "repair") else log_warn
+            report(
+                "`paper/` is a REAL directory but .scitex/writer does not "
+                "exist -- cannot safely convert."
+            )
+            log_detail(
+                "hint: inspect `paper/` manually; it may be the only copy of "
+                "your manuscript. Do NOT delete it."
+            )
+        else:
+            diverged = compute_divergence(link, canonical)
+            if not diverged:
+                # Safe to convert: everything in paper/ already in canonical.
+                if level == "repair" or args.force_after_backup:
+                    backup = _backup_and_link(link, project_dir)
+                    log_pass(
+                        "converted real `paper/` dir to a symlink "
+                        "-> .scitex/writer (no divergence)"
+                    )
+                    log_detail(f"backup of former paper/: {backup}")
+                else:
+                    report = log_fail if level == "error" else log_warn
+                    report(
+                        "`paper/` is a REAL directory (not a symlink), though "
+                        "its content matches .scitex/writer."
+                    )
+                    log_detail(
+                        "hint: re-run with --level repair to back it up and "
+                        "replace it with a symlink."
+                    )
+            elif args.force_after_backup:
+                # Explicitly forced: move diverged paper/ to a backup (NEVER
+                # delete), then symlink. This is the sanctioned safe escape.
+                shown = diverged[:_MAX_LIST]
+                backup = _backup_and_link(link, project_dir)
+                log_pass(
+                    f"moved DIVERGED `paper/` ({len(diverged)} unique/differing "
+                    f"file(s)) to a timestamped backup and created the symlink "
+                    f"-> .scitex/writer (no data lost)"
+                )
+                log_detail(f"backup of diverged paper/: {backup}")
+                for rel in shown:
+                    log_detail(f"preserved: {rel}")
+                if len(diverged) > len(shown):
+                    log_detail(f"... and {len(diverged) - len(shown)} more")
+            else:
+                # Diverged, not forced -- always loud, always preserve. This is
+                # dangerous, so it is an error regardless of warn/error/repair.
+                log_fail(
+                    f"`paper/` is a REAL directory and has DIVERGED from "
+                    f".scitex/writer ({len(diverged)} file(s) missing or "
+                    f"differing). Refusing to auto-convert."
+                )
+                shown = diverged[:_MAX_LIST]
+                for rel in shown:
+                    log_detail(f"diverged: paper/{rel}")
+                if len(diverged) > len(shown):
+                    log_detail(f"... and {len(diverged) - len(shown)} more")
+                if level == "repair":
+                    log_detail(
+                        "hint: this content is NOT in .scitex/writer. Back it "
+                        "up and inspect, or re-run with --force-after-backup "
+                        "to move paper/ to a timestamped backup then symlink."
+                    )
+                else:
+                    log_detail(
+                        "hint: re-run with --level repair --force-after-backup "
+                        "to back up paper/ then replace it with a symlink."
+                    )
+
+    # --- Case: link is some other non-symlink file -------------------------
+    elif link.exists():
+        report = log_fail if level in ("error", "repair") else log_warn
+        report("`paper` exists but is neither a symlink nor a directory.")
+        log_detail("hint: inspect it manually; not touching it.")
+
+    # --- Case: link is missing ---------------------------------------------
+    else:
+        if level == "repair" and canonical.exists():
+            _make_relative_symlink(link)
+            log_pass("created `paper` symlink -> .scitex/writer")
+        else:
+            # Missing link is not drift -- nothing to enforce. Non-intrusive.
+            log_pass("no `paper` symlink present; nothing to enforce")
+
+    print()
+    print(
+        f"{BOLD}Summary:{NC} {GREEN}{PASS_COUNT} passed{NC}, "
+        f"{YELLOW}{WARN_COUNT} warnings{NC}, {RED}{FAIL_COUNT} errors{NC}"
+    )
+    if FAIL_COUNT > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scitex_writer/__init__.py
+++ b/src/scitex_writer/__init__.py
@@ -136,9 +136,71 @@ def ensure_workspace(project_dir, git_strategy="child", **kwargs):
 
     writer_path = Path(project_dir) / ".scitex" / "writer"
     if writer_path.exists() and any(writer_path.iterdir()):
+        _maybe_scaffold_paper_symlink(Path(project_dir))
         return writer_path
     Writer(str(writer_path), git_strategy=git_strategy, **kwargs)
+    _maybe_scaffold_paper_symlink(Path(project_dir))
     return writer_path
+
+
+def _resolve_paper_symlink_level(project_dir):
+    """Resolve the paper-symlink severity level (env + config; default ``off``).
+
+    Mirrors the precedence used by scripts/python/check_paper_symlink.py but
+    is kept dependency-free here to avoid an import cycle: env
+    ``SCITEX_WRITER_PAPER_SYMLINK`` then ``~/.scitex/writer/config.yaml``'s
+    ``paper_symlink.level``, defaulting to ``off``.
+    """
+    import os
+    from pathlib import Path
+
+    levels = ("off", "warn", "error", "repair")
+
+    env = os.environ.get("SCITEX_WRITER_PAPER_SYMLINK", "").strip().lower()
+    if env in levels:
+        return env
+
+    user_cfg = Path.home() / ".scitex" / "writer" / "config.yaml"
+    if user_cfg.exists():
+        try:
+            import yaml
+
+            data = yaml.safe_load(user_cfg.read_text(encoding="utf-8")) or {}
+            block = data.get("paper_symlink") if isinstance(data, dict) else None
+            level = block.get("level") if isinstance(block, dict) else None
+            if isinstance(level, str) and level.lower() in levels:
+                return level.lower()
+        except Exception:
+            pass
+    return "off"
+
+
+def _maybe_scaffold_paper_symlink(project_dir):
+    """Create the ``paper -> .scitex/writer`` link ONLY when level == ``repair``.
+
+    The link is a private convention; we scaffold it only when the user has
+    actively opted in (level ``repair``). Idempotent and never clobbers an
+    existing ``paper`` entry of any kind.
+    """
+    import os
+    from pathlib import Path
+
+    if _resolve_paper_symlink_level(project_dir) != "repair":
+        return
+
+    project_dir = Path(project_dir)
+    link = project_dir / "paper"
+    canonical = project_dir / ".scitex" / "writer"
+    # Never clobber an existing entry (symlink, dir, or file).
+    if link.exists() or link.is_symlink():
+        return
+    if not canonical.exists():
+        return
+    try:
+        os.symlink(".scitex/writer", link, target_is_directory=True)
+    except OSError:
+        # Best-effort scaffold; the check/repair command is the primary path.
+        pass
 
 
 __all__ = [

--- a/src/scitex_writer/_cli/__init__.py
+++ b/src/scitex_writer/_cli/__init__.py
@@ -1372,6 +1372,54 @@ def check_overflow_cmd(project, doc_type, strict, max_pt, as_json):
     return result.get("exit_code", 0)
 
 
+@main_group.command("check-paper-symlink")
+@click.option("-p", "--project", default=".", help="Project path.")
+@click.option(
+    "--level",
+    type=click.Choice(["off", "warn", "error", "repair"]),
+    default=None,
+    help="Severity: off (default), warn, error, or repair. Overrides env/config.",
+)
+@click.option(
+    "--force-after-backup",
+    is_flag=True,
+    default=False,
+    help="On repair, convert even a diverged paper/ dir -- but back it up first.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit JSON.")
+def check_paper_symlink_cmd(project, level, force_after_backup, as_json):
+    """Detect/repair drift in the `paper` -> `.scitex/writer` convenience symlink.
+
+    `paper -> .scitex/writer` is a private convention -- disabled (off) by
+    default. When `paper` silently becomes a REAL directory it diverges into
+    two manuscript copies; this finds that drift. With --level repair it fixes
+    the safe cases, but NEVER deletes diverged content (use --force-after-backup
+    to back it up first). Severity precedence: --level > env
+    SCITEX_WRITER_PAPER_SYMLINK > ./config.yaml > ~/.scitex/writer/config.yaml.
+
+    \b
+    Example:
+        $ scitex-writer check-paper-symlink
+        $ scitex-writer check-paper-symlink --level repair
+        $ scitex-writer check-paper-symlink --level repair --force-after-backup
+    """
+    from .. import checks
+
+    result = checks.paper_symlink(
+        project, level=level, force_after_backup=force_after_backup
+    )
+    if as_json:
+        _emit_json(result)
+        return 0 if result.get("success") else 1
+    out = (result.get("stdout") or "").rstrip()
+    if out:
+        click.echo(out)
+    err = (result.get("stderr") or "").rstrip()
+    if err:
+        click.echo(err, err=True)
+    return result.get("exit_code", 0)
+
+
 @main_group.command("check-references")
 @click.option("-p", "--project", default=".", help="Project path.")
 @click.option(

--- a/src/scitex_writer/_mcp/handlers/__init__.py
+++ b/src/scitex_writer/_mcp/handlers/__init__.py
@@ -8,6 +8,7 @@ from ._checks import (
     check_float_order,
     check_limits,
     check_overflow,
+    check_paper_symlink,
     check_references,
 )
 from ._claim import (
@@ -30,6 +31,7 @@ __all__ = [
     "check_float_order",
     "check_limits",
     "check_overflow",
+    "check_paper_symlink",
     "check_references",
     "clone_project",
     "compile_manuscript",

--- a/src/scitex_writer/_mcp/handlers/_checks.py
+++ b/src/scitex_writer/_mcp/handlers/_checks.py
@@ -200,11 +200,52 @@ def check_overflow(
     return _run_script(script, project_path, args, timeout)
 
 
+def check_paper_symlink(
+    project_dir: str,
+    level: str | None = None,
+    force_after_backup: bool = False,
+    timeout: int = 60,
+) -> dict:
+    """Detect/repair drift in the top-level ``paper`` -> ``.scitex/writer`` symlink.
+
+    The ``paper -> .scitex/writer`` link is a PRIVATE convention -- disabled
+    (``off``) by default. When ``paper`` silently becomes a REAL directory it
+    diverges into two manuscript copies; this check finds that drift and, only
+    under ``level="repair"``, fixes the safe cases. Diverged content (files in
+    ``paper/`` missing from or differing against ``.scitex/writer``) is NEVER
+    deleted or overwritten: ``repair`` refuses unless ``force_after_backup`` is
+    set, which always moves ``paper/`` to a timestamped backup first.
+
+    Severity precedence (highest -> lowest): ``level`` arg, env
+    ``SCITEX_WRITER_PAPER_SYMLINK``, project ``./config.yaml``
+    (``paper_symlink.level``), user ``~/.scitex/writer/config.yaml``, default
+    ``off``.
+
+    Args:
+        project_dir: Project root (holds ``.scitex/writer`` and the ``paper``
+            link).
+        level: One of ``off``, ``warn``, ``error``, ``repair``. When ``None``,
+            the env/config precedence resolves the level.
+        force_after_backup: On ``repair``, convert even diverged ``paper/`` --
+            but always back it up first. Never deletes content.
+        timeout: Subprocess timeout in seconds.
+    """
+    project_path = resolve_project_path(project_dir)
+    script = _script_path(project_path, "check_paper_symlink.py")
+    args: list[str] = []
+    if level is not None:
+        args += ["--level", level]
+    if force_after_backup:
+        args.append("--force-after-backup")
+    return _run_script(script, project_path, args, timeout)
+
+
 __all__ = [
     "check_references",
     "check_float_order",
     "check_limits",
     "check_overflow",
+    "check_paper_symlink",
 ]
 
 # EOF

--- a/src/scitex_writer/checks.py
+++ b/src/scitex_writer/checks.py
@@ -32,6 +32,7 @@ from typing import Optional as _Optional
 from ._mcp.handlers import check_float_order as _check_float_order
 from ._mcp.handlers import check_limits as _check_limits
 from ._mcp.handlers import check_overflow as _check_overflow
+from ._mcp.handlers import check_paper_symlink as _check_paper_symlink
 from ._mcp.handlers import check_references as _check_references
 
 try:
@@ -142,6 +143,48 @@ def overflow(
     return handler(project_dir, doc_type, strict, max_pt)
 
 
-__all__ = ["references", "float_order", "limits", "overflow"]
+@_supports_return_as
+def paper_symlink(
+    project_dir: str,
+    level: _Optional[_Literal["off", "warn", "error", "repair"]] = None,
+    force_after_backup: bool = False,
+    handler: _Optional[_Callable[..., dict]] = None,
+) -> dict:
+    """Detect / repair drift in the ``paper`` -> ``.scitex/writer`` symlink.
+
+    The ``paper -> .scitex/writer`` link is a **private** convention, so it is
+    never enforced by default. Severity is a user-level knob with four levels:
+
+    * ``off`` — check disabled, zero noise. **This is the public default**
+      (when nothing is configured), so the package never errors-by-default.
+    * ``warn`` — report drift as a warning (``exit_code`` 0).
+    * ``error`` — report drift as an error (``exit_code`` 1).
+    * ``repair`` — actively fix the safe cases (create / repoint the symlink;
+      convert a non-diverged real ``paper/`` dir after backing it up).
+
+    Severity precedence (highest → lowest): the ``level`` argument, env
+    ``SCITEX_WRITER_PAPER_SYMLINK``, project ``./config.yaml``
+    (``paper_symlink.level``), user ``~/.scitex/writer/config.yaml``
+    (``paper_symlink.level``), then the ``off`` default.
+
+    Safety: if ``paper/`` is a real directory holding content that is **not**
+    present (same path + same SHA-256) under ``.scitex/writer``, conversion is
+    REFUSED and the directory is preserved — it is never deleted or
+    overwritten. ``force_after_backup=True`` still moves ``paper/`` to a
+    timestamped backup dir before symlinking, so diverged work is never lost.
+
+    Returns a dict with ``success``, ``exit_code``, ``stdout``, ``stderr``,
+    and ``summary={passed, warnings, errors}``.
+
+    ``handler`` is the underlying check implementation; it defaults to
+    :func:`scitex_writer._mcp.handlers.check_paper_symlink`. Exposed so callers
+    (and tests) can supply an alternate implementation without patching
+    internals.
+    """
+    handler = handler or _check_paper_symlink
+    return handler(project_dir, level, force_after_backup)
+
+
+__all__ = ["references", "float_order", "limits", "overflow", "paper_symlink"]
 
 # EOF

--- a/tests/scripts/python/test_check_paper_symlink.py
+++ b/tests/scripts/python/test_check_paper_symlink.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: check_paper_symlink.py
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Add scripts/python to path for imports
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from check_paper_symlink import compute_divergence  # noqa: E402
+
+_SCRIPT = ROOT_DIR / "scripts" / "python" / "check_paper_symlink.py"
+
+
+# ============================================================================
+# helpers
+# ============================================================================
+
+
+def _make_canonical(tmp_path, files):
+    """Create <tmp>/.scitex/writer/ with the given {relpath: content}."""
+    canonical = tmp_path / ".scitex" / "writer"
+    canonical.mkdir(parents=True)
+    for rel, content in files.items():
+        p = canonical / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    return canonical
+
+
+def _run(project, *extra):
+    # No env-driven config should leak into the test.
+    env = dict(os.environ)
+    env.pop("SCITEX_WRITER_PAPER_SYMLINK", None)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), str(project), *extra],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+# ============================================================================
+# compute_divergence
+# ============================================================================
+
+
+def test_compute_divergence_identical_returns_empty(tmp_path):
+    """No divergence when every paper/ file matches canonical by content."""
+    # Arrange
+    canonical = _make_canonical(tmp_path, {"a.tex": "hello"})
+    link = tmp_path / "paper"
+    link.mkdir()
+    (link / "a.tex").write_text("hello")
+    # Act
+    diverged = compute_divergence(link, canonical)
+    # Assert
+    assert diverged == []
+
+
+def test_compute_divergence_flags_unique_and_differing(tmp_path):
+    """Files missing from or differing against canonical are reported."""
+    # Arrange
+    canonical = _make_canonical(tmp_path, {"a.tex": "hello"})
+    link = tmp_path / "paper"
+    link.mkdir()
+    (link / "a.tex").write_text("CHANGED")
+    (link / "new.tex").write_text("only-in-paper")
+    # Act
+    diverged = compute_divergence(link, canonical)
+    # Assert
+    assert sorted(diverged) == ["a.tex", "new.tex"]
+
+
+# ============================================================================
+# End-to-end script behaviour (no LaTeX toolchain needed)
+# ============================================================================
+
+
+def test_pass_when_paper_is_correct_symlink(tmp_path):
+    """A correct paper -> .scitex/writer symlink passes (exit 0)."""
+    # Arrange
+    _make_canonical(tmp_path, {"a.tex": "x"})
+    os.symlink(".scitex/writer", tmp_path / "paper", target_is_directory=True)
+    # Act
+    proc = _run(tmp_path, "--level", "error")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_off_level_is_noop(tmp_path):
+    """level=off disables the check entirely (exit 0, no enforcement)."""
+    # Arrange: a diverged real dir that would otherwise be an error.
+    canonical = _make_canonical(tmp_path, {"a.tex": "x"})  # noqa: F841
+    link = tmp_path / "paper"
+    link.mkdir()
+    (link / "new.tex").write_text("only-in-paper")
+    # Act
+    proc = _run(tmp_path, "--level", "off")
+    # Assert
+    assert proc.returncode == 0
+    assert "disabled" in proc.stdout
+
+
+def test_repair_creates_symlink_when_missing(tmp_path):
+    """level=repair creates the symlink when paper is missing & canonical exists."""
+    # Arrange
+    _make_canonical(tmp_path, {"a.tex": "x"})
+    # Act
+    proc = _run(tmp_path, "--level", "repair")
+    # Assert
+    link = tmp_path / "paper"
+    assert proc.returncode == 0
+    assert link.is_symlink()
+    assert os.readlink(link) == ".scitex/writer"
+
+
+def test_repair_converts_nondiverged_real_dir_with_backup(tmp_path):
+    """A real, non-diverged paper/ is backed up then replaced by a symlink."""
+    # Arrange
+    _make_canonical(tmp_path, {"a.tex": "same"})
+    link = tmp_path / "paper"
+    link.mkdir()
+    (link / "a.tex").write_text("same")
+    # Act
+    proc = _run(tmp_path, "--level", "repair")
+    # Assert
+    assert proc.returncode == 0
+    assert link.is_symlink()
+    backups = list((tmp_path / ".scitex").glob("writer-paper-backup-*"))
+    assert len(backups) == 1
+    assert (backups[0] / "a.tex").read_text() == "same"
+
+
+def test_diverged_repair_without_force_refuses(tmp_path):
+    """Diverged real paper/ under repair (no force) refuses: no symlink, dir intact."""
+    # Arrange
+    _make_canonical(tmp_path, {"a.tex": "canonical"})
+    link = tmp_path / "paper"
+    link.mkdir()
+    (link / "a.tex").write_text("DIVERGED")
+    (link / "unique.tex").write_text("only-in-paper")
+    # Act
+    proc = _run(tmp_path, "--level", "repair")
+    # Assert
+    assert proc.returncode == 1
+    assert link.is_dir() and not link.is_symlink()
+    assert (link / "unique.tex").read_text() == "only-in-paper"
+    assert not list((tmp_path / ".scitex").glob("writer-paper-backup-*"))
+
+
+def test_diverged_force_after_backup_preserves_and_links(tmp_path):
+    """Diverged paper/ with --force-after-backup is moved to backup, then symlinked."""
+    # Arrange
+    _make_canonical(tmp_path, {"a.tex": "canonical"})
+    link = tmp_path / "paper"
+    link.mkdir()
+    (link / "unique.tex").write_text("only-in-paper")
+    # Act
+    proc = _run(tmp_path, "--level", "repair", "--force-after-backup")
+    # Assert
+    assert proc.returncode == 0
+    assert link.is_symlink()
+    backups = list((tmp_path / ".scitex").glob("writer-paper-backup-*"))
+    assert len(backups) == 1
+    # Diverged content preserved -- nothing lost.
+    assert (backups[0] / "unique.tex").read_text() == "only-in-paper"


### PR DESCRIPTION
## Summary

Adds a `paper -> .scitex/writer` drift check across all four interfaces
(SSOT script, MCP handler, public Python API, CLI), plus opt-in scaffolding.

scitex-writer keeps the canonical manuscript at `<project>/.scitex/writer/`
and exposes a convenience symlink `paper -> .scitex/writer`. When `paper`
silently becomes a REAL directory it diverges into two manuscript copies
(this bit the "neurovista" project). This detects/repairs that drift WITHOUT
imposing the convention on the public package.

### Four-level severity knob (default `off`)
- `off` (DEFAULT, public, nothing configured) — check disabled, zero noise.
  The package **never errors by default**.
- `warn` — report drift as a warning (exit 0).
- `error` — report drift as an error (exit 1).
- `repair` — actively fix the safe cases.

Precedence (highest→lowest), mirroring the package's documented config
precedence: `--level` flag > env `SCITEX_WRITER_PAPER_SYMLINK` >
project `./config.yaml` (`paper_symlink.level`) >
user `~/.scitex/writer/config.yaml` (`paper_symlink.level`) > default `off`.

### Divergence-preserve safety
If `paper/` is a real dir holding content NOT present (same relpath + same
SHA-256) under `.scitex/writer/`, conversion is **refused** and the directory
is **preserved** — never deleted/overwritten. `--force-after-backup` still
moves `paper/` to a timestamped `.scitex/writer-paper-backup-<ts>/` first, so
diverged work is never lost. Symlink create/repoint and non-diverged-dir
conversion (with backup) are the only auto-repairs.

### Scaffold only on opt-in
`ensure_workspace` creates the `paper` symlink **only** when the resolved
level is `repair` (the user actively opted in), and never clobbers an existing
`paper` entry.

## Files changed
- `scripts/python/check_paper_symlink.py` (new SSOT script)
- `src/scitex_writer/_mcp/handlers/_checks.py` (+`check_paper_symlink`)
- `src/scitex_writer/_mcp/handlers/__init__.py` (export)
- `src/scitex_writer/checks.py` (+`paper_symlink` public API)
- `src/scitex_writer/__init__.py` (`ensure_workspace` scaffold-on-repair)
- `src/scitex_writer/_cli/__init__.py` (+`check-paper-symlink` command)
- `tests/scripts/python/test_check_paper_symlink.py` (new tests)

## Verification
**Full pytest must run on a capable host** — the container's `.venv` is broken
(missing interpreter / no pytest, `scitex_writer` not importable under
`/opt/venv-sac/bin/python3`; the `nv-sac-exec-mount` limitation). I verified
the self-contained stdlib SCRIPT directly against `/tmp` fixtures for every
case and `py_compile`d all edited python files:

| Case | Expected exit | Observed |
|---|---|---|
| correct symlink (level=error) | 0 | 0 |
| `off` no-op (diverged dir present) | 0 | 0 |
| repair creates missing symlink | 0 | 0 |
| repair converts non-diverged real dir (backup made) | 0 | 0 |
| **diverged + repair WITHOUT force → refuse** | 1 | **1** (paper dir + unique content intact, no backup) |
| **diverged + `--force-after-backup` → move+symlink** | 0 | **0** (backup holds preserved content, no loss) |
| real dir, no canonical → refuse loudly | 1 | 1 (paper preserved) |
| wrong-target symlink + repair → repoint | 0 | 0 |
| env precedence (`SCITEX_WRITER_PAPER_SYMLINK=error`, diverged) | 1 | 1 |

## Note (pre-existing)
`src/scitex_writer/_cli/__init__.py` is already ~1968 lines (well over the
512-line limit) BEFORE this change. Splitting that CLI orchestrator into
focused command modules is a separate refactor owned elsewhere; this PR only
adds the one additive `check-paper-symlink` command mirroring `check-overflow`.

Card: nv-writer-paper-symlink