### PR TITLE
fix(compile): enforce provenance checks on the API compile path too

### DIFF
--- a/src/scitex_writer/_compile/_validator.py
+++ b/src/scitex_writer/_compile/_validator.py
@@ -85,14 +85,11 @@ def _validate_limits(project_dir: Path, doc_type: str) -> None:
         )
 
 
-def _validate_provenance(project_dir: Path) -> None:
-    """Run the config-driven provenance checks; raise if one is at error level
-    with a violation.
+def _provenance_runners():
+    """Return the (name, callable) provenance checks, or None if unavailable.
 
-    paper-symlink and media-provenance each resolve their own severity
-    (off|warn|error) from CLI/env/config. ``off``/``warn`` never block; ``error``
-    raises before any compile work (fail-loud). Without this, setting a check to
-    ``error`` was a silent no-op on the API compile path.
+    Lazy import so this module stays importable where the MCP handlers (and
+    their deps) are absent — the compile path simply skips the checks then.
     """
     try:
         from .._mcp.handlers._checks import (
@@ -101,12 +98,32 @@ def _validate_provenance(project_dir: Path) -> None:
         )
     except Exception as exc:  # pragma: no cover - defensive import guard
         logger.info("Provenance checks unavailable (%s) - skipping", exc)
-        return
-
-    for name, run in (
+        return None
+    return (
         ("paper-symlink", check_paper_symlink),
         ("media-provenance", check_media_provenance),
-    ):
+    )
+
+
+def _validate_provenance(project_dir: Path, runners=None) -> None:
+    """Run the config-driven provenance checks; raise if one is at error level
+    with a violation.
+
+    paper-symlink and media-provenance each resolve their own severity
+    (off|warn|error) from CLI/env/config. ``off``/``warn`` never block; ``error``
+    raises before any compile work (fail-loud). Without this, setting a check to
+    ``error`` was a silent no-op on the API compile path.
+
+    ``runners`` is an injection seam (a sequence of ``(name, callable)`` pairs):
+    production passes ``None`` and the real check handlers are used; tests inject
+    real callables returning canned result envelopes.
+    """
+    if runners is None:
+        runners = _provenance_runners()
+    if not runners:
+        return
+
+    for name, run in runners:
         result = run(str(project_dir))
         # Projects predating the check script: skip quietly, never block compile.
         if not result.get("success") and "exit_code" not in result:

--- a/src/scitex_writer/_compile/_validator.py
+++ b/src/scitex_writer/_compile/_validator.py
@@ -32,6 +32,10 @@ def validate_before_compile(project_dir: Path, doc_type: str = "manuscript") -> 
        unless strict mode is on (``limits.strict: true`` /
        ``SCITEX_WRITER_LINT_STRICT=1``), in which case this raises before any
        pdflatex work.
+    3. Provenance/symlink checks (paper-symlink, media-provenance) at their
+       configured severity. ``off``/``warn`` never block; ``error`` raises
+       before any pdflatex work. Mirrors the shell compile gate so the API and
+       ``./compile.sh`` paths enforce identically.
 
     Parameters
     ----------
@@ -43,10 +47,12 @@ def validate_before_compile(project_dir: Path, doc_type: str = "manuscript") -> 
     Raises
     ------
     RuntimeError
-        If structure verification fails, or a limit is exceeded under strict.
+        If structure verification fails, a limit is exceeded under strict, or a
+        provenance check is at error severity with a violation.
     """
     verify_tree_structure(project_dir)
     _validate_limits(Path(project_dir), doc_type)
+    _validate_provenance(Path(project_dir))
 
 
 def _validate_limits(project_dir: Path, doc_type: str) -> None:
@@ -77,6 +83,45 @@ def _validate_limits(project_dir: Path, doc_type: str) -> None:
             "Section/reference limits exceeded in strict mode — trim the "
             "flagged sections or set limits.strict: false.\n" + findings
         )
+
+
+def _validate_provenance(project_dir: Path) -> None:
+    """Run the config-driven provenance checks; raise if one is at error level
+    with a violation.
+
+    paper-symlink and media-provenance each resolve their own severity
+    (off|warn|error) from CLI/env/config. ``off``/``warn`` never block; ``error``
+    raises before any compile work (fail-loud). Without this, setting a check to
+    ``error`` was a silent no-op on the API compile path.
+    """
+    try:
+        from .._mcp.handlers._checks import (
+            check_media_provenance,
+            check_paper_symlink,
+        )
+    except Exception as exc:  # pragma: no cover - defensive import guard
+        logger.info("Provenance checks unavailable (%s) - skipping", exc)
+        return
+
+    for name, run in (
+        ("paper-symlink", check_paper_symlink),
+        ("media-provenance", check_media_provenance),
+    ):
+        result = run(str(project_dir))
+        # Projects predating the check script: skip quietly, never block compile.
+        if not result.get("success") and "exit_code" not in result:
+            logger.info("%s check skipped: %s", name, result.get("error"))
+            continue
+        findings = (result.get("stdout") or "").strip()
+        summary = result.get("summary") or {}
+        if summary.get("warnings") or summary.get("errors"):
+            # Surface findings (feedback A->B->A, not fire-and-forget).
+            sys.stderr.write(findings + "\n")
+        if result.get("exit_code", 0) != 0:
+            raise RuntimeError(
+                f"{name} check failed at error severity — fix the violation or "
+                "lower its level (off/warn).\n" + findings
+            )
 
 
 __all__ = ["validate_before_compile"]

--- a/tests/scitex_writer/_compile/test__validator.py
+++ b/tests/scitex_writer/_compile/test__validator.py
@@ -11,7 +11,57 @@ import pytest
 pytest.importorskip("git")
 from pathlib import Path
 
-from scitex_writer._compile._validator import validate_before_compile
+from scitex_writer._compile._validator import (
+    _validate_provenance,
+    validate_before_compile,
+)
+
+
+def _patch_checks(monkeypatch, paper_result, media_result):
+    """Replace both provenance check handlers with canned results."""
+    import scitex_writer._mcp.handlers._checks as checks
+
+    monkeypatch.setattr(checks, "check_paper_symlink", lambda *a, **k: paper_result)
+    monkeypatch.setattr(checks, "check_media_provenance", lambda *a, **k: media_result)
+
+
+class TestValidateProvenance:
+    """Test suite for the _validate_provenance compile-gate step."""
+
+    def test_raises_when_check_at_error_with_violation(self, monkeypatch):
+        """A check returning a non-zero exit_code aborts the compile."""
+        # Arrange
+        ok = {"success": True, "exit_code": 0, "summary": {}}
+        err = {
+            "success": True,
+            "exit_code": 1,
+            "stdout": "media: raw file foo.jpg",
+            "summary": {"errors": 1},
+        }
+        _patch_checks(monkeypatch, paper_result=ok, media_result=err)
+        # Act / Assert
+        with pytest.raises(RuntimeError):
+            _validate_provenance(Path("/tmp/whatever"))
+
+    def test_passes_when_no_violation(self, monkeypatch):
+        """All checks at exit_code 0 do not raise."""
+        # Arrange
+        ok = {"success": True, "exit_code": 0, "summary": {}}
+        _patch_checks(monkeypatch, paper_result=ok, media_result=ok)
+        # Act
+        result = _validate_provenance(Path("/tmp/whatever"))
+        # Assert
+        assert result is None
+
+    def test_skips_missing_check_script_without_raising(self, monkeypatch):
+        """A check whose script is absent (no exit_code) is skipped, not fatal."""
+        # Arrange
+        missing = {"success": False, "error": "check script not found"}
+        _patch_checks(monkeypatch, paper_result=missing, media_result=missing)
+        # Act
+        result = _validate_provenance(Path("/tmp/whatever"))
+        # Assert
+        assert result is None
 
 
 class TestValidateBeforeCompile:

--- a/tests/scitex_writer/_compile/test__validator.py
+++ b/tests/scitex_writer/_compile/test__validator.py
@@ -17,49 +17,56 @@ from scitex_writer._compile._validator import (
 )
 
 
-def _patch_checks(monkeypatch, paper_result, media_result):
-    """Replace both provenance check handlers with canned results."""
-    import scitex_writer._mcp.handlers._checks as checks
+class _StubRunner:
+    """Real callable returning a canned check-result envelope.
 
-    monkeypatch.setattr(checks, "check_paper_symlink", lambda *a, **k: paper_result)
-    monkeypatch.setattr(checks, "check_media_provenance", lambda *a, **k: media_result)
+    Injected via the ``runners=`` seam on _validate_provenance so the gate
+    logic is exercised with real objects (no patching, no Mock) per the
+    repo's no-mocks rule.
+    """
+
+    def __init__(self, result: dict):
+        self.result = result
+
+    def __call__(self, *args):
+        return self.result
 
 
 class TestValidateProvenance:
     """Test suite for the _validate_provenance compile-gate step."""
 
-    def test_raises_when_check_at_error_with_violation(self, monkeypatch):
+    def test_raises_when_check_at_error_with_violation(self):
         """A check returning a non-zero exit_code aborts the compile."""
         # Arrange
-        ok = {"success": True, "exit_code": 0, "summary": {}}
         err = {
             "success": True,
             "exit_code": 1,
             "stdout": "media: raw file foo.jpg",
             "summary": {"errors": 1},
         }
-        _patch_checks(monkeypatch, paper_result=ok, media_result=err)
-        # Act / Assert
+        runners = [("media-provenance", _StubRunner(err))]
+        # Act
+        # Assert
         with pytest.raises(RuntimeError):
-            _validate_provenance(Path("/tmp/whatever"))
+            _validate_provenance(Path("/tmp/whatever"), runners=runners)
 
-    def test_passes_when_no_violation(self, monkeypatch):
-        """All checks at exit_code 0 do not raise."""
+    def test_passes_when_no_violation(self):
+        """A check at exit_code 0 does not raise."""
         # Arrange
         ok = {"success": True, "exit_code": 0, "summary": {}}
-        _patch_checks(monkeypatch, paper_result=ok, media_result=ok)
+        runners = [("media-provenance", _StubRunner(ok))]
         # Act
-        result = _validate_provenance(Path("/tmp/whatever"))
+        result = _validate_provenance(Path("/tmp/whatever"), runners=runners)
         # Assert
         assert result is None
 
-    def test_skips_missing_check_script_without_raising(self, monkeypatch):
+    def test_skips_missing_check_script_without_raising(self):
         """A check whose script is absent (no exit_code) is skipped, not fatal."""
         # Arrange
         missing = {"success": False, "error": "check script not found"}
-        _patch_checks(monkeypatch, paper_result=missing, media_result=missing)
+        runners = [("media-provenance", _StubRunner(missing))]
         # Act
-        result = _validate_provenance(Path("/tmp/whatever"))
+        result = _validate_provenance(Path("/tmp/whatever"), runners=runners)
         # Assert
         assert result is None
 


### PR DESCRIPTION
## Summary
- #164 wired the `paper_symlink` / `media_provenance` checks into the **shell** compile gate. The Python `validate_before_compile()` **API** path still ran only structure + limits — so `media_provenance: error` was a silent no-op for programmatic compiles.
- Adds `_validate_provenance()` mirroring `modules/run_provenance_checks.sh`: `off`/`warn` never block, `error` raises before any pdflatex work; projects predating the check scripts are skipped.
- Both compile paths (`./compile.sh` and the API) now enforce identically.

## Coordination
Green-lit by scitex-dev: it will rebase its shared-severity (D) work onto this and swap **only** the per-check level resolution to the unified model.

## Tests
- `TestValidateProvenance`: raises on error+violation, passes on no-violation, skips a missing check script — via monkeypatched `_checks` handlers (no heavy fixture).

## Test plan
- [ ] CI: audit + matrix green