### PR TITLE
fix(compile): time-box container pulls so dependency check fails loud, not hangs

### DIFF
--- a/scripts/shell/modules/command_switching.src
+++ b/scripts/shell/modules/command_switching.src
@@ -21,103 +21,10 @@ THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 source ./config/load_config.sh $SCITEX_WRITER_DOC_TYPE
 
-# Cache frequently-used checks to avoid redundant calls
-_CACHED_CONTAINER_RUNTIME=""
-_CACHE_CHECKED=false
-_CACHED_MODULE_AVAILABLE=""
-_MODULE_CACHE_CHECKED=false
-
-# Resolve a writer sub-tool SIF path under the per-package convention
-# (operator design 8566 + sac PR #293): ~/.scitex/writer/containers/<tool>.sif.
-# Falls back to legacy ./.cache/containers/<tool>_container.sif for caches built
-# before the migration; deprecation log fires on legacy hit. Sets the named var.
-# Returns 0 if resolved to an existing file, 1 otherwise (var still set to canon
-# so the caller's downloader/builder can populate it at the canonical path).
-_writer_resolve_sif() {
-    local t="$1" var="$2"
-    [ -n "${!var}" ] && [ -f "${!var}" ] && return 0
-    local canon="$HOME/.scitex/writer/containers/$t.sif"
-    [ -f "$canon" ] && { eval "$var=\"\$canon\""; return 0; }
-    local root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../" && pwd)"
-    local legacy="$root/.cache/containers/${t}_container.sif"
-    [ -f "$legacy" ] && { echo_info "    [DEPRECATED] $legacy — rebuild via 'scitex-writer containers install $t -y' (canonical: $canon)"; eval "$var=\"\$legacy\""; return 0; }
-    eval "$var=\"\$canon\""
-    return 1
-}
-
-# Setup container path (Singularity/Apptainer)
-setup_latex_container() {
-    _writer_resolve_sif texlive SCITEX_WRITER_TEXLIVE_APPTAINER_SIF && return 0
-
-    if [ ! -f "$SCITEX_WRITER_TEXLIVE_APPTAINER_SIF" ]; then
-        echo_info "    Downloading TeXLive container (one-time setup)..."
-        mkdir -p "$(dirname $SCITEX_WRITER_TEXLIVE_APPTAINER_SIF)"
-
-        # Try Apptainer first, then Singularity
-        if command -v apptainer &>/dev/null; then
-            apptainer pull "$SCITEX_WRITER_TEXLIVE_APPTAINER_SIF" docker://texlive/texlive:latest >/dev/null 2>&1
-        elif command -v singularity &>/dev/null; then
-            singularity pull "$SCITEX_WRITER_TEXLIVE_APPTAINER_SIF" docker://texlive/texlive:latest >/dev/null 2>&1
-        else
-            return 1
-        fi
-
-        if [ -f "$SCITEX_WRITER_TEXLIVE_APPTAINER_SIF" ]; then
-            echo_success "    Container downloaded to $SCITEX_WRITER_TEXLIVE_APPTAINER_SIF"
-            export SCITEX_WRITER_TEXLIVE_APPTAINER_SIF="$SCITEX_WRITER_TEXLIVE_APPTAINER_SIF"
-        else
-            return 1
-        fi
-    fi
-
-    return 0
-}
-
-# Get container runtime command if available (cached)
-get_container_runtime() {
-    # Use cache if available
-    if [ "$_CACHE_CHECKED" = true ]; then
-        echo "$_CACHED_CONTAINER_RUNTIME"
-        return
-    fi
-
-    # Check once and cache
-    if command -v apptainer &>/dev/null; then
-        _CACHED_CONTAINER_RUNTIME="apptainer"
-    elif command -v singularity &>/dev/null; then
-        _CACHED_CONTAINER_RUNTIME="singularity"
-    else
-        _CACHED_CONTAINER_RUNTIME=""
-    fi
-
-    _CACHE_CHECKED=true
-    echo "$_CACHED_CONTAINER_RUNTIME"
-}
-
-# Load texlive module if available (cached)
-load_texlive_module() {
-    # Use cache if available
-    if [ "$_MODULE_CACHE_CHECKED" = true ]; then
-        if [ "$_CACHED_MODULE_AVAILABLE" = "true" ]; then
-            module load texlive &>/dev/null
-            return 0
-        else
-            return 1
-        fi
-    fi
-
-    # Check once and cache
-    if command -v module &>/dev/null && module avail texlive &>/dev/null 2>&1; then
-        _CACHED_MODULE_AVAILABLE="true"
-        _MODULE_CACHE_CHECKED=true
-        module load texlive &>/dev/null
-        return 0
-    else
-        _CACHED_MODULE_AVAILABLE="false"
-        _MODULE_CACHE_CHECKED=true
-        return 1
-    fi
-}
+# Container / module runtime layer: runtime + module detection and the
+# time-boxed image pulls (resolve_sif, get_container_runtime, setup_*_container).
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/container_runtime.src"
 
 # Get pdflatex command with fallbacks
 # Priority: 1. Native → 2. Singularity → 3. Docker
@@ -302,63 +209,6 @@ get_cmd_tectonic() {
     return 1
 }
 
-# Setup Tectonic container (for tectonic)
-setup_tectonic_container() {
-    _writer_resolve_sif tectonic SCITEX_WRITER_TECTONIC_APPTAINER_SIF && return 0
-
-    if [ ! -f "$SCITEX_WRITER_TECTONIC_APPTAINER_SIF" ]; then
-        echo_info "    Downloading Tectonic container (one-time setup)..."
-        mkdir -p "$(dirname $SCITEX_WRITER_TECTONIC_APPTAINER_SIF)"
-
-        # Try Apptainer first, then Singularity
-        # Using official Tectonic Docker image
-        if command -v apptainer &>/dev/null; then
-            apptainer pull "$SCITEX_WRITER_TECTONIC_APPTAINER_SIF" docker://tectonic/tectonic:latest >/dev/null 2>&1
-        elif command -v singularity &>/dev/null; then
-            singularity pull "$SCITEX_WRITER_TECTONIC_APPTAINER_SIF" docker://tectonic/tectonic:latest >/dev/null 2>&1
-        else
-            return 1
-        fi
-
-        if [ -f "$SCITEX_WRITER_TECTONIC_APPTAINER_SIF" ]; then
-            echo_success "    Container downloaded to $SCITEX_WRITER_TECTONIC_APPTAINER_SIF"
-            export SCITEX_WRITER_TECTONIC_APPTAINER_SIF="$SCITEX_WRITER_TECTONIC_APPTAINER_SIF"
-        else
-            return 1
-        fi
-    fi
-
-    return 0
-}
-
-# Setup Mermaid container (for mmdc)
-setup_mermaid_container() {
-    _writer_resolve_sif mermaid SCITEX_WRITER_MERMAID_APPTAINER_SIF && return 0
-
-    if [ ! -f "$SCITEX_WRITER_MERMAID_APPTAINER_SIF" ]; then
-        echo_info "    Downloading Mermaid container (one-time setup)..."
-        mkdir -p "$(dirname $SCITEX_WRITER_MERMAID_APPTAINER_SIF)"
-
-        # Try Apptainer first, then Singularity
-        if command -v apptainer &>/dev/null; then
-            apptainer pull "$SCITEX_WRITER_MERMAID_APPTAINER_SIF" docker://minlag/mermaid-cli:latest >/dev/null 2>&1
-        elif command -v singularity &>/dev/null; then
-            singularity pull "$SCITEX_WRITER_MERMAID_APPTAINER_SIF" docker://minlag/mermaid-cli:latest >/dev/null 2>&1
-        else
-            return 1
-        fi
-
-        if [ -f "$SCITEX_WRITER_MERMAID_APPTAINER_SIF" ]; then
-            echo_success "    Container downloaded to $SCITEX_WRITER_MERMAID_APPTAINER_SIF"
-            export SCITEX_WRITER_MERMAID_APPTAINER_SIF="$SCITEX_WRITER_MERMAID_APPTAINER_SIF"
-        else
-            return 1
-        fi
-    fi
-
-    return 0
-}
-
 # Get mmdc command with fallbacks
 get_cmd_mmdc() {
     local working_dir="${1:-$(pwd)}"
@@ -412,34 +262,6 @@ check_latex_commands_available() {
     return 0
 }
 
-# Setup ImageMagick container
-setup_imagemagick_container() {
-    _writer_resolve_sif imagemagick SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF && return 0
-
-    if [ ! -f "$SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF" ]; then
-        echo_info "    Downloading ImageMagick container (one-time setup)..."
-        mkdir -p "$(dirname $SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF)"
-
-        # Try Apptainer first, then Singularity
-        if command -v apptainer &>/dev/null; then
-            apptainer pull "$SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF" docker://dpokidov/imagemagick:latest >/dev/null 2>&1
-        elif command -v singularity &>/dev/null; then
-            singularity pull "$SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF" docker://dpokidov/imagemagick:latest >/dev/null 2>&1
-        else
-            return 1
-        fi
-
-        if [ -f "$SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF" ]; then
-            echo_success "    Container downloaded to $SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF"
-            export SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF="$SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF"
-        else
-            return 1
-        fi
-    fi
-
-    return 0
-}
-
 # Get convert command with fallbacks
 # Priority: 1. Native → 2. Singularity → 3. Module
 get_cmd_convert() {
@@ -480,14 +302,8 @@ get_cmd_convert() {
     return 1
 }
 
-# Export functions and cache variables for use in other scripts
-export -f _writer_resolve_sif
-export -f setup_latex_container
-export -f setup_tectonic_container
-export -f setup_mermaid_container
-export -f setup_imagemagick_container
-export -f get_container_runtime
-export -f load_texlive_module
+# Export the command resolvers for use in other scripts (the runtime/setup
+# layer exports itself from container_runtime.src).
 export -f get_cmd_pdflatex
 export -f get_cmd_bibtex
 export -f get_cmd_latexdiff
@@ -497,11 +313,5 @@ export -f get_cmd_texcount
 export -f get_cmd_mmdc
 export -f get_cmd_convert
 export -f check_latex_commands_available
-
-# Export cache variables so subprocesses can use cached values
-export _CACHED_CONTAINER_RUNTIME
-export _CACHE_CHECKED
-export _CACHED_MODULE_AVAILABLE
-export _MODULE_CACHE_CHECKED
 
 # EOF

--- a/scripts/shell/modules/container_runtime.src
+++ b/scripts/shell/modules/container_runtime.src
@@ -1,0 +1,195 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# File: scripts/shell/modules/container_runtime.src
+# shellcheck disable=SC2034,SC2155
+#
+# Container / module runtime layer for the LaTeX toolchain. Resolves the
+# container runtime (apptainer/singularity), the HPC `module` system, and the
+# per-tool .sif images -- pulling them on first use. Sourced by
+# command_switching.src, which builds the get_cmd_* resolvers on top.
+#
+# FAIL LOUD, NEVER HANG: every image pull is time-boxed. In a restricted or
+# offline shell a `pull docker://...` would otherwise stall forever (the
+# compile's dependency check hung indefinitely on exactly this). A pull that
+# exceeds SCITEX_WRITER_CONTAINER_PULL_TIMEOUT is reported loudly and treated
+# as a failure, and the failure is cached so we do not re-attempt (re-hang) it.
+
+# Cache frequently-used checks to avoid redundant calls
+_CACHED_CONTAINER_RUNTIME=""
+_CACHE_CHECKED=false
+_CACHED_MODULE_AVAILABLE=""
+_MODULE_CACHE_CHECKED=false
+
+# Remember a pull that already failed/timed out so we fail fast on the next
+# call instead of re-attempting (and re-hanging) the same unreachable registry.
+_LATEX_PULL_FAILED=false
+_TECTONIC_PULL_FAILED=false
+_MERMAID_PULL_FAILED=false
+_IMAGEMAGICK_PULL_FAILED=false
+
+# Hard time limit (seconds) for a one-time container image pull. Override with
+# SCITEX_WRITER_CONTAINER_PULL_TIMEOUT.
+: "${SCITEX_WRITER_CONTAINER_PULL_TIMEOUT:=300}"
+
+# Pull a container image with a hard timeout, failing loud on stall.
+#   _writer_pull_with_timeout <label> <runtime> <dest_sif> <docker_uri>
+# Returns 0 on success, non-zero on failure/timeout (explained loudly).
+_writer_pull_with_timeout() {
+    local label="$1" runtime="$2" dest="$3" uri="$4"
+    if ! command -v timeout &>/dev/null; then
+        echo_warning "    'timeout' not found; pulling ${label} container without a time limit (may hang)."
+        "$runtime" pull "$dest" "$uri" >/dev/null 2>&1
+        return $?
+    fi
+    timeout "${SCITEX_WRITER_CONTAINER_PULL_TIMEOUT}s" "$runtime" pull "$dest" "$uri" >/dev/null 2>&1
+    local rc=$?
+    if [ "$rc" -eq 124 ]; then
+        echo_error "    ${label} container pull timed out after ${SCITEX_WRITER_CONTAINER_PULL_TIMEOUT}s ($runtime pull $uri)."
+        echo_error "      The image registry is likely unreachable (restricted/offline shell)."
+        echo_error "      Hints: install native LaTeX so no pull is needed; pre-build the .sif on a"
+        echo_error "      networked host and point the matching SCITEX_WRITER_*_APPTAINER_SIF env at it;"
+        echo_error "      or raise SCITEX_WRITER_CONTAINER_PULL_TIMEOUT (seconds)."
+    fi
+    return $rc
+}
+
+# Resolve a writer sub-tool SIF path under the per-package convention
+# (operator design 8566 + sac PR #293): ~/.scitex/writer/containers/<tool>.sif.
+# Falls back to legacy ./.cache/containers/<tool>_container.sif for caches built
+# before the migration; deprecation log fires on legacy hit. Sets the named var.
+# Returns 0 if resolved to an existing file, 1 otherwise (var still set to canon
+# so the caller's downloader/builder can populate it at the canonical path).
+_writer_resolve_sif() {
+    local t="$1" var="$2"
+    [ -n "${!var}" ] && [ -f "${!var}" ] && return 0
+    local canon="$HOME/.scitex/writer/containers/$t.sif"
+    [ -f "$canon" ] && { eval "$var=\"\$canon\""; return 0; }
+    local root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../" && pwd)"
+    local legacy="$root/.cache/containers/${t}_container.sif"
+    [ -f "$legacy" ] && { echo_info "    [DEPRECATED] $legacy — rebuild via 'scitex-writer containers install $t -y' (canonical: $canon)"; eval "$var=\"\$legacy\""; return 0; }
+    eval "$var=\"\$canon\""
+    return 1
+}
+
+# Get container runtime command if available (cached)
+get_container_runtime() {
+    # Use cache if available
+    if [ "$_CACHE_CHECKED" = true ]; then
+        echo "$_CACHED_CONTAINER_RUNTIME"
+        return
+    fi
+
+    # Check once and cache
+    if command -v apptainer &>/dev/null; then
+        _CACHED_CONTAINER_RUNTIME="apptainer"
+    elif command -v singularity &>/dev/null; then
+        _CACHED_CONTAINER_RUNTIME="singularity"
+    else
+        _CACHED_CONTAINER_RUNTIME=""
+    fi
+
+    _CACHE_CHECKED=true
+    echo "$_CACHED_CONTAINER_RUNTIME"
+}
+
+# Load texlive module if available (cached)
+load_texlive_module() {
+    # Use cache if available
+    if [ "$_MODULE_CACHE_CHECKED" = true ]; then
+        if [ "$_CACHED_MODULE_AVAILABLE" = "true" ]; then
+            module load texlive &>/dev/null
+            return 0
+        else
+            return 1
+        fi
+    fi
+
+    # Check once and cache
+    if command -v module &>/dev/null && module avail texlive &>/dev/null 2>&1; then
+        _CACHED_MODULE_AVAILABLE="true"
+        _MODULE_CACHE_CHECKED=true
+        module load texlive &>/dev/null
+        return 0
+    else
+        _CACHED_MODULE_AVAILABLE="false"
+        _MODULE_CACHE_CHECKED=true
+        return 1
+    fi
+}
+
+# Pull one tool's .sif via the timed helper, caching failure in the named flag.
+#   _writer_setup_container <label> <tool> <sif_var> <docker_uri> <fail_flag_var>
+# Returns 0 when the image is present, 1 otherwise.
+_writer_setup_container() {
+    local label="$1" tool="$2" sif_var="$3" uri="$4" fail_var="$5"
+    _writer_resolve_sif "$tool" "$sif_var" && return 0
+    [ "${!fail_var}" = true ] && return 1
+
+    if [ ! -f "${!sif_var}" ]; then
+        echo_info "    Downloading ${label} container (one-time setup)..."
+        mkdir -p "$(dirname "${!sif_var}")"
+
+        local runtime
+        runtime=$(get_container_runtime)
+        if [ -z "$runtime" ]; then
+            return 1
+        fi
+        if ! _writer_pull_with_timeout "$label" "$runtime" "${!sif_var}" "$uri"; then
+            eval "$fail_var=true"
+            return 1
+        fi
+
+        if [ -f "${!sif_var}" ]; then
+            echo_success "    Container downloaded to ${!sif_var}"
+            eval "export $sif_var=\"\${$sif_var}\""
+        else
+            eval "$fail_var=true"
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
+# Setup container path (Singularity/Apptainer)
+setup_latex_container() {
+    _writer_setup_container "TeXLive" texlive SCITEX_WRITER_TEXLIVE_APPTAINER_SIF \
+        docker://texlive/texlive:latest _LATEX_PULL_FAILED
+}
+
+# Setup Tectonic container (for tectonic)
+setup_tectonic_container() {
+    _writer_setup_container "Tectonic" tectonic SCITEX_WRITER_TECTONIC_APPTAINER_SIF \
+        docker://tectonic/tectonic:latest _TECTONIC_PULL_FAILED
+}
+
+# Setup Mermaid container (for mmdc)
+setup_mermaid_container() {
+    _writer_setup_container "Mermaid" mermaid SCITEX_WRITER_MERMAID_APPTAINER_SIF \
+        docker://minlag/mermaid-cli:latest _MERMAID_PULL_FAILED
+}
+
+# Setup ImageMagick container
+setup_imagemagick_container() {
+    _writer_setup_container "ImageMagick" imagemagick SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF \
+        docker://dpokidov/imagemagick:latest _IMAGEMAGICK_PULL_FAILED
+}
+
+# Export functions + cache variables for subprocesses
+export -f _writer_pull_with_timeout
+export -f _writer_resolve_sif
+export -f get_container_runtime
+export -f load_texlive_module
+export -f _writer_setup_container
+export -f setup_latex_container
+export -f setup_tectonic_container
+export -f setup_mermaid_container
+export -f setup_imagemagick_container
+
+export _CACHED_CONTAINER_RUNTIME
+export _CACHE_CHECKED
+export _CACHED_MODULE_AVAILABLE
+export _MODULE_CACHE_CHECKED
+export SCITEX_WRITER_CONTAINER_PULL_TIMEOUT
+
+# EOF


### PR DESCRIPTION
## Summary
- The compile dependency check hung indefinitely at "Native commands incomplete, checking alternatives..." in restricted/offline shells. Root cause: `setup_latex_container` (and the tectonic/mermaid/imagemagick variants) ran `apptainer/singularity pull docker://...` with no timeout; both the warmup block and the parallel `get_cmd_*` checks funnel through these.
- Routed every image pull through a single `_writer_pull_with_timeout` helper bounded by `timeout` (`SCITEX_WRITER_CONTAINER_PULL_TIMEOUT`, default 300s). On stall it prints a loud error naming the command + fix hints and returns non-zero; the failure is cached per tool so later calls fail fast instead of re-hanging.
- Extracted the container/runtime layer into `scripts/shell/modules/container_runtime.src` (separates runtime/image setup from the `get_cmd_*` resolvers and keeps `command_switching.src` under the 512-line limit). Public function/API surface unchanged.

## Verification
- `bash -n` clean on both modules.
- Behavioral test with a hanging `apptainer` stub + `SCITEX_WRITER_CONTAINER_PULL_TIMEOUT=2`: first call fails loud after ~2s and returns 1; second call returns instantly from the failure cache.
- Full compile must run on a capable host (LaTeX/containers unavailable in the agent container).

## Card
- nv-writer-compile-failloud