### PR TITLE
chore(release): 2.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.21.0] - 2026-06-25
+
+### Added
+- **`paper` symlink check** (`scitex-writer check-paper-symlink`, also
+  `checks.paper_symlink()`) — detects when the top-level `paper` convenience
+  link to `.scitex/writer` has drifted into a real directory (two diverging
+  manuscript copies). Severity is a user-level knob (`off`/`warn`/`error`/
+  `repair`) read from `SCITEX_WRITER_PAPER_SYMLINK` or
+  `~/.scitex/writer/config.yaml`. Repair never destroys diverged content — a
+  divergent `paper/` directory is preserved (backed up) and only converted with
+  an explicit `--force-after-backup`.
+
+### Fixed
+- **`update-project` no longer copies the package's own source into your
+  project** — it previously vendored the entire `scitex_writer` Python package
+  (thousands of files) into every consumer project, which made the updater
+  unusable for re-syncing. It now syncs only the engine/template files
+  (scripts, build scripts, `base.tex`, styles, `Makefile`).
+- **Compile dependency check no longer hangs when a container image cannot be
+  downloaded** — in a restricted or offline shell the check used to stall
+  forever trying to pull a TeX/Mermaid/ImageMagick container. Pulls are now
+  time-boxed (`SCITEX_WRITER_CONTAINER_PULL_TIMEOUT`, default 300s) and fail
+  loud with hints (install natively, pre-build the container, or raise the
+  timeout) instead of hanging.
+
 ## [2.20.0] - 2026-06-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.20.0"
+version = "2.21.0"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/tests/scitex_writer/test_checks.py
+++ b/tests/scitex_writer/test_checks.py
@@ -28,7 +28,13 @@ def test_module_exports_references_float_order_limits_and_overflow():
     # Act
     exported = checks.__all__
     # Assert
-    assert exported == ["references", "float_order", "limits", "overflow"]
+    assert exported == [
+        "references",
+        "float_order",
+        "limits",
+        "overflow",
+        "paper_symlink",
+    ]
 
 
 def test_references_forwards_all_arguments_to_handler():

--- a/tests/scripts/python/test_check_paper_symlink.py
+++ b/tests/scripts/python/test_check_paper_symlink.py
@@ -107,7 +107,8 @@ def _run_off_with_diverged_dir(tmp_path):
 
 def test_off_level_exits_zero(tmp_path):
     """level=off disables enforcement -- exit 0 even over a diverged dir."""
-    # Arrange / Act
+    # Arrange
+    # Act
     proc = _run_off_with_diverged_dir(tmp_path)
     # Assert
     assert proc.returncode == 0
@@ -115,7 +116,8 @@ def test_off_level_exits_zero(tmp_path):
 
 def test_off_level_reports_disabled(tmp_path):
     """level=off says so explicitly rather than silently doing nothing."""
-    # Arrange / Act
+    # Arrange
+    # Act
     proc = _run_off_with_diverged_dir(tmp_path)
     # Assert
     assert "disabled" in proc.stdout
@@ -129,21 +131,24 @@ def _run_repair_missing(tmp_path):
 
 
 def test_repair_missing_exits_zero(tmp_path):
-    # Arrange / Act
+    # Arrange
+    # Act
     proc, _ = _run_repair_missing(tmp_path)
     # Assert
     assert proc.returncode == 0
 
 
 def test_repair_missing_creates_symlink(tmp_path):
-    # Arrange / Act
+    # Arrange
+    # Act
     _, link = _run_repair_missing(tmp_path)
     # Assert
     assert link.is_symlink()
 
 
 def test_repair_missing_symlink_is_relative(tmp_path):
-    # Arrange / Act
+    # Arrange
+    # Act
     _, link = _run_repair_missing(tmp_path)
     # Assert
     assert os.readlink(link) == ".scitex/writer"
@@ -159,28 +164,32 @@ def _run_repair_nondiverged(tmp_path):
 
 
 def test_repair_nondiverged_exits_zero(tmp_path):
-    # Arrange / Act
+    # Arrange
+    # Act
     proc, _ = _run_repair_nondiverged(tmp_path)
     # Assert
     assert proc.returncode == 0
 
 
 def test_repair_nondiverged_becomes_symlink(tmp_path):
-    # Arrange / Act
+    # Arrange
+    # Act
     _, link = _run_repair_nondiverged(tmp_path)
     # Assert
     assert link.is_symlink()
 
 
 def test_repair_nondiverged_makes_one_backup(tmp_path):
-    # Arrange / Act
+    # Arrange
+    # Act
     _run_repair_nondiverged(tmp_path)
     # Assert
     assert len(_backups(tmp_path)) == 1
 
 
 def test_repair_nondiverged_backup_preserves_content(tmp_path):
-    # Arrange / Act
+    # Arrange
+    # Act
     _run_repair_nondiverged(tmp_path)
     # Assert
     assert (_backups(tmp_path)[0] / "a.tex").read_text() == "same"
@@ -197,28 +206,32 @@ def _run_diverged_no_force(tmp_path):
 
 
 def test_diverged_no_force_exits_one(tmp_path):
-    # Arrange / Act
+    # Arrange
+    # Act
     proc, _ = _run_diverged_no_force(tmp_path)
     # Assert
     assert proc.returncode == 1
 
 
 def test_diverged_no_force_leaves_real_dir(tmp_path):
-    # Arrange / Act
+    # Arrange
+    # Act
     _, link = _run_diverged_no_force(tmp_path)
     # Assert
     assert link.is_dir() and not link.is_symlink()
 
 
 def test_diverged_no_force_preserves_unique_content(tmp_path):
-    # Arrange / Act
+    # Arrange
+    # Act
     _, link = _run_diverged_no_force(tmp_path)
     # Assert
     assert (link / "unique.tex").read_text() == "only-in-paper"
 
 
 def test_diverged_no_force_makes_no_backup(tmp_path):
-    # Arrange / Act
+    # Arrange
+    # Act
     _run_diverged_no_force(tmp_path)
     # Assert
     assert not _backups(tmp_path)
@@ -234,28 +247,32 @@ def _run_diverged_force(tmp_path):
 
 
 def test_diverged_force_exits_zero(tmp_path):
-    # Arrange / Act
+    # Arrange
+    # Act
     proc, _ = _run_diverged_force(tmp_path)
     # Assert
     assert proc.returncode == 0
 
 
 def test_diverged_force_becomes_symlink(tmp_path):
-    # Arrange / Act
+    # Arrange
+    # Act
     _, link = _run_diverged_force(tmp_path)
     # Assert
     assert link.is_symlink()
 
 
 def test_diverged_force_makes_one_backup(tmp_path):
-    # Arrange / Act
+    # Arrange
+    # Act
     _run_diverged_force(tmp_path)
     # Assert
     assert len(_backups(tmp_path)) == 1
 
 
 def test_diverged_force_preserves_unique_content(tmp_path):
-    # Arrange / Act
+    # Arrange
+    # Act
     _run_diverged_force(tmp_path)
     # Assert
     assert (_backups(tmp_path)[0] / "unique.tex").read_text() == "only-in-paper"

--- a/tests/scripts/python/test_check_paper_symlink.py
+++ b/tests/scripts/python/test_check_paper_symlink.py
@@ -81,6 +81,10 @@ def test_compute_divergence_flags_unique_and_differing(tmp_path):
 # ============================================================================
 
 
+def _backups(tmp_path):
+    return list((tmp_path / ".scitex").glob("writer-paper-backup-*"))
+
+
 def test_pass_when_paper_is_correct_symlink(tmp_path):
     """A correct paper -> .scitex/writer symlink passes (exit 0)."""
     # Arrange
@@ -92,80 +96,166 @@ def test_pass_when_paper_is_correct_symlink(tmp_path):
     assert proc.returncode == 0
 
 
-def test_off_level_is_noop(tmp_path):
-    """level=off disables the check entirely (exit 0, no enforcement)."""
-    # Arrange: a diverged real dir that would otherwise be an error.
-    canonical = _make_canonical(tmp_path, {"a.tex": "x"})  # noqa: F841
+def _run_off_with_diverged_dir(tmp_path):
+    """level=off over a diverged real paper/ that would otherwise error."""
+    _make_canonical(tmp_path, {"a.tex": "x"})
     link = tmp_path / "paper"
     link.mkdir()
     (link / "new.tex").write_text("only-in-paper")
-    # Act
-    proc = _run(tmp_path, "--level", "off")
+    return _run(tmp_path, "--level", "off")
+
+
+def test_off_level_exits_zero(tmp_path):
+    """level=off disables enforcement -- exit 0 even over a diverged dir."""
+    # Arrange / Act
+    proc = _run_off_with_diverged_dir(tmp_path)
     # Assert
     assert proc.returncode == 0
+
+
+def test_off_level_reports_disabled(tmp_path):
+    """level=off says so explicitly rather than silently doing nothing."""
+    # Arrange / Act
+    proc = _run_off_with_diverged_dir(tmp_path)
+    # Assert
     assert "disabled" in proc.stdout
 
 
-def test_repair_creates_symlink_when_missing(tmp_path):
-    """level=repair creates the symlink when paper is missing & canonical exists."""
-    # Arrange
+def _run_repair_missing(tmp_path):
+    """level=repair when paper is missing and canonical exists."""
     _make_canonical(tmp_path, {"a.tex": "x"})
-    # Act
     proc = _run(tmp_path, "--level", "repair")
+    return proc, tmp_path / "paper"
+
+
+def test_repair_missing_exits_zero(tmp_path):
+    # Arrange / Act
+    proc, _ = _run_repair_missing(tmp_path)
     # Assert
-    link = tmp_path / "paper"
     assert proc.returncode == 0
+
+
+def test_repair_missing_creates_symlink(tmp_path):
+    # Arrange / Act
+    _, link = _run_repair_missing(tmp_path)
+    # Assert
     assert link.is_symlink()
+
+
+def test_repair_missing_symlink_is_relative(tmp_path):
+    # Arrange / Act
+    _, link = _run_repair_missing(tmp_path)
+    # Assert
     assert os.readlink(link) == ".scitex/writer"
 
 
-def test_repair_converts_nondiverged_real_dir_with_backup(tmp_path):
-    """A real, non-diverged paper/ is backed up then replaced by a symlink."""
-    # Arrange
+def _run_repair_nondiverged(tmp_path):
+    """level=repair over a real, non-diverged paper/ dir."""
     _make_canonical(tmp_path, {"a.tex": "same"})
     link = tmp_path / "paper"
     link.mkdir()
     (link / "a.tex").write_text("same")
-    # Act
-    proc = _run(tmp_path, "--level", "repair")
+    return _run(tmp_path, "--level", "repair"), link
+
+
+def test_repair_nondiverged_exits_zero(tmp_path):
+    # Arrange / Act
+    proc, _ = _run_repair_nondiverged(tmp_path)
     # Assert
     assert proc.returncode == 0
+
+
+def test_repair_nondiverged_becomes_symlink(tmp_path):
+    # Arrange / Act
+    _, link = _run_repair_nondiverged(tmp_path)
+    # Assert
     assert link.is_symlink()
-    backups = list((tmp_path / ".scitex").glob("writer-paper-backup-*"))
-    assert len(backups) == 1
-    assert (backups[0] / "a.tex").read_text() == "same"
 
 
-def test_diverged_repair_without_force_refuses(tmp_path):
-    """Diverged real paper/ under repair (no force) refuses: no symlink, dir intact."""
-    # Arrange
+def test_repair_nondiverged_makes_one_backup(tmp_path):
+    # Arrange / Act
+    _run_repair_nondiverged(tmp_path)
+    # Assert
+    assert len(_backups(tmp_path)) == 1
+
+
+def test_repair_nondiverged_backup_preserves_content(tmp_path):
+    # Arrange / Act
+    _run_repair_nondiverged(tmp_path)
+    # Assert
+    assert (_backups(tmp_path)[0] / "a.tex").read_text() == "same"
+
+
+def _run_diverged_no_force(tmp_path):
+    """level=repair (no force) over a DIVERGED real paper/ dir."""
     _make_canonical(tmp_path, {"a.tex": "canonical"})
     link = tmp_path / "paper"
     link.mkdir()
     (link / "a.tex").write_text("DIVERGED")
     (link / "unique.tex").write_text("only-in-paper")
-    # Act
-    proc = _run(tmp_path, "--level", "repair")
+    return _run(tmp_path, "--level", "repair"), link
+
+
+def test_diverged_no_force_exits_one(tmp_path):
+    # Arrange / Act
+    proc, _ = _run_diverged_no_force(tmp_path)
     # Assert
     assert proc.returncode == 1
+
+
+def test_diverged_no_force_leaves_real_dir(tmp_path):
+    # Arrange / Act
+    _, link = _run_diverged_no_force(tmp_path)
+    # Assert
     assert link.is_dir() and not link.is_symlink()
+
+
+def test_diverged_no_force_preserves_unique_content(tmp_path):
+    # Arrange / Act
+    _, link = _run_diverged_no_force(tmp_path)
+    # Assert
     assert (link / "unique.tex").read_text() == "only-in-paper"
-    assert not list((tmp_path / ".scitex").glob("writer-paper-backup-*"))
 
 
-def test_diverged_force_after_backup_preserves_and_links(tmp_path):
-    """Diverged paper/ with --force-after-backup is moved to backup, then symlinked."""
-    # Arrange
+def test_diverged_no_force_makes_no_backup(tmp_path):
+    # Arrange / Act
+    _run_diverged_no_force(tmp_path)
+    # Assert
+    assert not _backups(tmp_path)
+
+
+def _run_diverged_force(tmp_path):
+    """level=repair --force-after-backup over a DIVERGED real paper/ dir."""
     _make_canonical(tmp_path, {"a.tex": "canonical"})
     link = tmp_path / "paper"
     link.mkdir()
     (link / "unique.tex").write_text("only-in-paper")
-    # Act
-    proc = _run(tmp_path, "--level", "repair", "--force-after-backup")
+    return _run(tmp_path, "--level", "repair", "--force-after-backup"), link
+
+
+def test_diverged_force_exits_zero(tmp_path):
+    # Arrange / Act
+    proc, _ = _run_diverged_force(tmp_path)
     # Assert
     assert proc.returncode == 0
+
+
+def test_diverged_force_becomes_symlink(tmp_path):
+    # Arrange / Act
+    _, link = _run_diverged_force(tmp_path)
+    # Assert
     assert link.is_symlink()
-    backups = list((tmp_path / ".scitex").glob("writer-paper-backup-*"))
-    assert len(backups) == 1
-    # Diverged content preserved -- nothing lost.
-    assert (backups[0] / "unique.tex").read_text() == "only-in-paper"
+
+
+def test_diverged_force_makes_one_backup(tmp_path):
+    # Arrange / Act
+    _run_diverged_force(tmp_path)
+    # Assert
+    assert len(_backups(tmp_path)) == 1
+
+
+def test_diverged_force_preserves_unique_content(tmp_path):
+    # Arrange / Act
+    _run_diverged_force(tmp_path)
+    # Assert
+    assert (_backups(tmp_path)[0] / "unique.tex").read_text() == "only-in-paper"


### PR DESCRIPTION
Release 2.21.0 — bumps version + CHANGELOG for the three merged engine fixes:

- `update-project` no longer vendors the whole package src into consumer projects (#150)
- new `paper`-symlink check with a user-level severity knob (#151)
- compile dependency check time-boxes container pulls and fails loud instead of hanging (#152)

After this merges to develop, promote develop→main and tag `v2.21.0` to trigger the PyPI publish + GitHub release.