### PR TITLE
docs(skills): session learnings — dark mode, fail-loud compile, check-severity env vars

### DIFF
--- a/src/scitex_writer/_skills/scitex-writer/10_compilation.md
+++ b/src/scitex_writer/_skills/scitex-writer/10_compilation.md
@@ -13,7 +13,19 @@ tags: [scitex-writer-compilation]
 ./compile.sh manuscript --quiet    # Main manuscript
 ./compile.sh supplementary --quiet # Supplementary materials
 ./compile.sh revision --quiet      # Revision with tracked changes
+./compile.sh manuscript -dm        # Dark mode (-dm / --dark-mode): dark page, light text
 ```
+
+## Dark mode
+
+Three ways, highest precedence first: the `-dm` / `--dark-mode` compile flag
+> the `SCITEX_WRITER_DARK_MODE=true` env var > `theme: dark` in
+`config/config_<doctype>.yaml` (else light). It recolors the **page and text**
+of the PDF (style: `00_shared/latex_styles/dark_mode.tex`).
+
+Caveat: dark mode does **not** adapt figures — figure media are raster images
+with their own (usually white) backgrounds, so they render as light boxes on a
+dark page. Submission builds should use light mode (the default).
 
 ## Python API
 
@@ -92,3 +104,21 @@ The compile output includes word counts with comma-separated formatting and per-
 **Tables regenerating after removal**: Same issue — move source `.tex` and `.csv` files from `caption_and_media/` to `legacy/`.
 
 **Dark mode when env says false**: Check that `SCITEX_WRITER_DARK_MODE=false` is exported in the shell environment, not just set in a config file.
+
+**Compile aborts: "yq is present but does NOT run"**: config is read with `yq`;
+a broken `yq` (commonly a project `.venv/bin/yq` whose Python shebang no longer
+resolves → "bad interpreter") would otherwise yield empty paths and a cryptic
+`mkdir ''`/`tee ''` failure. The dependency check now probes `yq` for real and
+`load_config.sh` fails loud first. Fix: repair/recreate the venv, or put a
+working `yq` (Go build: https://github.com/mikefarah/yq) first on `PATH`.
+
+**Compile reports "did NOT produce a fresh PDF"**: the 3-pass engine records the
+output PDF's mtime and fails loud if no *newer* PDF was written — so a stale
+pre-existing PDF is never passed off as a successful build (e.g. when the LaTeX
+container can't mount). Fix the engine availability the error names; never trust
+a stale `manuscript.pdf`.
+
+**Dependency check shows a tool as missing even though the binary exists**: the
+check probes EXECUTION (`<tool> --version`), not mere presence — an
+unmountable LaTeX container or a broken shim correctly fails here rather than
+greenlighting a non-functional engine.

--- a/src/scitex_writer/_skills/scitex-writer/20_env-vars.md
+++ b/src/scitex_writer/_skills/scitex-writer/20_env-vars.md
@@ -22,10 +22,23 @@ tags: [scitex-writer-env-vars]
 |---|---|---|---|
 | `SCITEX_WRITER_ENGINE` | LaTeX engine (`pdflatex`, `xelatex`, `lualatex`). | `pdflatex` | string |
 | `SCITEX_WRITER_DRAFT_MODE` | Render manuscript in draft mode (faster, no figures). | `false` | bool |
-| `SCITEX_WRITER_DARK_MODE` | Render PDF with dark background (preview only). | `false` | bool |
+| `SCITEX_WRITER_DARK_MODE` | Render PDF with dark page + light text (preview only; equivalent to the `-dm`/`--dark-mode` flag and `theme: dark` config). Does NOT adapt figures — they stay light, so use light mode for submission. | `false` | bool |
 | `SCITEX_WRITER_VERBOSE_PDFLATEX` | Forward full pdflatex output to stderr. | `false` | bool |
 | `SCITEX_WRITER_VERBOSE_BIBTEX` | Forward full bibtex output to stderr. | `false` | bool |
 | `SCITEX_STYLE` | Citation / style override (shared with scitex-plt). | `default` | string |
+
+## Pre-compile / post-compile checks (severity)
+
+Each check resolves a severity; precedence is the CLI flag > the env var below >
+project `./config.yaml` > user `~/.scitex/writer/config.yaml` > the per-check
+default. Setting `off` disables a check; `warn` reports but exits 0; `error`
+exits non-zero.
+
+| Variable | Purpose | Default | Type |
+|---|---|---|---|
+| `SCITEX_WRITER_LINT_STRICT` | Tighten `check-limits` + `check-overflow` warnings to errors (the legacy strict toggle). | `false` | bool |
+| `SCITEX_WRITER_PAPER_SYMLINK` | Severity for the `paper -> .scitex/writer` symlink check (`off`/`warn`/`error`/`repair`). Private convention — default `warn`. | `warn` | enum |
+| `SCITEX_WRITER_MEDIA_PROVENANCE` | Severity for the media-symlink/provenance check on `caption_and_media/` (`off`/`warn`/`error`). Private convention — default `off`. | `off` | enum |
 
 ## Branding & naming
 


### PR DESCRIPTION
## Summary
Gives back learnings from dogfooding 2.21.0 into the shipped scitex-writer skill docs (`src/scitex_writer/_skills/scitex-writer/`). Documents **merged** behavior the docs were missing:

- **10_compilation.md** — dark mode (the `-dm`/`--dark-mode` flag + `theme:` config + precedence) and the figure-not-adapted caveat; new **Common Issues** for: the broken-`yq` loud abort (#160), the honest-compile fresh-PDF gate (#156), and the execution-probe dependency check (#156).
- **20_env-vars.md** — dark-mode caveat on the env row; a new **checks-severity** section (`SCITEX_WRITER_LINT_STRICT` / `_PAPER_SYMLINK` / `_MEDIA_PROVENANCE`) with the precedence ladder.

Only shipped behavior is documented. Intentionally omits not-yet-merged items (missing-figure fail-loud, caption-overflow handling, media-provenance CLI) — those get doc updates when they land.