### PR TITLE
fix(preamble): load lineno before siunitx (frontmatter number error)

### DIFF
--- a/00_shared/latex_styles/packages.tex
+++ b/00_shared/latex_styles/packages.tex
@@ -12,6 +12,11 @@
 % Include all common color options: table (for colortbl), svgnames (for tcolorbox)
 \usepackage[table,svgnames]{xcolor}
 
+%% Line numbers — MUST load before siunitx: lineno patches the output routine
+%% with \interlinepenalty\linenopenalty, which siunitx's number parser otherwise
+%% chokes on ("Invalid number" at \end{frontmatter}).
+\usepackage{lineno}
+
 %% Mathematics
 \usepackage{amsmath, amssymb, amsthm}
 \usepackage{siunitx}
@@ -46,8 +51,8 @@
 \usepackage{hyperref}
 \usepackage{xurl}  % break long URLs / DOIs at any character so they wrap instead of overflowing the margin
 
-%% Document features
-\usepackage{accsupp, lineno, bashful, lipsum}
+%% Document features (lineno loaded earlier, before siunitx)
+\usepackage{accsupp, bashful, lipsum}
 
 %% Visual enhancements
 \usepackage[most]{tcolorbox}


### PR DESCRIPTION
## Summary
- `lineno` patches the output routine with `\interlinepenalty\linenopenalty`. With `siunitx` loaded first, its number parser chokes on those macros during frontmatter/abstract typesetting → `siunitx Error: Invalid number '\xdef 0{0}\advance \interlinepenalty \linenopenalty ...'` at `\end{frontmatter}`.
- Move `\usepackage{lineno}` ahead of `\usepackage{siunitx}` in `00_shared/latex_styles/packages.tex` (and out of the later `accsupp, …` group).

## Verification
- Confirmed by neurovista: applying this ordering to their manuscript cleared the error and the document compiles clean (zero caption/siunitx/alignment errors). I can't run LaTeX in-container, so this is host-verified on a real manuscript.

## Notes
`manuscript.tex` is assembled from this shared preamble at compile time, so the source edit propagates on the next compile. Closes `writer-lineno-siunitx-guard`.

## Test plan
- [ ] CI green (no Python touched)