### PR TITLE
fix(compile): enforce provenance/symlink checks at compile time

### DIFF
--- a/scripts/shell/compile_manuscript.sh
+++ b/scripts/shell/compile_manuscript.sh
@@ -257,6 +257,16 @@ main() {
     "$PROJECT_ROOT/scripts/shell/modules/check_dependancy_commands.sh"
     log_stage_end "Dependency Check"
 
+    # Provenance / symlink checks (paper_symlink, media_provenance) at their
+    # configured severity -- an error-level violation aborts before compile work
+    # (off/warn never block).
+    log_stage_start "Provenance Checks"
+    if ! "$PROJECT_ROOT/scripts/shell/modules/run_provenance_checks.sh"; then
+        log_error "Provenance check failed (a check is set to error and found a violation)"
+        exit 1
+    fi
+    log_stage_end "Provenance Checks"
+
     # Merge bibliography files if multiple exist
     log_stage_start "Bibliography Merge"
     "$PROJECT_ROOT/scripts/shell/modules/merge_bibliographies.sh"

--- a/scripts/shell/compile_revision.sh
+++ b/scripts/shell/compile_revision.sh
@@ -219,6 +219,14 @@ parse_arguments() {
     fi
     log_stage_end "Dependency Check"
 
+    # Provenance / symlink checks at their configured severity (error blocks).
+    log_stage_start "Provenance Checks"
+    if ! ./scripts/shell/modules/run_provenance_checks.sh; then
+        echo -e "${RED}ERRO: Provenance check failed (a check is set to error and found a violation)${NC}"
+        exit 1
+    fi
+    log_stage_end "Provenance Checks"
+
     # 2. Merge bibliography files if multiple exist
     log_stage_start "Bibliography Merge"
     ./scripts/shell/modules/merge_bibliographies.sh

--- a/scripts/shell/compile_supplementary.sh
+++ b/scripts/shell/compile_supplementary.sh
@@ -226,6 +226,14 @@ main() {
     ./scripts/shell/modules/check_dependancy_commands.sh
     log_stage_end "Dependency Check"
 
+    # Provenance / symlink checks at their configured severity (error blocks).
+    log_stage_start "Provenance Checks"
+    if ! ./scripts/shell/modules/run_provenance_checks.sh; then
+        log_error "Provenance check failed (a check is set to error and found a violation)"
+        exit 1
+    fi
+    log_stage_end "Provenance Checks"
+
     # Merge bibliography files if multiple exist
     log_stage_start "Bibliography Merge"
     ./scripts/shell/modules/merge_bibliographies.sh

--- a/scripts/shell/modules/run_provenance_checks.sh
+++ b/scripts/shell/modules/run_provenance_checks.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# File: scripts/shell/modules/run_provenance_checks.sh
+#
+# Run the config-driven provenance/symlink checks at their RESOLVED severity
+# (off|warn|error via CLI/env/config). Each underlying script
+# (scripts/python/check_{paper_symlink,media_provenance}.py) resolves its own
+# level and exits non-zero ONLY at error-level with a violation. So:
+#   off   -> no-op (exit 0)
+#   warn  -> reports, exit 0 (does NOT block the compile)
+#   error -> exit 1 (blocks the compile, fail-loud)
+# This is what makes `paper_symlink: error` / `media_provenance: error` actually
+# enforce at compile time -- previously the compile ran neither check.
+#
+# Returns the worst exit code across the checks (0 unless a check errored).
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Honor the PROJECT_ROOT the caller (compile_*.sh) already resolved + exported;
+# fall back to the install-relative root when run standalone.
+PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$THIS_DIR/../../.." && pwd)}"
+PY="${SCITEX_WRITER_PYTHON:-python3}"
+
+rc=0
+for chk in check_paper_symlink check_media_provenance; do
+    script="$THIS_DIR/../../python/${chk}.py"
+    [ -f "$script" ] || continue
+    "$PY" "$script" "$PROJECT_ROOT" || rc=$?
+done
+
+exit "$rc"


### PR DESCRIPTION
## Summary
- The `paper_symlink` and `media_provenance` checks resolve a severity (off|warn|error) from CLI/env/config, but the **shell compile pipeline ran neither** — so `media_provenance: error` / `paper_symlink: error` were **silent no-ops at compile time**. A manuscript could ship with raw (non script-generated) media despite the config demanding `error`.
- Adds a **Provenance Checks** stage after the Dependency Check in `compile_{manuscript,supplementary,revision}.sh`, driven by a new `modules/run_provenance_checks.sh`.
- The module runs both check scripts at their resolved severity and returns the worst exit code: `off` → no-op, `warn` → reports but does not block, `error` → aborts the compile (fail-loud, before any pdflatex work). Missing check scripts are skipped so projects predating the checks still compile.

## Scope
Shell compile gate only (the `./compile.sh` path consumers actually hit). The Python `validate_before_compile` API path is intentionally left for scitex-dev's validator-unification (D) track to avoid duplicating the severity plumbing.

## Verification
- `bash -n` clean on the new module + all three compile scripts.
- Module exits 0 when no violations.
- `check_media_provenance.py <proj> --level error --require-under-scripts` exits 1 on a raw-file media violation → module exits 1 → compile aborts.

## Test plan
- [ ] CI: audit + matrix green
- [ ] Host: real compile of a project with a raw-file media + `media_provenance: error` aborts at the Provenance stage