### PR TITLE
fix(compile): latexmk engine swallowed its real exit code (fail-loud)

### DIFF
--- a/scripts/shell/modules/engines/compile_latexmk.sh
+++ b/scripts/shell/modules/engines/compile_latexmk.sh
@@ -71,9 +71,16 @@ compile_with_latexmk() {
         echo_info "    Timeout: ${SCITEX_WRITER_COMPILE_TIMEOUT}s"
     fi
 
-    # Run latexmk with properly quoted array expansion
-    local output=$($timeout_prefix $latexmk_cmd "${opts[@]}" "$tex_file" 2>&1 | grep -v "gocryptfs not found")
+    # Run latexmk with properly quoted array expansion.
+    # Capture latexmk's REAL exit code, then filter the output for display in a
+    # SEPARATE step. Piping latexmk straight into `grep` and reading `$?` would
+    # capture grep's exit, not latexmk's: a failed build still prints output, so
+    # grep exits 0 and the engine falsely reports success -- masking the failure
+    # and letting cleanup keep a stale PDF (the soul.sty silent-failure bug).
+    local output
+    output=$($timeout_prefix $latexmk_cmd "${opts[@]}" "$tex_file" 2>&1)
     local exit_code=$?
+    output=$(printf '%s\n' "$output" | grep -v "gocryptfs not found")
 
     # Check for timeout (exit code 124)
     if [ $exit_code -eq 124 ]; then

--- a/tests/scripts/shell/modules/engines/test_compile_latexmk.sh
+++ b/tests/scripts/shell/modules/engines/test_compile_latexmk.sh
@@ -40,9 +40,55 @@ assert_file_exists() {
     fi
 }
 
-# Add your tests here
-test_placeholder() {
-    echo "TODO: Add tests for compile_latexmk.sh"
+REPO_ROOT="$(realpath "$THIS_DIR/../../../../..")"
+MODULE="$REPO_ROOT/scripts/shell/modules/engines/compile_latexmk.sh"
+
+# Regression: a FAILING latexmk must make compile_with_latexmk return non-zero.
+# The original code read `exit_code=$?` after `latexmk ... | grep`, capturing
+# grep's exit (0, since a failed build still prints output) and falsely
+# reporting success -- which let cleanup keep a stale PDF (soul.sty silent
+# failure). This guards the fix: real latexmk exit code must propagate.
+test_failing_latexmk_propagates_nonzero() {
+    ((TESTS_RUN++))
+    local desc="failing latexmk -> compile_with_latexmk returns non-zero"
+    local workdir
+    workdir="$(mktemp -d)"
+    # Stub `latexmk` that PRINTS output (like a real failed build) then exits 1.
+    cat >"$workdir/latexmk" <<'STUB'
+#!/bin/bash
+echo "! LaTeX Error: File 'soul.sty' not found."
+echo "Emergency stop."
+exit 12
+STUB
+    chmod +x "$workdir/latexmk"
+
+    # Minimal logging shims so the module is callable in isolation.
+    echo_info() { :; }; echo_error() { :; }; echo_success() { :; }
+    echo_warning() { :; }; log_info() { :; }
+    export -f echo_info echo_error echo_success echo_warning log_info 2>/dev/null
+
+    # Sourcing the engine transitively loads config (command_switching.src);
+    # give it the doc-type/root it expects, mirroring a real invocation.
+    export SCITEX_WRITER_DOC_TYPE="${SCITEX_WRITER_DOC_TYPE:-manuscript}"
+    export PROJECT_ROOT="${PROJECT_ROOT:-$REPO_ROOT}"
+    # shellcheck disable=SC1090
+    source "$MODULE"
+    # Force the stub as the latexmk binary, non-auto so a fatal error returns 1.
+    get_cmd_latexmk() { echo "$workdir/latexmk"; }
+    SCITEX_WRITER_ENGINE="latexmk"
+    LOG_DIR="$workdir"
+
+    compile_with_latexmk "$workdir/doc.tex" >/dev/null 2>&1
+    local rc=$?
+    rm -rf "$workdir"
+
+    if [ "$rc" -ne 0 ]; then
+        echo -e "${GREEN}✓${NC} $desc (rc=$rc)"
+        ((TESTS_PASSED++))
+    else
+        echo -e "${RED}✗${NC} $desc (rc=$rc, expected non-zero)"
+        ((TESTS_FAILED++))
+    fi
 }
 
 # Run tests
@@ -50,7 +96,7 @@ main() {
     echo "Testing: compile_latexmk.sh"
     echo "========================================"
 
-    test_placeholder
+    test_failing_latexmk_propagates_nonzero
 
     echo "========================================"
     echo "Results: $TESTS_PASSED/$TESTS_RUN passed"


### PR DESCRIPTION
## Summary
- `compile_with_latexmk` read `exit_code=$?` **after** a `latexmk ... | grep -v "gocryptfs not found"` pipe, so it captured **grep's** exit, not latexmk's. A failed build still prints output → grep exits 0 → the engine reported **success** → `cleanup()` kept the **stale PDF** instead of deleting it.
- This silently masked real LaTeX failures. Found via neurovista dogfooding: a missing `soul.sty` made the in-container build fail, but a stale PDF made it look successful the whole time.
- Fix: capture latexmk's exit code directly, then filter output for display separately (mirrors the **tectonic** engine; **3pass** already used `${PIPESTATUS[0]}`). latexmk was the lone offender.

## Verification
- Behavioral proof: stub that prints then `exit 1` → old pattern yields `exit_code=0` (masked), new yields `exit_code=1` (fail-loud).
- Replaced the placeholder engine test with a regression test (stub latexmk exits non-zero → `compile_with_latexmk` returns non-zero); passes locally.
- `bash -n` clean.

## Note
Separate from but related to the texlive `soul.sty` gap, which is a container-image drift (soul ∈ `texlive-plain-generic`, already in the system-deps SSoT) resolved by the recipe cutover — not a code change here.

## Test plan
- [ ] CI green (shell-only change; no Python touched)