### PR TITLE
feat(system-deps): scitex-writer SSoT for LaTeX apt deps (scitex_dev.system_deps provider)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,9 @@ scitex-writer = "scitex_writer"
 [project.entry-points."scitex_dev.skills"]
 scitex-writer = "scitex_writer"
 
+[project.entry-points."scitex_dev.system_deps"]
+scitex-writer = "scitex_writer._system_deps:provide"
+
 [project.urls]
 Homepage = "https://github.com/ywatanabe1989/scitex-writer"
 Documentation = "https://scitex-writer.readthedocs.io"

--- a/src/scitex_writer/_system_deps.py
+++ b/src/scitex_writer/_system_deps.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_system_deps.py
+
+"""scitex-writer's native system (apt) dependency provider.
+
+scitex-writer is the single source of truth for its own LaTeX apt packages —
+an image build installs from this list instead of hardcoding it. The set
+mirrors the proven scripts/containers/texlive.def recipe.
+
+Registered as a ``scitex_dev.system_deps`` entry-point so
+``scitex-dev ecosystem system-deps`` can aggregate it across leaves; the
+uniform ``scitex-writer dev system-deps list|install`` CLI verb wraps it (added
+with the _cli split). Standalone interim emit (no scitex-dev needed)::
+
+    apt-get install -y --no-install-recommends $(python -m scitex_writer._system_deps)
+
+NOTE: bibliography is the natbib + bibtex path (texlive-bibtex-extra), matching
+texlive.def -- NOT biber/biblatex. NOTE: a manuscript using `bashful` must
+compile with ``--shell-escape`` (a compile flag, not an apt package).
+"""
+
+from __future__ import annotations
+
+# (package, purpose). SSoT LaTeX apt set -- mirror of scripts/containers/texlive.def.
+_PACKAGES: list[tuple[str, str]] = [
+    ("texlive-latex-base", "core LaTeX"),
+    ("texlive-latex-recommended", "recommended LaTeX packages"),
+    ("texlive-latex-extra", "extra LaTeX packages (pdfpages, tcolorbox, csvsimple, makecell, ...)"),
+    ("texlive-fonts-recommended", "recommended fonts"),
+    ("texlive-fonts-extra", "extra fonts"),
+    ("texlive-science", "siunitx + science math packages"),
+    ("texlive-pictures", "tikz / pgfplots"),
+    ("texlive-publishers", "publisher classes (elsarticle, ...)"),
+    ("texlive-luatex", "LuaLaTeX engine"),
+    ("texlive-xetex", "XeLaTeX engine"),
+    ("texlive-bibtex-extra", "BibTeX + natbib bibliography path"),
+    ("texlive-lang-english", "English language/hyphenation support"),
+    ("texlive-plain-generic", "plain/generic packages"),
+    ("latexmk", "compile orchestrator"),
+    ("latexdiff", "tracked-changes (revision) diff"),
+    ("chktex", "LaTeX linter"),
+    ("texlive-extra-utils", "texcount and other LaTeX utilities"),
+    ("parallel", "GNU parallel -- figure/table conversion + dependency check"),
+]
+
+#: Apt package names, in install order (the SSoT list).
+APT_PACKAGES: list[str] = [pkg for pkg, _ in _PACKAGES]
+
+
+def provide():
+    """Return this leaf's system deps for the ``scitex_dev.system_deps`` group.
+
+    ``SystemDepSpec`` is imported lazily from scitex_dev so this module stays
+    importable (and ``python -m scitex_writer._system_deps`` works) even where
+    scitex-dev isn't installed -- the aggregator that calls ``provide()`` runs
+    in an environment that provides scitex_dev.
+    """
+    from scitex_dev.system_deps import SystemDepSpec
+
+    return [
+        SystemDepSpec(package=pkg, purpose=purpose, provider="scitex-writer")
+        for pkg, purpose in _PACKAGES
+    ]
+
+
+def _main() -> int:
+    # One apt package name per line (consumed by an image %post that runs its
+    # own apt). The `scitex-writer dev system-deps list` verb wraps this.
+    print("\n".join(APT_PACKAGES))
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(_main())
+
+# EOF

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -29,6 +29,7 @@ CROSS_PACKAGE_IMPORTS = [
     "scitex_dev.cli",
     "scitex_dev.decorators",
     "scitex_dev.skills",
+    "scitex_dev.system_deps",
     "scitex_dev.types",
     "scitex_scholar",
     "scitex_ui",

--- a/tests/scitex_writer/test__system_deps.py
+++ b/tests/scitex_writer/test__system_deps.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: src/scitex_writer/_system_deps.py
+
+import pytest
+
+from scitex_writer._system_deps import APT_PACKAGES, _main, _PACKAGES
+
+
+def test_apt_packages_nonempty():
+    # Arrange
+    # Act
+    # Assert
+    assert APT_PACKAGES
+
+
+def test_apt_packages_has_core_latex():
+    # Arrange
+    # Act
+    # Assert
+    assert "texlive-latex-base" in APT_PACKAGES
+
+
+def test_apt_packages_has_parallel():
+    # Arrange
+    # Act
+    # Assert
+    assert "parallel" in APT_PACKAGES
+
+
+def test_apt_packages_match_package_table():
+    # Arrange
+    expected = [pkg for pkg, _ in _PACKAGES]
+    # Act
+    # Assert
+    assert APT_PACKAGES == expected
+
+
+def test_main_emits_one_package_per_line(capsys):
+    # Arrange
+    # Act
+    _main()
+    # Assert
+    assert capsys.readouterr().out.splitlines() == APT_PACKAGES
+
+
+def test_provide_tags_every_dep_with_writer_provider():
+    # Arrange
+    pytest.importorskip("scitex_dev.system_deps")
+    from scitex_writer._system_deps import provide
+
+    # Act
+    specs = provide()
+    # Assert
+    assert all(s.provider == "scitex-writer" for s in specs)


### PR DESCRIPTION
## Summary
Makes scitex-writer the single source of truth for its LaTeX apt packages so an image build installs from this list instead of hardcoding a duplicate (the nested-SIF `containers install texlive` path can't mount in unprivileged agent containers). Card: `scitex-writer-system-deps-provider`.

- `src/scitex_writer/_system_deps.py`: `APT_PACKAGES` (SSoT) + `provide() -> list[SystemDepSpec]` for the `scitex_dev.system_deps` entry-point group, mirroring the proven `scripts/containers/texlive.def` set + GNU `parallel`. Plus `python -m scitex_writer._system_deps` (one apt name/line).
- `pyproject.toml`: registers the `scitex_dev.system_deps` entry-point.

Image %post (interim until the CLI verb lands):
```
apt-get install -y --no-install-recommends $(python -m scitex_writer._system_deps)
```

## Flags for review
- **`provide()` coded to the documented `SystemDepSpec(package, purpose, provider)` shape** — the merged `scitex_dev.system_deps` contract wasn't readable from my env (older installed scitex_dev; scitex-dev agent down). The `provide()` test skips if the contract isn't importable, runs (and surfaces any field mismatch) where it is. Verify against the merged contract.
- **`dev system-deps list|install` verb deferred** to scitex-dev's `_cli` split (the 1968-line `_cli/__init__.py` trips the line-limit hook). The `python -m` emit is the interim surface.
- **bibtex vs biber:** mirrors `texlive.def` (natbib + bibtex via `texlive-bibtex-extra`, explicitly *not* biber). The operator push mentioned `biber` — confirm which is authoritative; trivial to add.

## Verification
`python -m scitex_writer._system_deps` emits the 18-package list correctly; `_system_deps.py` is pure stdlib (`py_compile` clean). Tests added (single-assert, AAA). Full suite gated by CI.