### PR TITLE
fix(tables): render acronyms + math in csv->LaTeX (verbatim $/\, drop forced title-case)

### DIFF
--- a/scripts/python/csv_to_latex.py
+++ b/scripts/python/csv_to_latex.py
@@ -53,6 +53,18 @@ def escape_latex(text):
     return text
 
 
+def _is_verbatim(value) -> bool:
+    """True if a header/cell already carries explicit LaTeX or math.
+
+    A value containing ``$`` (math) or ``\\`` (a LaTeX command) is authored
+    intentionally — pass it through verbatim (no escaping, number-formatting,
+    or title-casing) so e.g. ``$R^2$``, ``$p$``, ``$N_{\\mathrm{perm}}$`` or
+    ``\\textit{r}`` render. Plain values are still escaped (safe). Rare literal
+    ``$`` in plain data must be escaped by the author as ``\\$``.
+    """
+    return "$" in str(value) or "\\" in str(value)
+
+
 def format_number(val):
     """Format numbers appropriately for LaTeX."""
     try:
@@ -166,10 +178,13 @@ def csv_to_latex(csv_file, output_file, caption=None, label=None, max_rows=30):
     # Header row
     headers = []
     for col in df.columns:
-        # Format header
-        header = escape_latex(col)
-        # Remove underscores and capitalize
-        header = header.replace("\\_", " ").title()
+        # Format header. Verbatim if it carries explicit LaTeX/math (e.g.
+        # "$R^2$"); otherwise escape + underscores->spaces. NOT title-cased —
+        # render as authored so acronyms survive ("ROC-AUC" stays "ROC-AUC").
+        if _is_verbatim(col):
+            header = str(col)
+        else:
+            header = escape_latex(col).replace("\\_", " ")
         headers.append(f"\\textbf{{{header}}}")
     lines.append(" & ".join(headers) + " \\\\")
     lines.append("\\midrule")
@@ -186,11 +201,15 @@ def csv_to_latex(csv_file, output_file, caption=None, label=None, max_rows=30):
             if str(val) == "...":
                 is_separator = True
 
-            # Format the value
+            # Format the value. Pass through verbatim if it carries explicit
+            # LaTeX/math ("$p<0.001$"); otherwise number-format + escape.
             if pd.notna(val):
                 if not is_separator:
-                    val = format_number(val)
-                    val = escape_latex(val)
+                    if _is_verbatim(val):
+                        val = str(val)
+                    else:
+                        val = format_number(val)
+                        val = escape_latex(val)
             else:
                 val = "--"  # Display for missing values
 

--- a/tests/scripts/python/test_csv_to_latex.py
+++ b/tests/scripts/python/test_csv_to_latex.py
@@ -459,6 +459,42 @@ class TestCsvToLatex:
         # Assert
         assert "truncated" in content.lower() or "omitted" in content.lower()
 
+    def test_csv_to_latex_preserves_acronym_header(self, tmp_path):
+        """Header acronyms are not title-cased (ROC-AUC stays ROC-AUC)."""
+        # Arrange
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text("ROC-AUC\n0.9")
+        output_file = tmp_path / "output.tex"
+        csv_to_latex(csv_file, output_file)
+        # Act
+        content = output_file.read_text()
+        # Assert
+        assert "\\textbf{ROC-AUC}" in content
+
+    def test_csv_to_latex_math_header_verbatim(self, tmp_path):
+        """A header carrying $...$ math is passed through unescaped."""
+        # Arrange
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text("$R^2$\n0.8")
+        output_file = tmp_path / "output.tex"
+        csv_to_latex(csv_file, output_file)
+        # Act
+        content = output_file.read_text()
+        # Assert
+        assert "\\textbf{$R^2$}" in content
+
+    def test_csv_to_latex_math_cell_verbatim(self, tmp_path):
+        """A cell carrying $...$ math is passed through unescaped."""
+        # Arrange
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text("stat\n$p<0.001$")
+        output_file = tmp_path / "output.tex"
+        csv_to_latex(csv_file, output_file)
+        # Act
+        content = output_file.read_text()
+        # Assert
+        assert "$p<0.001$" in content
+
 
 if __name__ == "__main__":
     pytest.main([os.path.abspath(__file__), "-v"])


### PR DESCRIPTION
## Summary
`csv_to_latex.py` made scientific tables un-renderable for two reasons (found dogfooding neurovista's Tables 2/3/4):
- headers were force-`.title()`-cased -> acronyms mangled (`AUC`->`Auc`, `ROC-AUC`->`Roc-Auc`);
- `escape_latex` escaped `$`/`^`/`\` in headers AND cells -> no math/italic stat symbols (`$R^2$`, `$p$`, `$N_{\mathrm{perm}}$`).

Fix:
- headers render AS AUTHORED (underscores->spaces, bold) with NO `.title()` -- acronyms survive;
- a header/cell containing `$` or `\` is passed through VERBATIM (no escape / number-format / title) so math + LaTeX render; plain values are still escaped (safe).

No new csv convention: write acronyms plainly (`ROC-AUC`) and stat symbols in `$...$`. Rare literal `$` in plain data -> escape as `\$`.

## Behavior change
Existing tables' headers are NO LONGER auto-Title-Cased -- they render exactly as written in the csv. Flagging for review; that is the point of the fix but it changes existing tables' header casing.

## Verification
Local (fresh venv + pandas): ROC-AUC preserved as `\textbf{ROC-AUC}`; `$R^2$` header + `$p<0.001$` cell verbatim; plain `A & B` still escaped; `mean value` -> `\textbf{mean value}` (the behavior change). Added 3 regression tests; existing csv_to_latex tests still pass. Full suite gated by CI.

Unblocks neurovista Table 2 (`N_perm` math), Table 3 (ROC-AUC), Table 4 (italic r/R^2/p).