### PR TITLE
feat(system-deps): add biber alongside bibtex (keep-both)

### DIFF
--- a/src/scitex_writer/_system_deps.py
+++ b/src/scitex_writer/_system_deps.py
@@ -15,9 +15,11 @@ with the _cli split). Standalone interim emit (no scitex-dev needed)::
 
     apt-get install -y --no-install-recommends $(python -m scitex_writer._system_deps)
 
-NOTE: bibliography is the natbib + bibtex path (texlive-bibtex-extra), matching
-texlive.def -- NOT biber/biblatex. NOTE: a manuscript using `bashful` must
-compile with ``--shell-escape`` (a compile flag, not an apt package).
+NOTE: bibtex (texlive-bibtex-extra) is the default natbib bibliography path,
+matching texlive.def. ``biber`` is also included so biblatex-based manuscripts
+compile out of the box -- it does NOT change the default engine (an
+operator/config choice). NOTE: a manuscript using `bashful` must compile with
+``--shell-escape`` (a compile flag, not an apt package).
 """
 
 from __future__ import annotations
@@ -34,7 +36,8 @@ _PACKAGES: list[tuple[str, str]] = [
     ("texlive-publishers", "publisher classes (elsarticle, ...)"),
     ("texlive-luatex", "LuaLaTeX engine"),
     ("texlive-xetex", "XeLaTeX engine"),
-    ("texlive-bibtex-extra", "BibTeX + natbib bibliography path"),
+    ("texlive-bibtex-extra", "BibTeX + natbib bibliography path (default)"),
+    ("biber", "Biber backend for biblatex-based manuscripts (non-default)"),
     ("texlive-lang-english", "English language/hyphenation support"),
     ("texlive-plain-generic", "plain/generic packages"),
     ("latexmk", "compile orchestrator"),

--- a/tests/scitex_writer/test__system_deps.py
+++ b/tests/scitex_writer/test__system_deps.py
@@ -28,6 +28,14 @@ def test_apt_packages_has_parallel():
     assert "parallel" in APT_PACKAGES
 
 
+def test_apt_packages_has_both_bibtex_and_biber():
+    # Arrange
+    # Act
+    # Assert: keep-both -- bibtex is the default natbib path, biber lets
+    # biblatex-based projects compile (neurovista coordination, 2026-06-26).
+    assert {"texlive-bibtex-extra", "biber"} <= set(APT_PACKAGES)
+
+
 def test_apt_packages_match_package_table():
     # Arrange
     expected = [pkg for pkg, _ in _PACKAGES]


### PR DESCRIPTION
## Summary
- bibtex (`texlive-bibtex-extra`) stays the **default** natbib bibliography path matching `texlive.def`.
- Adds the `biber` apt package so **biblatex-based** manuscripts compile out of the box.
- Engine-neutral: does **not** change the default engine (an operator/config choice). The list goes 18 → 19; scitex-dev's aggregator dedups providers, so no contract change.

## Coordination
- neurovista: bibtex for their natbib manuscript (biblatex blocks commented out); recommended keep-both.
- scitex-dev: ratified field shape; expects 19 pkgs after this lands.

## Verification
- `scitex-dev linter check-files` clean on source + test.
- `python -m scitex_writer._system_deps` emits both `texlive-bibtex-extra` and `biber`.

## Test plan
- [ ] CI: audit + matrix green