### PR TITLE
fix(compile): fail loud on broken/missing yq instead of empty-path cascade

### DIFF
--- a/config/load_config.sh
+++ b/config/load_config.sh
@@ -26,6 +26,29 @@ echo_header() { echo_info "=== $1 ==="; }
 echo_warn() { echo -e "${YELLOW}WARN: $1${NC}"; }
 echo_error_soft() { echo -e "${RED}ERRO: $1${NC}"; }
 
+# Fail loud if yq is missing or broken BEFORE we read any config value. Every
+# path below is extracted with `yq`; a silently-failing yq (e.g. a .venv/bin/yq
+# whose Python shebang no longer resolves -> "bad interpreter") otherwise yields
+# EMPTY paths that cascade into `mkdir ''` / `tee ''` and a cryptic "Failed to
+# compile" far from the real cause. One clear error here beats 30 of those.
+_require_working_yq() {
+    if ! command -v yq &>/dev/null; then
+        echo_error "yq not found on PATH -- required to read the YAML config."
+        echo_error "  Install it (Go: https://github.com/mikefarah/yq) or add a working yq to PATH."
+        exit 1
+    fi
+    if ! yq --version >/dev/null 2>&1; then
+        local _yq_path _yq_err
+        _yq_path="$(command -v yq)"
+        _yq_err="$(yq --version 2>&1 | head -1)"
+        echo_error "yq is present ($_yq_path) but does NOT run: ${_yq_err}"
+        echo_error "  Likely a broken interpreter (e.g. a .venv/bin/yq whose Python shebang no longer resolves)."
+        echo_error "  Fix: repair/recreate the venv, or put a working yq first on PATH; then re-run."
+        exit 1
+    fi
+}
+_require_working_yq
+
 # Resolve dark mode from config BEFORE the load-cache guard, so `theme: dark`
 # ALWAYS applies -- even when CONFIG_LOADED is inherited (a cached re-source
 # must not silently render the PDF light; dark is an accessibility default).
@@ -164,6 +187,29 @@ else
     export SCITEX_WRITER_DARK_LINK_INTERNAL="$(yq -r '.dark_mode.link_internal' "$CONFIG_FILE")"
     export SCITEX_WRITER_DARK_LINK_CITATION="$(yq -r '.dark_mode.link_citation' "$CONFIG_FILE")"
     export SCITEX_WRITER_DARK_LINK_URL="$(yq -r '.dark_mode.link_url' "$CONFIG_FILE")"
+fi
+
+# Fail loud if a critical path came back empty. yq runs fine (probed above), so
+# an empty here means the KEY is missing from $CONFIG_FILE -- abort now with the
+# offending key rather than letting an empty path reach `mkdir ''` / `tee ''`.
+_stxw_missing=""
+for _stxw_pair in \
+    "paths.doc_root_dir:$SCITEX_WRITER_ROOT_DIR" \
+    "paths.doc_log_dir:$LOG_DIR" \
+    "paths.compiled_tex:$SCITEX_WRITER_COMPILED_TEX" \
+    "paths.compiled_pdf:$SCITEX_WRITER_COMPILED_PDF" \
+    "paths.base_tex:$SCITEX_WRITER_BASE_TEX"; do
+    _stxw_key="${_stxw_pair%%:*}"
+    _stxw_val="${_stxw_pair#*:}"
+    if [ -z "$_stxw_val" ] || [ "$_stxw_val" = "null" ]; then
+        _stxw_missing="${_stxw_missing} ${_stxw_key}"
+    fi
+done
+if [ -n "$_stxw_missing" ]; then
+    echo_error "config $CONFIG_FILE is missing required path key(s):${_stxw_missing}"
+    echo_error "  These resolve to empty paths and would break the compile (mkdir/tee on '')."
+    echo_error "  Check $CONFIG_FILE has a complete 'paths:' block (compare against the template)."
+    exit 1
 fi
 
 if [ "$CONFIG_LOADED" != "true" ]; then

--- a/scripts/shell/modules/check_dependancy_commands.sh
+++ b/scripts/shell/modules/check_dependancy_commands.sh
@@ -148,6 +148,21 @@ check_texcount() {
     return 0
 }
 
+check_yq() {
+    # yq is invoked directly by config/load_config.sh to read every YAML path.
+    # Probe EXECUTION (not mere presence): a present-but-broken yq (e.g. a
+    # .venv/bin/yq whose Python shebang no longer resolves -> "bad interpreter")
+    # must FAIL here, otherwise it passes the gate green and then silently
+    # yields empty paths during config load.
+    if ! command -v yq &>/dev/null || ! yq --version &>/dev/null 2>&1; then
+        echo "- yq"
+        echo "    - Go (recommended): https://github.com/mikefarah/yq"
+        echo "    - If present but failing: a broken venv interpreter -- repair the venv or put a working yq first on PATH"
+        return 1
+    fi
+    return 0
+}
+
 check_xlsx2csv() {
     if ! command -v xlsx2csv &>/dev/null && ! python3 -c "import xlsx2csv" &>/dev/null 2>&1; then
         echo "- xlsx2csv"
@@ -323,6 +338,10 @@ check_all_dependencies() {
         check_bibtexparser >"$temp_dir/req_bibtexparser" 2>&1
         echo $? >"$temp_dir/req_bibtexparser.exit"
     ) &
+    (
+        check_yq >"$temp_dir/req_yq" 2>&1
+        echo $? >"$temp_dir/req_yq.exit"
+    ) &
 
     # Run all optional checks in parallel
     (
@@ -350,7 +369,7 @@ check_all_dependencies() {
     # Collect required results with exit codes
     declare -A tool_status
     local exit_code
-    for tool in pdflatex bibtex latexdiff texcount xlsx2csv csv2latex parallel bibtexparser; do
+    for tool in pdflatex bibtex latexdiff texcount yq xlsx2csv csv2latex parallel bibtexparser; do
         exit_code=$(cat "$temp_dir/req_${tool}.exit" 2>/dev/null || echo 1)
         if [ "$exit_code" -eq 0 ]; then
             tool_status[$tool]="✓"
@@ -391,6 +410,7 @@ check_all_dependencies() {
         printf "      %-20s %s\n" "bibtex" "${tool_status[bibtex]}"
         printf "      %-20s %s\n" "latexdiff" "${tool_status[latexdiff]}"
         printf "      %-20s %s\n" "texcount" "${tool_status[texcount]}"
+        printf "      %-20s %s\n" "yq" "${tool_status[yq]}"
         printf "      %-20s %s\n" "xlsx2csv" "${tool_status[xlsx2csv]}"
         printf "      %-20s %s\n" "csv2latex" "${tool_status[csv2latex]}"
         printf "      %-20s %s\n" "parallel" "${tool_status[parallel]}"


### PR DESCRIPTION
## Summary
On the host (native LaTeX all green), `compile.sh -m` failed cryptically: `.venv/bin/yq`'s Python shebang didn't resolve → ~34 "bad interpreter: No such file or directory" lines, then every config path var came back **empty** → `mkdir ''` / `tee ''` → "Failed to compile TeX structure" far from the real cause. Two fail-loud gaps (carded `nv-writer-yq-failloud`, from neurovista dogfooding):

1. **`config/load_config.sh` trusted yq blindly.** Added a working-yq probe **before** reading any config (fails loud naming the broken yq + the likely-broken-interpreter cause + the fix), and a guard that aborts if a critical extracted path (`doc_root_dir`/`doc_log_dir`/`compiled_tex`/`compiled_pdf`/`base_tex`) is empty/null — instead of letting it reach `mkdir ''`/`tee ''`.
2. **`yq` wasn't in the dependency gate.** Added `check_yq` with an **execution** probe (`yq --version` exit 0), so a present-but-broken yq fails the gate instead of passing green.

## Verification
- `bash -n` clean on both files.
- With a broken-shebang `yq` stub on PATH, `load_config.sh` now prints a single clear error and exits 1 *before* any flood/empty-path cascade.
- Full pytest + audit gated by CI.

## Card
- nv-writer-yq-failloud

## Note (separate)
`config_shared.yaml` is referenced nowhere in the repo (template ships only the 3 doc-type configs) — not a regression, never implemented. Flagged for a possible future DRY-the-configs feature, out of scope here.