### PR TITLE
feat(checks): lint \footnote inside \caption{} (pre-compile, error by default)

### DIFF
--- a/scripts/python/check_caption_footnote.py
+++ b/scripts/python/check_caption_footnote.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/check_caption_footnote.py
+# Purpose: Catch \footnote (and \footnotetext used as an in-caption workaround)
+#          inside a \caption{} at LINT time, before compile.
+#
+#          \footnote inside \caption{} is a fatal LaTeX pattern: the caption
+#          argument is reprocessed (list-of-figures + heading), which yields
+#          "Argument of \caption@ydblarg has an extra }" and a runaway
+#          \@xfootnote -- fatal inside figure*/table* spanning floats. The
+#          blessed pattern is \caption[short]{long\protect\footnotemark} with
+#          \footnotetext AFTER the float, so \footnotemark in a caption is SAFE
+#          and is NOT flagged here.
+#
+#          Two detection modes:
+#            - caption_and_media/*.tex : the WHOLE file is the caption body the
+#              engine wraps in \caption{}, so any \footnote/\footnotetext in it
+#              is in-caption.
+#            - other source *.tex      : brace-match each \caption{...} arg and
+#              flag \footnote/\footnotetext within it.
+#          The generated assembled doc (e.g. 01_manuscript/manuscript.tex) is
+#          NOT scanned -- it duplicates the sources above and is a build
+#          artifact; scanning sources keeps this a pre-compile lint.
+#
+#          Severity is a user-level knob:
+#            off    -- check disabled
+#            warn   -- report as a warning (exit 0)
+#            error  -- report as an error (exit 1)   [DEFAULT]
+#          Default is error because the pattern is always a fatal compile bug;
+#          a clean manuscript never triggers it.
+#
+#          Severity precedence (highest -> lowest):
+#            1. --level {off,warn,error} CLI flag
+#            2. env SCITEX_WRITER_CAPTION_FOOTNOTE
+#            3. project ./config.yaml key caption_footnote.level
+#            4. user-wide ~/.scitex/writer/config.yaml key caption_footnote.level
+#            5. default error
+#
+# Usage:
+#   python check_caption_footnote.py [project_dir]
+#                                    [--doc-type manuscript|supplementary|revision|all]
+#                                    [--level off|warn|error]
+#
+# Self-contained: stdlib + optional PyYAML (only to read config files).
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+# ANSI colors (match check_media_provenance.py / check_paper_symlink.py)
+GREEN = "\033[0;32m"
+YELLOW = "\033[1;33m"
+RED = "\033[0;31m"
+DIM = "\033[0;90m"
+BOLD = "\033[1m"
+NC = "\033[0m"
+
+PASS_COUNT = 0
+WARN_COUNT = 0
+FAIL_COUNT = 0
+
+_LEVELS = ("off", "warn", "error")
+_DEFAULT_LEVEL = "error"
+
+_DOC_DIRS = {
+    "manuscript": "01_manuscript",
+    "supplementary": "02_supplementary",
+    "revision": "03_revision",
+}
+
+# \footnote and \footnotetext, but NOT \footnotemark (the blessed in-caption
+# pattern). The negative lookahead rejects a following letter, so \footnotemark
+# (\footnote + "mark") is excluded while \footnote{ / \footnote[ / \footnotetext
+# match.
+_FOOTNOTE_RE = re.compile(r"\\footnote(?:text)?(?![A-Za-z])")
+_CAPTION_RE = re.compile(r"\\caption\b")
+
+_MAX_LIST = 50
+
+
+def log_pass(msg):
+    global PASS_COUNT
+    print(f"  {GREEN}[PASS]{NC} {msg}")
+    PASS_COUNT += 1
+
+
+def log_warn(msg):
+    global WARN_COUNT
+    print(f"  {YELLOW}[WARN]{NC} {msg}")
+    WARN_COUNT += 1
+
+
+def log_fail(msg):
+    global FAIL_COUNT
+    print(f"  {RED}[FAIL]{NC} {msg}")
+    FAIL_COUNT += 1
+
+
+def log_detail(msg):
+    print(f"    {DIM}{msg}{NC}")
+
+
+def _read_block(config_path):
+    """Read the ``caption_footnote`` mapping from a YAML config, or ``{}``."""
+    if not config_path.exists():
+        return {}
+    try:
+        import yaml
+    except ImportError:
+        return {}
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    block = data.get("caption_footnote")
+    return block if isinstance(block, dict) else {}
+
+
+def _config_blocks(project_dir):
+    proj = _read_block(Path(project_dir) / "config.yaml")
+    user = _read_block(Path.home() / ".scitex" / "writer" / "config.yaml")
+    return proj, user
+
+
+def resolve_level(cli_level, proj_block, user_block):
+    """Resolve the effective severity level via the documented precedence."""
+    if cli_level:
+        return cli_level.lower()
+    env = os.environ.get("SCITEX_WRITER_CAPTION_FOOTNOTE", "").strip().lower()
+    if env in _LEVELS:
+        return env
+    for block in (proj_block, user_block):
+        level = block.get("level")
+        if isinstance(level, str) and level.lower() in _LEVELS:
+            return level.lower()
+    return _DEFAULT_LEVEL
+
+
+def _strip_comments(text):
+    """Blank out LaTeX comments (unescaped % to EOL) while preserving newlines
+    and column offsets, so line/col reporting stays accurate."""
+    out = []
+    for line in text.splitlines(keepends=True):
+        i = 0
+        cut = None
+        while i < len(line):
+            ch = line[i]
+            if ch == "\\":
+                i += 2  # escaped char (incl. \%); skip both
+                continue
+            if ch == "%":
+                cut = i
+                break
+            i += 1
+        if cut is None:
+            out.append(line)
+        else:
+            nl = "\n" if line.endswith("\n") else ""
+            out.append(line[:cut] + nl)
+    return "".join(out)
+
+
+def _line_of(text, idx):
+    """1-based line number of character offset ``idx``."""
+    return text.count("\n", 0, idx) + 1
+
+
+def _caption_arg_spans(text):
+    """Yield (start, end) char offsets of each \\caption{...} argument body.
+
+    Skips an optional ``*`` and an optional ``[...]`` short-caption arg, then
+    brace-matches the mandatory ``{...}`` (honoring escaped braces). ``start``
+    is just after the opening brace, ``end`` is the matching close brace index.
+    """
+    for m in _CAPTION_RE.finditer(text):
+        i = m.end()
+        n = len(text)
+        if i < n and text[i] == "*":
+            i += 1
+        while i < n and text[i] in " \t\r\n":
+            i += 1
+        # Optional [short] arg (brace/bracket-escaped chars skipped).
+        if i < n and text[i] == "[":
+            depth = 1
+            i += 1
+            while i < n and depth:
+                if text[i] == "\\":
+                    i += 2
+                    continue
+                if text[i] == "[":
+                    depth += 1
+                elif text[i] == "]":
+                    depth -= 1
+                i += 1
+            while i < n and text[i] in " \t\r\n":
+                i += 1
+        if i >= n or text[i] != "{":
+            continue
+        start = i + 1
+        depth = 1
+        j = start
+        while j < n and depth:
+            if text[j] == "\\":
+                j += 2
+                continue
+            if text[j] == "{":
+                depth += 1
+            elif text[j] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            j += 1
+        if depth == 0:
+            yield start, j
+
+
+def _iter_source_tex(project_dir, doc_types):
+    """Yield (path, is_caption_media) for each source .tex under the docs.
+
+    Walks ``<doc>/contents/`` (NOT the generated assembled ``<doc>.tex``).
+    ``is_caption_media`` is True for files under a ``caption_and_media/`` dir --
+    those whole files are caption bodies.
+    """
+    for doc_type in doc_types:
+        contents = project_dir / _DOC_DIRS[doc_type] / "contents"
+        if not contents.is_dir():
+            continue
+        for root, _dirs, files in os.walk(contents):
+            in_caption_media = (os.sep + "caption_and_media") in (
+                os.sep + os.path.relpath(root, contents)
+            ) or root.endswith("caption_and_media")
+            for name in files:
+                if name.endswith(".tex"):
+                    yield Path(root) / name, in_caption_media
+
+
+def _offenses_in(path, is_caption_media):
+    """Return [(line, snippet), ...] for footnote-in-caption hits in ``path``."""
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    text = _strip_comments(raw)
+    hits = []
+    if is_caption_media:
+        # The whole file becomes the \caption{} body.
+        for m in _FOOTNOTE_RE.finditer(text):
+            hits.append((_line_of(text, m.start()), m.group(0)))
+    else:
+        for start, end in _caption_arg_spans(text):
+            for m in _FOOTNOTE_RE.finditer(text, start, end):
+                hits.append((_line_of(text, m.start()), m.group(0)))
+    return hits
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Lint: ERROR when \\footnote/\\footnotetext appears inside a "
+        "\\caption{} (a fatal LaTeX pattern). \\footnotemark is allowed."
+    )
+    parser.add_argument("project_dir", nargs="?", default=".")
+    parser.add_argument(
+        "--doc-type",
+        choices=[*_DOC_DIRS, "all"],
+        default="all",
+        help="Which document(s) to scan (default: all present).",
+    )
+    parser.add_argument(
+        "--level",
+        choices=list(_LEVELS),
+        default=None,
+        help="Severity: off, warn, or error (default). Overrides env and config.",
+    )
+    args = parser.parse_args()
+
+    project_dir = Path(args.project_dir).resolve()
+    proj_block, user_block = _config_blocks(project_dir)
+    level = resolve_level(args.level, proj_block, user_block)
+
+    print(f"\n{BOLD}=== Caption Footnote Check (level={level}) ==={NC}\n")
+
+    if level == "off":
+        print(
+            f"  {DIM}[INFO]{NC} caption-footnote check is disabled (level=off)."
+        )
+        print(
+            f"\n{BOLD}Summary:{NC} {GREEN}0 passed{NC}, "
+            f"{YELLOW}0 warnings{NC}, {RED}0 errors{NC}"
+        )
+        return 0
+
+    doc_types = list(_DOC_DIRS) if args.doc_type == "all" else [args.doc_type]
+    report = log_fail if level == "error" else log_warn
+
+    offenders = []
+    scanned = 0
+    for path, is_caption_media in _iter_source_tex(project_dir, doc_types):
+        scanned += 1
+        for line, snippet in _offenses_in(path, is_caption_media):
+            rel = path.relative_to(project_dir)
+            offenders.append((f"{rel}:{line}", snippet))
+
+    if not offenders:
+        log_pass(
+            f"no \\footnote/\\footnotetext inside \\caption{{}} "
+            f"({scanned} source .tex scanned)"
+        )
+    else:
+        for loc, snippet in offenders[:_MAX_LIST]:
+            report(f"{loc}: {snippet} inside a \\caption{{}}")
+        if len(offenders) > _MAX_LIST:
+            log_detail(f"... and {len(offenders) - _MAX_LIST} more")
+        log_detail(
+            "fix: move the note out of the caption. Use "
+            "\\caption[short]{long\\protect\\footnotemark} and place "
+            "\\footnotetext{...} AFTER the float (\\footnotemark in a caption "
+            "is allowed); or inline the disclosure into the caption text."
+        )
+
+    print()
+    print(
+        f"{BOLD}Summary:{NC} {GREEN}{PASS_COUNT} passed{NC}, "
+        f"{YELLOW}{WARN_COUNT} warnings{NC}, {RED}{FAIL_COUNT} errors{NC}"
+    )
+    return 1 if FAIL_COUNT > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shell/modules/run_provenance_checks.sh
+++ b/scripts/shell/modules/run_provenance_checks.sh
@@ -2,15 +2,18 @@
 # -*- coding: utf-8 -*-
 # File: scripts/shell/modules/run_provenance_checks.sh
 #
-# Run the config-driven provenance/symlink checks at their RESOLVED severity
+# Run the config-driven pre-compile checks at their RESOLVED severity
 # (off|warn|error via CLI/env/config). Each underlying script
-# (scripts/python/check_{paper_symlink,media_provenance}.py) resolves its own
-# level and exits non-zero ONLY at error-level with a violation. So:
+# (scripts/python/check_{paper_symlink,media_provenance,caption_footnote}.py)
+# resolves its own level and exits non-zero ONLY at error-level with a
+# violation. So:
 #   off   -> no-op (exit 0)
 #   warn  -> reports, exit 0 (does NOT block the compile)
 #   error -> exit 1 (blocks the compile, fail-loud)
-# This is what makes `paper_symlink: error` / `media_provenance: error` actually
-# enforce at compile time -- previously the compile ran neither check.
+# This is what makes `paper_symlink: error` / `media_provenance: error` /
+# `caption_footnote: error` actually enforce at compile time -- previously the
+# compile ran none of them. caption_footnote defaults to error (a \footnote in
+# a \caption{} is always a fatal compile pattern).
 #
 # Returns the worst exit code across the checks (0 unless a check errored).
 
@@ -21,7 +24,7 @@ PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$THIS_DIR/../../.." && pwd)}"
 PY="${SCITEX_WRITER_PYTHON:-python3}"
 
 rc=0
-for chk in check_paper_symlink check_media_provenance; do
+for chk in check_paper_symlink check_media_provenance check_caption_footnote; do
     script="$THIS_DIR/../../python/${chk}.py"
     [ -f "$script" ] || continue
     "$PY" "$script" "$PROJECT_ROOT" || rc=$?

--- a/src/scitex_writer/_mcp/handlers/__init__.py
+++ b/src/scitex_writer/_mcp/handlers/__init__.py
@@ -5,6 +5,7 @@
 """MCP Handler implementations for SciTeX Writer."""
 
 from ._checks import (
+    check_caption_footnote,
     check_float_order,
     check_limits,
     check_media_provenance,
@@ -29,6 +30,7 @@ from ._update import update_project  # noqa: F401 -- now a package
 
 __all__ = [
     "add_claim",
+    "check_caption_footnote",
     "check_float_order",
     "check_limits",
     "check_media_provenance",

--- a/src/scitex_writer/_mcp/handlers/_checks.py
+++ b/src/scitex_writer/_mcp/handlers/_checks.py
@@ -281,6 +281,42 @@ def check_media_provenance(
     return _run_script(script, project_path, args, timeout)
 
 
+def check_caption_footnote(
+    project_dir: str,
+    doc_type: str = "all",
+    level: str | None = None,
+    timeout: int = 60,
+) -> dict:
+    """Lint: flag ``\\footnote``/``\\footnotetext`` inside a ``\\caption{}``.
+
+    ``\\footnote`` in a caption is a fatal LaTeX pattern (the caption arg is
+    reprocessed -> ``\\caption@ydblarg`` "extra }" + runaway ``\\@xfootnote``,
+    fatal in figure*/table* floats). ``\\footnotemark`` is the blessed in-caption
+    pattern and is NOT flagged. Scans the source ``.tex`` under
+    ``<doc>/contents/`` (caption_and_media/*.tex whole-file, plus brace-matched
+    ``\\caption{}`` args elsewhere); the generated assembled doc is not scanned.
+
+    Severity precedence (highest -> lowest): ``level`` arg, env
+    ``SCITEX_WRITER_CAPTION_FOOTNOTE``, project ``./config.yaml``
+    (``caption_footnote.level``), user ``~/.scitex/writer/config.yaml``, default
+    ``error`` (the pattern is always a fatal compile bug; a clean manuscript
+    never triggers it).
+
+    Args:
+        project_dir: Project root.
+        doc_type: ``manuscript``, ``supplementary``, ``revision``, or ``all``.
+        level: One of ``off``, ``warn``, ``error``. When ``None``, env/config
+            precedence resolves the level.
+        timeout: Subprocess timeout in seconds.
+    """
+    project_path = resolve_project_path(project_dir)
+    script = _script_path(project_path, "check_caption_footnote.py")
+    args = ["--doc-type", doc_type]
+    if level is not None:
+        args += ["--level", level]
+    return _run_script(script, project_path, args, timeout)
+
+
 __all__ = [
     "check_references",
     "check_float_order",
@@ -288,6 +324,7 @@ __all__ = [
     "check_overflow",
     "check_paper_symlink",
     "check_media_provenance",
+    "check_caption_footnote",
 ]
 
 # EOF

--- a/src/scitex_writer/checks.py
+++ b/src/scitex_writer/checks.py
@@ -29,6 +29,7 @@ from typing import Callable as _Callable
 from typing import Literal as _Literal
 from typing import Optional as _Optional
 
+from ._mcp.handlers import check_caption_footnote as _check_caption_footnote
 from ._mcp.handlers import check_float_order as _check_float_order
 from ._mcp.handlers import check_limits as _check_limits
 from ._mcp.handlers import check_media_provenance as _check_media_provenance
@@ -231,6 +232,52 @@ def media_provenance(
     return handler(project_dir, doc_type, level, require_under_scripts)
 
 
+def caption_footnote(
+    project_dir: str,
+    doc_type: _Literal["manuscript", "supplementary", "revision", "all"] = "all",
+    level: _Optional[_Literal["off", "warn", "error"]] = None,
+    handler: _Optional[_Callable[..., dict]] = None,
+) -> dict:
+    """Lint: flag ``\\footnote``/``\\footnotetext`` inside a ``\\caption{}``.
+
+    ``\\footnote`` in a caption is a fatal LaTeX pattern — the caption argument
+    is reprocessed (list-of-figures + heading), yielding
+    ``\\caption@ydblarg`` "extra }" and a runaway ``\\@xfootnote``, fatal in
+    ``figure*``/``table*`` spanning floats. The blessed pattern is
+    ``\\caption[short]{long\\protect\\footnotemark}`` with ``\\footnotetext``
+    **after** the float, so ``\\footnotemark`` in a caption is allowed and is
+    **not** flagged.
+
+    Scans the source ``.tex`` under ``<doc>/contents/`` — every
+    ``caption_and_media/*.tex`` whole-file (the engine wraps it in
+    ``\\caption{}``) plus brace-matched ``\\caption{}`` arguments in other
+    source files. The generated assembled doc is not scanned (it duplicates the
+    sources), keeping this a pre-compile lint.
+
+    Severity:
+
+    * ``error`` — report as an error (``exit_code`` 1). **The default**, because
+      the pattern is always a fatal compile bug; a clean manuscript never fires.
+    * ``warn`` — report as a warning (``exit_code`` 0).
+    * ``off`` — check disabled.
+
+    Severity precedence (highest → lowest): the ``level`` argument, env
+    ``SCITEX_WRITER_CAPTION_FOOTNOTE``, project ``./config.yaml``
+    (``caption_footnote.level``), user ``~/.scitex/writer/config.yaml``, then
+    the ``error`` default.
+
+    Returns a dict with ``success``, ``exit_code``, ``stdout``, ``stderr``,
+    and ``summary={passed, warnings, errors}``.
+
+    ``handler`` is the underlying check implementation; it defaults to
+    :func:`scitex_writer._mcp.handlers.check_caption_footnote`. Exposed so
+    callers (and tests) can supply an alternate implementation without patching
+    internals.
+    """
+    handler = handler or _check_caption_footnote
+    return handler(project_dir, doc_type, level)
+
+
 __all__ = [
     "references",
     "float_order",
@@ -238,6 +285,7 @@ __all__ = [
     "overflow",
     "paper_symlink",
     "media_provenance",
+    "caption_footnote",
 ]
 
 # EOF

--- a/tests/scitex_writer/test_checks.py
+++ b/tests/scitex_writer/test_checks.py
@@ -35,7 +35,31 @@ def test_module_exports_references_float_order_limits_and_overflow():
         "overflow",
         "paper_symlink",
         "media_provenance",
+        "caption_footnote",
     ]
+
+
+def test_caption_footnote_forwards_all_arguments_to_handler():
+    # Arrange
+    handler = _RecordingHandler({"success": True})
+    # Act
+    checks.caption_footnote(
+        "/path",
+        doc_type="supplementary",
+        level="error",
+        handler=handler,
+    )
+    # Assert
+    assert handler.calls == [("/path", "supplementary", "error")]
+
+
+def test_caption_footnote_defaults_are_all_doctype_none_level():
+    # Arrange
+    handler = _RecordingHandler({"success": True})
+    # Act
+    checks.caption_footnote("/path", handler=handler)
+    # Assert
+    assert handler.calls == [("/path", "all", None)]
 
 
 def test_media_provenance_forwards_all_arguments_to_handler():

--- a/tests/scripts/python/test_check_caption_footnote.py
+++ b/tests/scripts/python/test_check_caption_footnote.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: check_caption_footnote.py
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Add scripts/python to path for imports
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from check_caption_footnote import (  # noqa: E402
+    _caption_arg_spans,
+    _strip_comments,
+    resolve_level,
+)
+
+_SCRIPT = ROOT_DIR / "scripts" / "python" / "check_caption_footnote.py"
+
+_CAPTION_MEDIA = "01_manuscript/contents/figures/caption_and_media"
+
+
+# ============================================================================
+# helpers / fixtures
+# ============================================================================
+
+
+def _write(tmp_path, rel, content):
+    p = tmp_path / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _run(project, *extra):
+    env = dict(os.environ)
+    env.pop("SCITEX_WRITER_CAPTION_FOOTNOTE", None)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), str(project), *extra],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+@pytest.fixture
+def clean_env():
+    """Isolate env + HOME so no stray SCITEX_WRITER_CAPTION_FOOTNOTE or user
+    config.yaml leaks into severity resolution."""
+    saved = {
+        k: os.environ.get(k)
+        for k in ("SCITEX_WRITER_CAPTION_FOOTNOTE", "HOME")
+    }
+    os.environ.pop("SCITEX_WRITER_CAPTION_FOOTNOTE", None)
+    with tempfile.TemporaryDirectory() as home:
+        os.environ["HOME"] = home
+        yield home
+    for key, val in saved.items():
+        if val is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = val
+
+
+# ============================================================================
+# resolve_level — default severity
+# ============================================================================
+
+
+def test_resolve_level_defaults_to_error(clean_env):
+    """With no --level, no env, no config, the default level is error."""
+    # Arrange
+    # Act
+    level = resolve_level(None, {}, {})
+    # Assert
+    assert level == "error"
+
+
+def test_resolve_level_cli_overrides(clean_env):
+    """An explicit --level wins over everything else."""
+    # Arrange
+    # Act
+    level = resolve_level("warn", {"level": "error"}, {})
+    # Assert
+    assert level == "warn"
+
+
+# ============================================================================
+# _strip_comments
+# ============================================================================
+
+
+def test_strip_comments_blanks_commented_footnote():
+    """A \\footnote after an unescaped % is removed from the scanned text."""
+    # Arrange
+    text = "good % \\footnote{ignored}\n"
+    # Act
+    stripped = _strip_comments(text)
+    # Assert
+    assert "\\footnote" not in stripped
+
+
+def test_strip_comments_keeps_escaped_percent():
+    """An escaped \\% is not treated as a comment start."""
+    # Arrange
+    text = "50\\% yield \\footnote{kept}\n"
+    # Act
+    stripped = _strip_comments(text)
+    # Assert
+    assert "\\footnote{kept}" in stripped
+
+
+# ============================================================================
+# _caption_arg_spans — brace matching
+# ============================================================================
+
+
+def test_caption_arg_spans_matches_nested_braces():
+    """The span covers a caption arg containing nested braces."""
+    # Arrange
+    text = r"\caption{outer {inner} end}"
+    # Act
+    spans = list(_caption_arg_spans(text))
+    # Assert
+    assert [text[s:e] for s, e in spans] == ["outer {inner} end"]
+
+
+def test_caption_arg_spans_skips_optional_short_arg():
+    """An optional [short] arg before {...} is skipped, span is the long arg."""
+    # Arrange
+    text = r"\caption[short]{long body}"
+    # Act
+    spans = list(_caption_arg_spans(text))
+    # Assert
+    assert [text[s:e] for s, e in spans] == ["long body"]
+
+
+# ============================================================================
+# End-to-end script behaviour (no LaTeX toolchain needed)
+# ============================================================================
+
+
+def test_footnote_in_caption_media_file_errors(tmp_path, clean_env):
+    """\\footnote in a caption_and_media/*.tex (whole-file caption body) errors."""
+    # Arrange
+    _write(tmp_path, f"{_CAPTION_MEDIA}/01.tex", "Cohort.\\footnote{disclosure}\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_footnote_in_inline_caption_errors(tmp_path, clean_env):
+    """\\footnote inside an inline \\caption{} in a content .tex errors."""
+    # Arrange
+    _write(
+        tmp_path,
+        "01_manuscript/contents/results.tex",
+        "\\begin{figure}\\caption{Cap \\footnote{bad}}\\end{figure}\n",
+    )
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_footnotemark_in_caption_is_allowed(tmp_path, clean_env):
+    """\\footnotemark (the blessed pattern) in a caption body does NOT error."""
+    # Arrange
+    _write(tmp_path, f"{_CAPTION_MEDIA}/01.tex", "Cohort.\\footnotemark\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_footnotetext_in_caption_media_errors(tmp_path, clean_env):
+    """\\footnotetext used as an in-caption workaround is flagged too."""
+    # Arrange
+    _write(tmp_path, f"{_CAPTION_MEDIA}/01.tex", "Cohort.\\footnotetext{x}\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_commented_footnote_is_ignored(tmp_path, clean_env):
+    """A \\footnote inside a LaTeX comment does not trigger the lint."""
+    # Arrange
+    _write(tmp_path, f"{_CAPTION_MEDIA}/01.tex", "Cohort. % \\footnote{ignored}\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_off_level_exits_zero_with_violation(tmp_path, clean_env):
+    """--level off disables the check even when a violation is present."""
+    # Arrange
+    _write(tmp_path, f"{_CAPTION_MEDIA}/01.tex", "Cohort.\\footnote{bad}\n")
+    # Act
+    proc = _run(tmp_path, "--level", "off")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_warn_level_does_not_block(tmp_path, clean_env):
+    """--level warn reports the violation but exits 0 (does not block compile)."""
+    # Arrange
+    _write(tmp_path, f"{_CAPTION_MEDIA}/01.tex", "Cohort.\\footnote{bad}\n")
+    # Act
+    proc = _run(tmp_path, "--level", "warn")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_clean_manuscript_passes(tmp_path, clean_env):
+    """A caption with no footnote passes (exit 0)."""
+    # Arrange
+    _write(tmp_path, f"{_CAPTION_MEDIA}/01.tex", "Cohort design overview.\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 0


### PR DESCRIPTION
## Summary
`\footnote` inside a `\caption{}` is a **fatal** LaTeX pattern — the caption arg is reprocessed (list-of-figures + heading) → `\caption@ydblarg` "extra }" + runaway `\@xfootnote`, fatal in `figure*`/`table*` spanning floats (hit on neurovista figs 03 & 05). This catches it at **lint time**, before the compile.

- New `scripts/python/check_caption_footnote.py` (stdlib): scans source `.tex` under `<doc>/contents/` — every `caption_and_media/*.tex` whole-file (the engine wraps each in `\caption{}`) plus brace-matched `\caption{}` args in other source files. The generated assembled doc is not scanned (it duplicates the sources → pre-compile-reliable, no double-count).
- `\footnotemark` (the **blessed** in-caption pattern) is **allowed**; `\footnote` and `\footnotetext` (the workaround) are flagged with `file:line`. LaTeX comments stripped first.
- Severity `off|warn|error` via `--level` / `SCITEX_WRITER_CAPTION_FOOTNOTE` / `caption_footnote.level` (project|user config). **Default `error`** — the pattern is always fatal, so a clean manuscript never fires.
- Wired into the pre-compile gate (`run_provenance_checks.sh`) so `error` blocks the compile fail-loud; also exposed as handler `check_caption_footnote` + public `checks.caption_footnote()`.
- **Independent** rule, deliberately not coupled to figrecipe's parallel rule (operator scope).

## Context
Operator request (dogfooding follow-up to the footnote-in-caption bug), relayed via neurovista. Pairs with a forthcoming pre-compile reference-integrity gate.

## Verification
- Fully testable in-container (static `.tex` analysis, no LaTeX). Script-level tests: mode A (caption_and_media whole-file), mode B (inline `\caption{}` arg), `\footnotemark` allowed, `\footnotetext` flagged, commented-out ignored, `off`/`warn` non-blocking, clean passes. Plus public-API forwarding tests + `__all__` pins.
- `scitex-dev linter check-files` clean (the lone warning is the shared optional-import `except` pattern the sibling check scripts already carry); `bash -n` clean.

## Test plan
- [ ] CI: audit + matrix green