### PR TITLE
fix(compile): expose supplement .aux at doc-root for xr-hyper cross-refs

### DIFF
--- a/scripts/shell/compile_supplementary.sh
+++ b/scripts/shell/compile_supplementary.sh
@@ -338,6 +338,18 @@ main() {
     ./scripts/shell/modules/cleanup.sh
     log_stage_end "Cleanup"
 
+    # Expose the supplement .aux at doc-root for the main compile's
+    # \externaldocument (base.tex \link{./02_supplementary/supplementary} via
+    # xr-hyper reads ./02_supplementary/supplementary.aux). cleanup.sh sweeps
+    # doc-root *.aux into LOG_DIR, so this MUST run AFTER the Cleanup stage,
+    # else it gets swept back. Co-locating .aux with the doc-root .pdf keeps
+    # both the cross-ref numbers and the hyperlink targets correct.
+    _supp_aux="${LOG_DIR}/${SCITEX_WRITER_DOC_TYPE}.aux"
+    if [ -f "$_supp_aux" ]; then
+        cp -f "$_supp_aux" "./02_supplementary/${SCITEX_WRITER_DOC_TYPE}.aux"
+        echo_info "Exposed $_supp_aux -> ./02_supplementary/${SCITEX_WRITER_DOC_TYPE}.aux (xr-hyper)"
+    fi
+
     # Final steps
     log_stage_start "Directory Tree"
     ./scripts/shell/modules/custom_tree.sh


### PR DESCRIPTION
## Summary
- The main compile's `\externaldocument` (`base.tex \link{./02_supplementary/supplementary}` via xr-hyper) reads `./02_supplementary/supplementary.aux`, but `compile.sh -s` wrote the `.aux` only to `LOG_DIR` (`02_supplementary/LOGS/`) while moving the `.pdf` to doc-root → main compile logged "No file …supplementary.aux" and ~19 Supplementary Fig/Table refs rendered as `?`.
- Fix: copy the supplement `.aux` to doc-root **after** the Cleanup stage (cleanup.sh sweeps doc-root `*.aux` into `LOG_DIR`, so it must run after it). Co-locating `.aux` with the doc-root `.pdf` keeps both cross-ref numbers and hyperlink targets correct.

## Why not point \link at logs/
Rejected: `\externaldocument` hyperlinks target the `.aux`'s sibling `.pdf` at the same path, so pointing `\link` at `logs/` would make Supplementary hyperlinks jump to `logs/supplementary.pdf`, not the final doc-root `.pdf`.

## Verification
- Host-confirmed by neurovista (`compile.sh -s` then `-m`): `02_supplementary/supplementary.aux` persists at doc-root (15996 bytes), "No file" gone, undefined `supple-` refs dropped 19 → 1 (the last is a neurovista content gap, not engine). `bash -n` clean.

## Notes
Placement after Cleanup is essential (verified: an earlier copy got swept back into `LOG_DIR`). Generalizing to manuscript/revision (for reverse cross-refs) is a possible follow-up. Ordering: `-s` then `-m` still required (see `writer-supp-xref-ordering`).

## Test plan
- [ ] CI green (shell-only)