### PR TITLE
feat(checks): media-provenance check (default off) — script + handler + API

### DIFF
--- a/scripts/python/check_media_provenance.py
+++ b/scripts/python/check_media_provenance.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/check_media_provenance.py
+# Purpose: Verify that media artifacts committed to a manuscript are SYMLINKS
+#          (and, in strict mode, that they resolve under the project's
+#          `scripts/`) -- i.e. the paper is chained to the code that produced
+#          it, rather than holding loose, un-provenanced copies.
+#
+#          A scitex-writer project keeps rendered media under
+#            <doc>/contents/figures/caption_and_media/   (image/pdf/tif/svg)
+#            <doc>/contents/tables/caption_and_media/     (.csv)
+#          Caption `.tex` files (and `.md/.yaml/.yml/.json` sidecars, incl.
+#          figrecipe recipe yamls) are NOT media and are ignored.
+#
+#          This is a PRIVATE convention -- DISABLED (off) by default, so the
+#          public package never errors-by-default. Severity is a user-level
+#          knob with three levels:
+#            off    -- check disabled, zero noise (DEFAULT)
+#            warn   -- report non-symlink media as a warning (exit 0)
+#            error  -- report non-symlink media as an error (exit 1)
+#
+#          Two modes (the whole check is off by default):
+#            basic  -- a media file must be a symlink.
+#            strict -- the symlink must additionally resolve to a path UNDER
+#                      the project `scripts/` dir (require_under_scripts).
+#
+#          Severity precedence (highest -> lowest), mirroring the package's
+#          documented config precedence:
+#            1. --level {off,warn,error} CLI flag
+#            2. env SCITEX_WRITER_MEDIA_PROVENANCE
+#            3. project ./config.yaml key media_provenance.level
+#            4. user-wide ~/.scitex/writer/config.yaml key media_provenance.level
+#            5. default off
+#          require_under_scripts precedence (CLI only ever tightens):
+#            1. --require-under-scripts CLI flag (presence => true)
+#            2. project ./config.yaml key media_provenance.require_under_scripts
+#            3. user ~/.scitex/writer/config.yaml media_provenance.require_under_scripts
+#            4. default false
+#
+# Usage:
+#   python check_media_provenance.py [project_dir]
+#                                    [--doc-type manuscript|supplementary|revision|all]
+#                                    [--level off|warn|error]
+#                                    [--require-under-scripts]
+#
+# Self-contained: stdlib + optional PyYAML (only needed to read config files).
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# ANSI colors (match check_paper_symlink.py / check_overflow.py)
+GREEN = "\033[0;32m"
+YELLOW = "\033[1;33m"
+RED = "\033[0;31m"
+DIM = "\033[0;90m"
+BOLD = "\033[1m"
+NC = "\033[0m"
+
+PASS_COUNT = 0
+WARN_COUNT = 0
+FAIL_COUNT = 0
+
+_LEVELS = ("off", "warn", "error")
+_DEFAULT_LEVEL = "off"
+
+_DOC_DIRS = {
+    "manuscript": "01_manuscript",
+    "supplementary": "02_supplementary",
+    "revision": "03_revision",
+}
+
+# Rendered artifacts that must be symlinked, by media area.
+_FIGURE_MEDIA_EXTS = {".jpg", ".jpeg", ".png", ".pdf", ".tif", ".tiff", ".svg"}
+_TABLE_MEDIA_EXTS = {".csv"}
+
+# How many offending paths to print before truncating.
+_MAX_LIST = 50
+
+
+def log_pass(msg):
+    global PASS_COUNT
+    print(f"  {GREEN}[PASS]{NC} {msg}")
+    PASS_COUNT += 1
+
+
+def log_warn(msg):
+    global WARN_COUNT
+    print(f"  {YELLOW}[WARN]{NC} {msg}")
+    WARN_COUNT += 1
+
+
+def log_fail(msg):
+    global FAIL_COUNT
+    print(f"  {RED}[FAIL]{NC} {msg}")
+    FAIL_COUNT += 1
+
+
+def log_detail(msg):
+    print(f"    {DIM}{msg}{NC}")
+
+
+def _read_block(config_path):
+    """Read the ``media_provenance`` mapping from a YAML config, or ``{}``.
+
+    A missing file/key is simply ``{}`` (not an error). PyYAML is optional --
+    if it is absent we silently skip config files (env + CLI still work).
+    """
+    if not config_path.exists():
+        return {}
+    try:
+        import yaml
+    except ImportError:
+        return {}
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    block = data.get("media_provenance")
+    return block if isinstance(block, dict) else {}
+
+
+def _config_blocks(project_dir):
+    """Return (project_block, user_block) media_provenance mappings."""
+    proj = _read_block(Path(project_dir) / "config.yaml")
+    user = _read_block(Path.home() / ".scitex" / "writer" / "config.yaml")
+    return proj, user
+
+
+def resolve_level(cli_level, proj_block, user_block):
+    """Resolve the effective severity level via the documented precedence."""
+    if cli_level:
+        return cli_level.lower()
+
+    env = os.environ.get("SCITEX_WRITER_MEDIA_PROVENANCE", "").strip().lower()
+    if env in _LEVELS:
+        return env
+
+    for block in (proj_block, user_block):
+        level = block.get("level")
+        if isinstance(level, str) and level.lower() in _LEVELS:
+            return level.lower()
+
+    return _DEFAULT_LEVEL
+
+
+def resolve_require_under_scripts(cli_flag, proj_block, user_block):
+    """Resolve require_under_scripts. The CLI flag only ever tightens (true)."""
+    if cli_flag:
+        return True
+    for block in (proj_block, user_block):
+        val = block.get("require_under_scripts")
+        if isinstance(val, bool):
+            return val
+    return False
+
+
+def _iter_media_files(project_dir, doc_types):
+    """Yield (path, area) for every rendered-media file under the selected docs.
+
+    ``area`` is "figures" or "tables". Walks
+    ``<doc>/contents/{figures,tables}/caption_and_media/`` recursively;
+    selects files by extension so caption ``.tex`` and ``.md/.yaml/.yml/.json``
+    sidecars are skipped. Symlinked directories are not followed (os.walk
+    default) so a symlinked media file is still yielded as a file.
+    """
+    areas = (("figures", _FIGURE_MEDIA_EXTS), ("tables", _TABLE_MEDIA_EXTS))
+    for doc_type in doc_types:
+        doc_dir = project_dir / _DOC_DIRS[doc_type]
+        for area, exts in areas:
+            media_dir = doc_dir / "contents" / area / "caption_and_media"
+            if not media_dir.is_dir():
+                continue
+            for root, _dirs, files in os.walk(media_dir):
+                for name in files:
+                    p = Path(root) / name
+                    if p.suffix.lower() in exts:
+                        yield p, area
+
+
+def _resolves_under(path, scripts_dir):
+    """True if the symlink ``path`` resolves to a location under ``scripts_dir``."""
+    try:
+        target = Path(os.path.realpath(path))
+        target.relative_to(scripts_dir)
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Verify manuscript media are symlinks (chained to the code "
+        "that produced them). Private convention -- disabled (off) by default."
+    )
+    parser.add_argument("project_dir", nargs="?", default=".")
+    parser.add_argument(
+        "--doc-type",
+        choices=[*_DOC_DIRS, "all"],
+        default="all",
+        help="Which document(s) to scan (default: all present).",
+    )
+    parser.add_argument(
+        "--level",
+        choices=list(_LEVELS),
+        default=None,
+        help="Severity: off (default), warn, or error. Overrides env and config.",
+    )
+    parser.add_argument(
+        "--require-under-scripts",
+        action="store_true",
+        help="Strict mode: each media symlink must resolve UNDER the project "
+        "scripts/ dir, not merely be a symlink.",
+    )
+    args = parser.parse_args()
+
+    project_dir = Path(args.project_dir).resolve()
+    proj_block, user_block = _config_blocks(project_dir)
+    level = resolve_level(args.level, proj_block, user_block)
+    require_under_scripts = resolve_require_under_scripts(
+        args.require_under_scripts, proj_block, user_block
+    )
+
+    mode = "strict" if require_under_scripts else "basic"
+    print(f"\n{BOLD}=== Media Provenance Check (level={level}, {mode}) ==={NC}\n")
+
+    if level == "off":
+        print(
+            f"  {DIM}[INFO]{NC} media-provenance check is disabled (level=off). "
+            f"Set media_provenance.level or --level to enable."
+        )
+        print(
+            f"\n{BOLD}Summary:{NC} {GREEN}0 passed{NC}, "
+            f"{YELLOW}0 warnings{NC}, {RED}0 errors{NC}"
+        )
+        return 0
+
+    doc_types = list(_DOC_DIRS) if args.doc_type == "all" else [args.doc_type]
+    scripts_dir = (project_dir / "scripts").resolve()
+
+    report = log_fail if level == "error" else log_warn
+    total = 0
+    offenders = []
+    for path, _area in _iter_media_files(project_dir, doc_types):
+        total += 1
+        rel = path.relative_to(project_dir)
+        if not path.is_symlink():
+            offenders.append((str(rel), "not a symlink (loose copy)"))
+        elif require_under_scripts and not _resolves_under(path, scripts_dir):
+            offenders.append(
+                (str(rel), f"symlink resolves outside {scripts_dir.name}/")
+            )
+
+    if total == 0:
+        log_pass("no media files found under contents/*/caption_and_media/")
+    elif not offenders:
+        suffix = " resolving under scripts/" if require_under_scripts else ""
+        log_pass(f"all {total} media file(s) are symlinks{suffix}")
+    else:
+        for rel, why in offenders[:_MAX_LIST]:
+            report(f"{rel}: {why}")
+        if len(offenders) > _MAX_LIST:
+            log_detail(f"... and {len(offenders) - _MAX_LIST} more")
+        log_detail(
+            "fix: generate media from scripts/ and symlink it into "
+            "caption_and_media/, rather than committing a loose copy."
+        )
+
+    print()
+    print(
+        f"{BOLD}Summary:{NC} {GREEN}{PASS_COUNT} passed{NC}, "
+        f"{YELLOW}{WARN_COUNT} warnings{NC}, {RED}{FAIL_COUNT} errors{NC}"
+    )
+    if FAIL_COUNT > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scitex_writer/_mcp/handlers/__init__.py
+++ b/src/scitex_writer/_mcp/handlers/__init__.py
@@ -7,6 +7,7 @@
 from ._checks import (
     check_float_order,
     check_limits,
+    check_media_provenance,
     check_overflow,
     check_paper_symlink,
     check_references,
@@ -30,6 +31,7 @@ __all__ = [
     "add_claim",
     "check_float_order",
     "check_limits",
+    "check_media_provenance",
     "check_overflow",
     "check_paper_symlink",
     "check_references",

--- a/src/scitex_writer/_mcp/handlers/_checks.py
+++ b/src/scitex_writer/_mcp/handlers/_checks.py
@@ -240,12 +240,54 @@ def check_paper_symlink(
     return _run_script(script, project_path, args, timeout)
 
 
+def check_media_provenance(
+    project_dir: str,
+    doc_type: str = "all",
+    level: str | None = None,
+    require_under_scripts: bool = False,
+    timeout: int = 60,
+) -> dict:
+    """Verify manuscript media are symlinks (chained to the producing code).
+
+    Rendered artifacts under ``<doc>/contents/figures/caption_and_media/``
+    (image/pdf/tif/svg) and ``<doc>/contents/tables/caption_and_media/``
+    (``.csv``) should be SYMLINKS, not loose committed copies; caption ``.tex``
+    and ``.md/.yaml/.yml/.json`` sidecars are ignored. PRIVATE convention --
+    disabled (``off``) by default, so it never errors-by-default.
+
+    Severity precedence (highest -> lowest): ``level`` arg, env
+    ``SCITEX_WRITER_MEDIA_PROVENANCE``, project ``./config.yaml``
+    (``media_provenance.level``), user ``~/.scitex/writer/config.yaml``, default
+    ``off``. ``require_under_scripts`` (strict mode) additionally requires each
+    media symlink to resolve under the project ``scripts/`` dir; the flag only
+    ever tightens, config can also enable it.
+
+    Args:
+        project_dir: Project root.
+        doc_type: ``manuscript``, ``supplementary``, ``revision``, or ``all``.
+        level: One of ``off``, ``warn``, ``error``. When ``None``, env/config
+            precedence resolves the level.
+        require_under_scripts: Strict mode -- each symlink must resolve under
+            ``scripts/``.
+        timeout: Subprocess timeout in seconds.
+    """
+    project_path = resolve_project_path(project_dir)
+    script = _script_path(project_path, "check_media_provenance.py")
+    args = ["--doc-type", doc_type]
+    if level is not None:
+        args += ["--level", level]
+    if require_under_scripts:
+        args.append("--require-under-scripts")
+    return _run_script(script, project_path, args, timeout)
+
+
 __all__ = [
     "check_references",
     "check_float_order",
     "check_limits",
     "check_overflow",
     "check_paper_symlink",
+    "check_media_provenance",
 ]
 
 # EOF

--- a/src/scitex_writer/checks.py
+++ b/src/scitex_writer/checks.py
@@ -31,6 +31,7 @@ from typing import Optional as _Optional
 
 from ._mcp.handlers import check_float_order as _check_float_order
 from ._mcp.handlers import check_limits as _check_limits
+from ._mcp.handlers import check_media_provenance as _check_media_provenance
 from ._mcp.handlers import check_overflow as _check_overflow
 from ._mcp.handlers import check_paper_symlink as _check_paper_symlink
 from ._mcp.handlers import check_references as _check_references
@@ -185,6 +186,57 @@ def paper_symlink(
     return handler(project_dir, level, force_after_backup)
 
 
-__all__ = ["references", "float_order", "limits", "overflow", "paper_symlink"]
+@_supports_return_as
+def media_provenance(
+    project_dir: str,
+    doc_type: _Literal["manuscript", "supplementary", "revision", "all"] = "all",
+    level: _Optional[_Literal["off", "warn", "error"]] = None,
+    require_under_scripts: bool = False,
+    handler: _Optional[_Callable[..., dict]] = None,
+) -> dict:
+    """Verify manuscript media are symlinks chained to the producing code.
+
+    Rendered artifacts under ``<doc>/contents/figures/caption_and_media/``
+    (image/pdf/tif/svg) and ``<doc>/contents/tables/caption_and_media/``
+    (``.csv``) should be **symlinks**, not loose committed copies — so a paper
+    stays chained to the scripts that generated it. Caption ``.tex`` files and
+    ``.md/.yaml/.yml/.json`` sidecars (incl. figrecipe recipe yamls) are not
+    media and are ignored.
+
+    This is a **private** convention, never enforced by default:
+
+    * ``off`` — check disabled (the public default).
+    * ``warn`` — report non-symlink media as a warning (``exit_code`` 0).
+    * ``error`` — report non-symlink media as an error (``exit_code`` 1).
+
+    ``require_under_scripts`` is the strict mode: each media symlink must also
+    resolve to a path under the project ``scripts/`` dir. The flag only ever
+    tightens; ``media_provenance.require_under_scripts`` in config can enable it.
+
+    Severity precedence (highest → lowest): the ``level`` argument, env
+    ``SCITEX_WRITER_MEDIA_PROVENANCE``, project ``./config.yaml``
+    (``media_provenance.level``), user ``~/.scitex/writer/config.yaml``, then
+    the ``off`` default.
+
+    Returns a dict with ``success``, ``exit_code``, ``stdout``, ``stderr``,
+    and ``summary={passed, warnings, errors}``.
+
+    ``handler`` is the underlying check implementation; it defaults to
+    :func:`scitex_writer._mcp.handlers.check_media_provenance`. Exposed so
+    callers (and tests) can supply an alternate implementation without patching
+    internals.
+    """
+    handler = handler or _check_media_provenance
+    return handler(project_dir, doc_type, level, require_under_scripts)
+
+
+__all__ = [
+    "references",
+    "float_order",
+    "limits",
+    "overflow",
+    "paper_symlink",
+    "media_provenance",
+]
 
 # EOF

--- a/tests/scitex_writer/test_checks.py
+++ b/tests/scitex_writer/test_checks.py
@@ -34,7 +34,32 @@ def test_module_exports_references_float_order_limits_and_overflow():
         "limits",
         "overflow",
         "paper_symlink",
+        "media_provenance",
     ]
+
+
+def test_media_provenance_forwards_all_arguments_to_handler():
+    # Arrange
+    handler = _RecordingHandler({"success": True})
+    # Act
+    checks.media_provenance(
+        "/path",
+        doc_type="supplementary",
+        level="error",
+        require_under_scripts=True,
+        handler=handler,
+    )
+    # Assert
+    assert handler.calls == [("/path", "supplementary", "error", True)]
+
+
+def test_media_provenance_defaults_are_all_none_level_nonstrict():
+    # Arrange
+    handler = _RecordingHandler({"success": True})
+    # Act
+    checks.media_provenance("/path", handler=handler)
+    # Assert
+    assert handler.calls == [("/path", "all", None, False)]
 
 
 def test_references_forwards_all_arguments_to_handler():


### PR DESCRIPTION
Part **C** of the scitex-writer 2.22.0 checker redesign (by scitex-dev, operator-authorized). Adds a new default-off check that verifies manuscript media are **symlinks** (chained to the producing code) rather than loose committed copies.

## New check
`scripts/python/check_media_provenance.py` (self-contained stdlib, modeled on `check_paper_symlink.py`):
- Walks `<doc>/contents/figures/caption_and_media/` (image/pdf/tif/svg) and `<doc>/contents/tables/caption_and_media/` (`.csv`), recursively. Caption `.tex` and `.md/.yaml/.yml/.json` sidecars (incl. figrecipe yamls) are **not** media and are ignored.
- **Private convention, default OFF** — never errors-by-default. Levels `off`/`warn`/`error`; precedence `--level` > env `SCITEX_WRITER_MEDIA_PROVENANCE` > project `./config.yaml` (`media_provenance.level`) > user `~/.scitex/writer/config.yaml` > `off`.
- **basic** mode: a media file must be a symlink. **strict** mode (`--require-under-scripts` / `media_provenance.require_under_scripts`, default false, flag only tightens): the symlink must also resolve **under** the project `scripts/` dir.
- Standard `Summary:` line; exit 1 only on FAIL>0; `off` is a no-op.

## Wired through the three interfaces
- Thin MCP handler `check_media_provenance` in `_mcp/handlers/_checks.py` (+ handlers `__all__`).
- Public Python API `checks.media_provenance` (+ `checks.__all__`).
- `__all__`-pin test updated + two forwarding tests added (TQ007 one-assert, TQ002 markers).

## Verified
- `py_compile` clean on all changed `.py`.
- /tmp fixture (script run directly): off→no-op/exit0; warn→loose media warned/exit0; error→loose media exit1; basic→all-symlinks exit0 PASS; strict→symlink resolving outside `scripts/` flagged/exit1, all-under-`scripts/` exit0.
- Container can't import `scitex_writer` → pin/forwarding tests rely on CI.

## Deferred — CLI subcommand `check-media-provenance` (NOT in this PR)
Wiring the CLI command requires editing `src/scitex_writer/_cli/__init__.py`, which is **1969 lines** (≫512). The line-limit hook blocks any edit to it, and a *partial* check-* extraction would leave it at ~1790 lines — still over the limit, forcing `REFACTORING.md` to stay (a permanent suspension = the "dodge" we want to avoid). Getting it under 512 is the full CLI split (the `writer-cli-split-refactor` card), too large to bundle here. **Proposing the CLI command + full `_cli` split as a focused follow-up PR.** The check is already usable via the script, MCP handler, and `checks.media_provenance()`.