### PR TITLE
fix(compile): rerun bibtex when a source .bib is newer than the .bbl

### DIFF
--- a/scripts/shell/modules/merge_bibliographies.sh
+++ b/scripts/shell/modules/merge_bibliographies.sh
@@ -44,4 +44,27 @@ elif [ "$bib_file_count" -eq 0 ]; then
     fi
 fi
 
+# ============================================================================
+# Bib freshness guard
+# ============================================================================
+# Force a bibtex rerun when a source .bib is newer than the compiled .bbl.
+# Under latexmk -output-directory + custom BIBINPUTS, a source-only .bib edit
+# can leave the .bbl/.fdb_latexmk looking up-to-date, so bibtex is skipped and
+# the PDF ships with the OLD bibliography (silent wrong output). Clearing the
+# stale .bbl (and latexmk's fdb) forces regeneration. Confirmed on neurovista's
+# manuscript. Safe: worst case is one extra bibtex pass.
+if [ -n "${LOG_DIR:-}" ] && [ -n "${SCITEX_WRITER_DOC_TYPE:-}" ]; then
+    _bbl="${LOG_DIR}/${SCITEX_WRITER_DOC_TYPE}.bbl"
+    if [ -f "$_bbl" ]; then
+        for _bib in "$BIB_DIR"/*.bib ./"$BIB_OUTPUT"; do
+            [ -f "$_bib" ] || continue
+            if [ "$_bib" -nt "$_bbl" ]; then
+                echo_info "Source bib $_bib newer than $_bbl → clearing stale .bbl to force bibtex"
+                rm -f "$_bbl" "${LOG_DIR}/${SCITEX_WRITER_DOC_TYPE}.fdb_latexmk"
+                break
+            fi
+        done
+    fi
+fi
+
 # EOF


### PR DESCRIPTION
## Summary
- Under `latexmk -output-directory` + custom `BIBINPUTS`, a source-only `.bib` edit can leave the `.bbl`/`.fdb_latexmk` looking up-to-date, so bibtex is skipped and the PDF ships with the OLD bibliography — a silent wrong output.
- Found via neurovista dogfooding: they escaped a raw `&` in `bibliography.bib`, but the stale `manuscript.bbl` (12:52 vs .bib 13:23) persisted and the error stayed in the PDF; only manually deleting the `.bbl` forced a rerun.
- Fix: a bib-freshness guard in the Bibliography Merge stage (`merge_bibliographies.sh`, sourced by every `compile_*.sh`) — if any source `.bib` is newer than the compiled `.bbl`, clear the stale `.bbl` + `.fdb_latexmk` so bibtex regenerates.

## Verification
- Host-confirmed by neurovista on their manuscript: guard fired, `manuscript.bbl` regenerated (bibtex reran), exit 0, content errors 0, fresh PDF — with no manual cleanup.
- `bash -n` clean; local behavioral check (newer `.bib` clears stale `.bbl`) passes.

## Test plan
- [ ] CI green (shell-only; no Python touched)