### PR TITLE
fix(writer): container fail-loud + compile/dep-check honesty (B+E)

### DIFF
--- a/scripts/shell/modules/check_dependancy_commands.sh
+++ b/scripts/shell/modules/check_dependancy_commands.sh
@@ -37,6 +37,22 @@ source ./config/load_config.sh "$SCITEX_WRITER_DOC_TYPE"
 source "$(dirname "${BASH_SOURCE[0]}")/command_switching.src"
 log_info "Running ${BASH_SOURCE[0]}..."
 
+# Verify a RESOLVED command actually executes -- not merely that get_cmd_*
+# returned a non-empty string. Probes through the full command incl. any
+# container-exec prefix, so a present-but-unmountable .sif (squashfuse
+# 'fuse: device not found') fails here instead of being greenlit as a working
+# engine. Returns 0 only when the probe runs to a 0 exit within the timeout.
+_probe_runs() {
+    local cmd="$1"
+    [ -z "$cmd" ] && return 1
+    # shellcheck disable=SC2086  # $cmd is a multi-word resolved command line.
+    if command -v timeout &>/dev/null; then
+        timeout 20 $cmd --version &>/dev/null
+    else
+        $cmd --version &>/dev/null
+    fi
+}
+
 # Detect package manager
 detect_package_manager() {
     if command -v apt &>/dev/null; then
@@ -67,7 +83,7 @@ fi
 check_pdflatex() {
     local cmd
     cmd=$(get_cmd_pdflatex "$ORIG_DIR")
-    if [ -z "$cmd" ]; then
+    if [ -z "$cmd" ] || ! _probe_runs "$cmd"; then
         echo "- pdflatex"
         if [ "$PKG_MANAGER" = "apt" ]; then
             echo "    - ${SUDO_PREFIX}apt install texlive-latex-base"
@@ -75,7 +91,7 @@ check_pdflatex() {
             echo "    - ${SUDO_PREFIX}yum install texlive-latex"
         fi
         echo "    - Or use: module load texlive"
-        echo "    - Or use: apptainer/singularity with texlive container"
+        echo "    - Or use: scitex-writer containers install texlive -y"
         return 1
     fi
     return 0
@@ -84,7 +100,7 @@ check_pdflatex() {
 check_bibtex() {
     local cmd
     cmd=$(get_cmd_bibtex "$ORIG_DIR")
-    if [ -z "$cmd" ]; then
+    if [ -z "$cmd" ] || ! _probe_runs "$cmd"; then
         echo "- bibtex"
         if [ "$PKG_MANAGER" = "apt" ]; then
             echo "    - ${SUDO_PREFIX}apt install texlive-bibtex-extra"
@@ -92,7 +108,7 @@ check_bibtex() {
             echo "    - ${SUDO_PREFIX}yum install texlive-bibtex"
         fi
         echo "    - Or use: module load texlive"
-        echo "    - Or use: apptainer/singularity with texlive container"
+        echo "    - Or use: scitex-writer containers install texlive -y"
         return 1
     fi
     return 0
@@ -101,7 +117,7 @@ check_bibtex() {
 check_latexdiff() {
     local cmd
     cmd=$(get_cmd_latexdiff "$ORIG_DIR")
-    if [ -z "$cmd" ]; then
+    if [ -z "$cmd" ] || ! _probe_runs "$cmd"; then
         echo "- latexdiff"
         if [ "$PKG_MANAGER" = "apt" ]; then
             echo "    - ${SUDO_PREFIX}apt install latexdiff"
@@ -109,7 +125,7 @@ check_latexdiff() {
             echo "    - ${SUDO_PREFIX}yum install texlive-latexdiff"
         fi
         echo "    - Or use: module load texlive"
-        echo "    - Or use: apptainer/singularity with texlive container"
+        echo "    - Or use: scitex-writer containers install texlive -y"
         return 1
     fi
     return 0
@@ -118,7 +134,7 @@ check_latexdiff() {
 check_texcount() {
     local cmd
     cmd=$(get_cmd_texcount "$ORIG_DIR")
-    if [ -z "$cmd" ]; then
+    if [ -z "$cmd" ] || ! _probe_runs "$cmd"; then
         echo "- texcount"
         if [ "$PKG_MANAGER" = "apt" ]; then
             echo "    - ${SUDO_PREFIX}apt install texlive-extra-utils"
@@ -126,7 +142,7 @@ check_texcount() {
             echo "    - ${SUDO_PREFIX}yum install texlive-texcount"
         fi
         echo "    - Or use: module load texlive"
-        echo "    - Or use: apptainer/singularity with texlive container"
+        echo "    - Or use: scitex-writer containers install texlive -y"
         return 1
     fi
     return 0
@@ -191,7 +207,7 @@ check_numpy() {
 check_mmdc() {
     local cmd
     cmd=$(get_cmd_mmdc "$ORIG_DIR")
-    if [ -z "$cmd" ]; then
+    if [ -z "$cmd" ] || ! _probe_runs "$cmd"; then
         echo "- mmdc (optional, for Mermaid diagrams)"
         if ! command -v npm &>/dev/null; then
             echo "    - First install npm/nodejs"

--- a/scripts/shell/modules/container_runtime.src
+++ b/scripts/shell/modules/container_runtime.src
@@ -8,50 +8,17 @@
 # per-tool .sif images -- pulling them on first use. Sourced by
 # command_switching.src, which builds the get_cmd_* resolvers on top.
 #
-# FAIL LOUD, NEVER HANG: every image pull is time-boxed. In a restricted or
-# offline shell a `pull docker://...` would otherwise stall forever (the
-# compile's dependency check hung indefinitely on exactly this). A pull that
-# exceeds SCITEX_WRITER_CONTAINER_PULL_TIMEOUT is reported loudly and treated
-# as a failure, and the failure is cached so we do not re-attempt (re-hang) it.
+# FAIL LOUD, NEVER PULL: we resolve only an already-installed .sif. We never
+# `pull docker://...` here -- in a restricted or offline shell that stalls
+# forever and silently greenlights a non-functional engine (the compile's
+# dependency check hung indefinitely on exactly this). When the image is
+# absent we fail loudly with an actionable install hint instead.
 
 # Cache frequently-used checks to avoid redundant calls
 _CACHED_CONTAINER_RUNTIME=""
 _CACHE_CHECKED=false
 _CACHED_MODULE_AVAILABLE=""
 _MODULE_CACHE_CHECKED=false
-
-# Remember a pull that already failed/timed out so we fail fast on the next
-# call instead of re-attempting (and re-hanging) the same unreachable registry.
-_LATEX_PULL_FAILED=false
-_TECTONIC_PULL_FAILED=false
-_MERMAID_PULL_FAILED=false
-_IMAGEMAGICK_PULL_FAILED=false
-
-# Hard time limit (seconds) for a one-time container image pull. Override with
-# SCITEX_WRITER_CONTAINER_PULL_TIMEOUT.
-: "${SCITEX_WRITER_CONTAINER_PULL_TIMEOUT:=300}"
-
-# Pull a container image with a hard timeout, failing loud on stall.
-#   _writer_pull_with_timeout <label> <runtime> <dest_sif> <docker_uri>
-# Returns 0 on success, non-zero on failure/timeout (explained loudly).
-_writer_pull_with_timeout() {
-    local label="$1" runtime="$2" dest="$3" uri="$4"
-    if ! command -v timeout &>/dev/null; then
-        echo_warning "    'timeout' not found; pulling ${label} container without a time limit (may hang)."
-        "$runtime" pull "$dest" "$uri" >/dev/null 2>&1
-        return $?
-    fi
-    timeout "${SCITEX_WRITER_CONTAINER_PULL_TIMEOUT}s" "$runtime" pull "$dest" "$uri" >/dev/null 2>&1
-    local rc=$?
-    if [ "$rc" -eq 124 ]; then
-        echo_error "    ${label} container pull timed out after ${SCITEX_WRITER_CONTAINER_PULL_TIMEOUT}s ($runtime pull $uri)."
-        echo_error "      The image registry is likely unreachable (restricted/offline shell)."
-        echo_error "      Hints: install native LaTeX so no pull is needed; pre-build the .sif on a"
-        echo_error "      networked host and point the matching SCITEX_WRITER_*_APPTAINER_SIF env at it;"
-        echo_error "      or raise SCITEX_WRITER_CONTAINER_PULL_TIMEOUT (seconds)."
-    fi
-    return $rc
-}
 
 # Resolve a writer sub-tool SIF path under the per-package convention
 # (operator design 8566 + sac PR #293): ~/.scitex/writer/containers/<tool>.sif.
@@ -117,70 +84,49 @@ load_texlive_module() {
     fi
 }
 
-# Pull one tool's .sif via the timed helper, caching failure in the named flag.
-#   _writer_setup_container <label> <tool> <sif_var> <docker_uri> <fail_flag_var>
-# Returns 0 when the image is present, 1 otherwise.
-_writer_setup_container() {
-    local label="$1" tool="$2" sif_var="$3" uri="$4" fail_var="$5"
+# Require an already-installed .sif for a sub-tool -- NEVER pull.
+#   _writer_require_container <label> <tool> <sif_var> <install_hint>
+# Returns 0 if the image is present, 1 (loudly) otherwise. We deliberately do
+# NOT download: a `pull docker://...` in a restricted/offline shell hangs and
+# silently greenlights a non-functional engine. Fail loud with an actionable
+# hint so the caller (compile / dependency check) reports honestly.
+_writer_require_container() {
+    local label="$1" tool="$2" sif_var="$3" hint="$4"
     _writer_resolve_sif "$tool" "$sif_var" && return 0
-    [ "${!fail_var}" = true ] && return 1
-
-    if [ ! -f "${!sif_var}" ]; then
-        echo_info "    Downloading ${label} container (one-time setup)..."
-        mkdir -p "$(dirname "${!sif_var}")"
-
-        local runtime
-        runtime=$(get_container_runtime)
-        if [ -z "$runtime" ]; then
-            return 1
-        fi
-        if ! _writer_pull_with_timeout "$label" "$runtime" "${!sif_var}" "$uri"; then
-            eval "$fail_var=true"
-            return 1
-        fi
-
-        if [ -f "${!sif_var}" ]; then
-            echo_success "    Container downloaded to ${!sif_var}"
-            eval "export $sif_var=\"\${$sif_var}\""
-        else
-            eval "$fail_var=true"
-            return 1
-        fi
-    fi
-
-    return 0
+    echo_error "    ${label} container image not found: ${!sif_var}"
+    echo_error "      ${hint}"
+    return 1
 }
 
 # Setup container path (Singularity/Apptainer)
 setup_latex_container() {
-    _writer_setup_container "TeXLive" texlive SCITEX_WRITER_TEXLIVE_APPTAINER_SIF \
-        docker://texlive/texlive:latest _LATEX_PULL_FAILED
+    _writer_require_container "TeXLive" texlive SCITEX_WRITER_TEXLIVE_APPTAINER_SIF \
+        "Install it: 'scitex-writer containers install texlive -y', or set SCITEX_WRITER_TEXLIVE_APPTAINER_SIF to an existing .sif, or install native TeX Live."
 }
 
 # Setup Tectonic container (for tectonic)
 setup_tectonic_container() {
-    _writer_setup_container "Tectonic" tectonic SCITEX_WRITER_TECTONIC_APPTAINER_SIF \
-        docker://tectonic/tectonic:latest _TECTONIC_PULL_FAILED
+    _writer_require_container "Tectonic" tectonic SCITEX_WRITER_TECTONIC_APPTAINER_SIF \
+        "Build tectonic.sif (scripts/containers/tectonic.def) and set SCITEX_WRITER_TECTONIC_APPTAINER_SIF, or install native tectonic."
 }
 
 # Setup Mermaid container (for mmdc)
 setup_mermaid_container() {
-    _writer_setup_container "Mermaid" mermaid SCITEX_WRITER_MERMAID_APPTAINER_SIF \
-        docker://minlag/mermaid-cli:latest _MERMAID_PULL_FAILED
+    _writer_require_container "Mermaid" mermaid SCITEX_WRITER_MERMAID_APPTAINER_SIF \
+        "Provide mermaid.sif and set SCITEX_WRITER_MERMAID_APPTAINER_SIF, or install native mmdc (npm i -g @mermaid-js/mermaid-cli)."
 }
 
 # Setup ImageMagick container
 setup_imagemagick_container() {
-    _writer_setup_container "ImageMagick" imagemagick SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF \
-        docker://dpokidov/imagemagick:latest _IMAGEMAGICK_PULL_FAILED
+    _writer_require_container "ImageMagick" imagemagick SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF \
+        "Provide imagemagick.sif and set SCITEX_WRITER_IMAGEMAGICK_APPTAINER_SIF, or install native magick/convert."
 }
 
 # Export functions + cache variables for subprocesses
-export -f _writer_pull_with_timeout
 export -f _writer_resolve_sif
 export -f get_container_runtime
 export -f load_texlive_module
-export -f _writer_setup_container
+export -f _writer_require_container
 export -f setup_latex_container
 export -f setup_tectonic_container
 export -f setup_mermaid_container
@@ -190,6 +136,5 @@ export _CACHED_CONTAINER_RUNTIME
 export _CACHE_CHECKED
 export _CACHED_MODULE_AVAILABLE
 export _MODULE_CACHE_CHECKED
-export SCITEX_WRITER_CONTAINER_PULL_TIMEOUT
 
 # EOF

--- a/scripts/shell/modules/engines/compile_3pass.sh
+++ b/scripts/shell/modules/engines/compile_3pass.sh
@@ -9,6 +9,11 @@ THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Source command switching for command detection
 source "${THIS_DIR}/../command_switching.src"
 
+# Portable file mtime (epoch seconds); prints 0 if absent/unsupported.
+_file_mtime() {
+    stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0
+}
+
 compile_with_3pass() {
     local tex_file="$1"
     local pdf_file="${tex_file%.tex}.pdf"
@@ -63,6 +68,14 @@ compile_with_3pass() {
     local tex_basename=$(basename "${tex_file%.tex}")
     local aux_file="${LOG_DIR}/${tex_basename}.aux"
     local bib_base="${LOG_DIR}/${tex_basename}"
+    local out_pdf="${LOG_DIR}/${tex_basename}.pdf"
+
+    # Record the output PDF's mtime BEFORE compiling so we can prove a fresh
+    # build afterwards. Without this, a pre-existing (stale) PDF makes a no-op
+    # run look successful even when pdflatex never executed (e.g. the container
+    # failed to mount). We FAIL LOUD below instead of trusting a stale PDF.
+    local before_mtime=0
+    [ -f "$out_pdf" ] && before_mtime=$(_file_mtime "$out_pdf")
 
     # Check draft mode
     if [ "$SCITEX_WRITER_DRAFT_MODE" = "true" ]; then
@@ -84,6 +97,23 @@ compile_with_3pass() {
     fi
 
     local total_end=$(date +%s)
+
+    # HONESTY GATE: report success only if a NEWER PDF was actually produced.
+    # A newer mtime proves pdflatex ran and wrote output this run; its absence
+    # means the engine did not run (e.g. container mount failure) -- never pass
+    # off a stale PDF as a successful compile.
+    local after_mtime=0
+    [ -f "$out_pdf" ] && after_mtime=$(_file_mtime "$out_pdf")
+
+    if [ ! -f "$out_pdf" ] || [ "$after_mtime" -le "$before_mtime" ]; then
+        echo_error "    3-pass compilation did NOT produce a fresh PDF."
+        echo_error "      No newer $out_pdf than before the run -- pdflatex did not actually run"
+        echo_error "      (e.g. the container failed to mount: squashfuse 'fuse: device not found')."
+        echo_error "      Refusing to report a stale PDF as success."
+        echo_error "      Fix: 'scitex-writer containers install texlive -y' or install native TeX Live."
+        return 1
+    fi
+
     echo_success "    3-pass compilation: $(($total_end - $total_start))s"
 
     return 0


### PR DESCRIPTION
Part of the scitex-writer 2.22.0 **checker redesign** (fail-fast / fail-loud / no-surprise). Implemented by scitex-dev under operator authorization. Sequence B(+E) first.

## B — container path: never pull, fail loud
`scripts/shell/modules/container_runtime.src`
- `setup_*_container` now resolve an **already-installed** `.sif` via `_writer_resolve_sif` only. If absent → loud error with an actionable install hint (`scitex-writer containers install texlive -y`) and non-zero return. **No `pull docker://...`** — in a restricted/offline shell it hangs forever and silently greenlights a non-functional engine.
- Removed `_writer_pull_with_timeout`, `SCITEX_WRITER_CONTAINER_PULL_TIMEOUT`, and the four `*_PULL_FAILED` flags (supersedes the 2.21.0 time-boxing).

## E(i) — dependency-check FALSE POSITIVE
`scripts/shell/modules/check_dependancy_commands.sh`
- New `_probe_runs`: verifies the **resolved** command actually executes (`<cmd> --version` through any container-exec prefix, `timeout`-bounded) instead of trusting that `get_cmd_*` returned a non-empty string.
- Fixes `pdflatex ✓` shown when the only engine is a texlive container that cannot even mount (squashfuse `fuse: device not found`). Applied to pdflatex/bibtex/latexdiff/texcount + optional mmdc. Hints updated to the explicit install path.

## E(ii) — compile FALSE SUCCESS
`scripts/shell/modules/engines/compile_3pass.sh`
- The 3-pass engine returned success unconditionally, so a pre-existing **stale** `manuscript.pdf` looked like a successful build even when pdflatex never ran (the ~1s 3-pass was the tell).
- Now records the output PDF mtime **before** compiling and reports success only if a **newer** PDF was produced; otherwise fails loud (covers the container-can't-mount case). `latexmk`/`tectonic` engines already gate on the real engine exit code, so they're unchanged.

Card: `nv-writer-compile-false-success`

## Verified
- `bash -n` clean on all 3 files; line counts 140 / 414 / 125 (≤512).
- No dangling references to the removed symbols (rg).
- Unit fixture (/tmp) — all pass: B returns non-zero **without** attempting a pull + emits the install hint; `_probe_runs` accepts a working cmd, rejects a broken (exit≠0) cmd and an empty cmd; the mtime honesty-gate treats an unchanged (stale) PDF as FAIL and a freshly-written PDF as SUCCESS.
- shellcheck not available in the build container — relying on CI for it.

## Follow-ups noted (not in this PR, to keep it focused)
- `compile_latexmk.sh` masks latexmk's exit code via `$?` after a pipe (`| grep -v ...`) — it reads grep's status, not latexmk's. Pre-existing; worth a separate fix.