### PR TITLE
feat(checks): reference-integrity gate (engine + check-only mode)

### DIFF
--- a/scripts/python/check_ref_integrity.py
+++ b/scripts/python/check_ref_integrity.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/check_ref_integrity.py
+# Purpose: Pre-compile REFERENCE-INTEGRITY gate. Validate every reference class
+#          up front, report ALL problems at once (file:line), then exit non-zero
+#          so the caller can BLOCK the compile (the compile stage proceeds only
+#          on an explicit --yes/--force). Catches ?-refs and undefined \cite
+#          BEFORE a full compile instead of after, buried in the log.
+#
+#          Four classes:
+#            1. FIGURE  \ref  -> resolves to a \label / auto-label (fig:STEM)
+#            2. TABLE   \ref  -> resolves to a \label / auto-label (tab:STEM)
+#            3. CITATION      -> every \cite key exists in the merged bib
+#            4. SUPPLEMENTARY -> every supple- xref resolves against the
+#               supplement's .aux (base.tex \link[supple-]{...}); if the
+#               supplement hasn't been compiled (its .aux is missing), say so
+#               explicitly rather than reporting every supple- ref as undefined.
+#
+#          Reuses scripts/python/check_references.py's extractors (don't
+#          rewrite). Severity off|warn|error (DEFAULT error -- a broken ref ships
+#          a ?-mark / wrong PDF):
+#            off   -- skip the gate
+#            warn  -- report problems, exit 0 (does NOT block)
+#            error -- report problems, exit 1 (caller blocks the compile)
+#          Precedence (highest -> lowest): --level, env SCITEX_WRITER_REF_INTEGRITY,
+#          project ./config.yaml ref_integrity.level, user
+#          ~/.scitex/writer/config.yaml, default error. (To migrate onto the
+#          unified scripts/python/_severity.py resolver once that lands.)
+#
+# Usage:
+#   python check_ref_integrity.py [project_dir]
+#                                 [--doc-type manuscript|supplementary|revision|all]
+#                                 [--level off|warn|error]
+#
+# Self-contained: stdlib + optional PyYAML (config only) + sibling
+# check_references.py (same scripts/python/ dir).
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+# Reuse the proven extractors from the sibling check (same dir).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_references import (  # noqa: E402
+    collect_tex_files,
+    extract_bib_keys,
+    extract_citations,
+    extract_labels,
+    extract_refs,
+    infer_auto_labels,
+)
+
+GREEN = "\033[0;32m"
+YELLOW = "\033[1;33m"
+RED = "\033[0;31m"
+DIM = "\033[0;90m"
+BOLD = "\033[1m"
+NC = "\033[0m"
+
+PASS_COUNT = 0
+WARN_COUNT = 0
+FAIL_COUNT = 0
+
+_LEVELS = ("off", "warn", "error")
+_DEFAULT_LEVEL = "error"
+
+_DOC_DIRS = {
+    "manuscript": "01_manuscript",
+    "supplementary": "02_supplementary",
+    "revision": "03_revision",
+}
+
+# The supplement's labels are pulled into the main doc with this prefix
+# (base.tex: \link[supple-]{./02_supplementary/supplementary}).
+_SUPPLE_PREFIX = "supple-"
+_SUPPLE_AUX = Path("02_supplementary") / "supplementary.aux"
+
+_MAX_LIST = 100
+
+
+def log_pass(msg):
+    global PASS_COUNT
+    print(f"  {GREEN}[PASS]{NC} {msg}")
+    PASS_COUNT += 1
+
+
+def log_warn(msg):
+    global WARN_COUNT
+    print(f"  {YELLOW}[WARN]{NC} {msg}")
+    WARN_COUNT += 1
+
+
+def log_fail(msg):
+    global FAIL_COUNT
+    print(f"  {RED}[FAIL]{NC} {msg}")
+    FAIL_COUNT += 1
+
+
+def log_detail(msg):
+    print(f"    {DIM}{msg}{NC}")
+
+
+def _read_block(config_path):
+    if not config_path.exists():
+        return {}
+    try:
+        import yaml
+    except ImportError:
+        return {}
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    block = data.get("ref_integrity")
+    return block if isinstance(block, dict) else {}
+
+
+def resolve_level(cli_level, project_dir):
+    """Resolve severity via CLI > env > project config > user config > default."""
+    if cli_level:
+        return cli_level.lower()
+    env = os.environ.get("SCITEX_WRITER_REF_INTEGRITY", "").strip().lower()
+    if env in _LEVELS:
+        return env
+    proj = _read_block(Path(project_dir) / "config.yaml")
+    user = _read_block(Path.home() / ".scitex" / "writer" / "config.yaml")
+    for block in (proj, user):
+        level = block.get("level")
+        if isinstance(level, str) and level.lower() in _LEVELS:
+            return level.lower()
+    return _DEFAULT_LEVEL
+
+
+def _read_aux_labels(aux_path):
+    """Return the set of \\newlabel keys recorded in a LaTeX .aux file."""
+    if not aux_path.exists():
+        return None  # distinguish "not compiled" from "compiled, zero labels"
+    text = aux_path.read_text(encoding="utf-8", errors="replace")
+    return set(re.findall(r"\\newlabel\{([^}]+)\}", text))
+
+
+def _classify(key):
+    """Human label for a ref key by its prefix."""
+    if key.startswith(_SUPPLE_PREFIX):
+        return "supplementary"
+    if key.startswith("fig:"):
+        return "figure"
+    if key.startswith("tab:"):
+        return "table"
+    return "reference"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Pre-compile reference-integrity gate: validate figure/table "
+        "\\ref, \\cite-in-bib, and supple- xrefs; report all, then block."
+    )
+    parser.add_argument("project_dir", nargs="?", default=".")
+    parser.add_argument(
+        "--doc-type",
+        choices=[*_DOC_DIRS, "all"],
+        default="all",
+        help="Which document(s) to scan (default: all present).",
+    )
+    parser.add_argument(
+        "--level",
+        choices=list(_LEVELS),
+        default=None,
+        help="Severity: off, warn, or error (default). Overrides env and config.",
+    )
+    args = parser.parse_args()
+
+    project_dir = Path(args.project_dir).resolve()
+    level = resolve_level(args.level, project_dir)
+
+    print(f"\n{BOLD}=== Reference Integrity Gate (level={level}) ==={NC}\n")
+    if level == "off":
+        print(f"  {DIM}[INFO]{NC} reference-integrity gate is disabled (level=off).")
+        print(
+            f"\n{BOLD}Summary:{NC} {GREEN}0 passed{NC}, "
+            f"{YELLOW}0 warnings{NC}, {RED}0 errors{NC}"
+        )
+        return 0
+
+    report = log_fail if level == "error" else log_warn
+    doc_types = list(_DOC_DIRS) if args.doc_type == "all" else [args.doc_type]
+    bib_keys = extract_bib_keys(project_dir / "00_shared" / "bib_files")
+
+    # Supplement labels (for the supple- class). None => supplement not compiled.
+    supp_labels = _read_aux_labels(project_dir / _SUPPLE_AUX)
+
+    any_doc = False
+    for doc_type in doc_types:
+        doc_dir = project_dir / _DOC_DIRS[doc_type]
+        if not doc_dir.is_dir():
+            continue
+        any_doc = True
+        tex_files = collect_tex_files(doc_dir)
+        refs = extract_refs(tex_files)
+        labels = set(extract_labels(tex_files)) | set(infer_auto_labels(doc_dir))
+        cites = extract_citations(tex_files)
+
+        # Classes 1, 2, (other) + 4: every \ref resolves.
+        supple_refs = {k: v for k, v in refs.items() if k.startswith(_SUPPLE_PREFIX)}
+        local_refs = {k: v for k, v in refs.items() if not k.startswith(_SUPPLE_PREFIX)}
+
+        for key, locs in sorted(local_refs.items()):
+            if key in labels:
+                continue
+            for f, line in locs:
+                report(f"{doc_type}: {f.name}:{line}: {_classify(key)} \\ref{{{key}}} -> ?? (no \\label)")
+
+        # Class 4: supple- xrefs need the supplement .aux.
+        if supple_refs:
+            if supp_labels is None:
+                report(
+                    f"{doc_type}: supplement not compiled -- "
+                    f"{(project_dir / _SUPPLE_AUX)} missing; "
+                    f"{len(supple_refs)} supple- xref(s) cannot resolve"
+                )
+                log_detail("fix: run `compile.sh -s` before `compile.sh -m` so the supplement .aux exists.")
+            else:
+                for key, locs in sorted(supple_refs.items()):
+                    bare = key[len(_SUPPLE_PREFIX):]
+                    if bare in supp_labels:
+                        continue
+                    for f, line in locs:
+                        report(
+                            f"{doc_type}: {f.name}:{line}: supplementary \\ref{{{key}}} "
+                            f"-> ?? (no \\label{{{bare}}} in supplement)"
+                        )
+
+        # Class 3: every \cite key exists in the merged bib.
+        for key, locs in sorted(cites.items()):
+            if key in bib_keys:
+                continue
+            for f, line in locs:
+                report(f"{doc_type}: {f.name}:{line}: \\cite{{{key}}} -> not in bibliography")
+
+    if not any_doc:
+        log_pass("no document directories found to check")
+    elif FAIL_COUNT == 0 and WARN_COUNT == 0:
+        log_pass("all references, citations, and supple- xrefs resolve")
+
+    print()
+    print(
+        f"{BOLD}Summary:{NC} {GREEN}{PASS_COUNT} passed{NC}, "
+        f"{YELLOW}{WARN_COUNT} warnings{NC}, {RED}{FAIL_COUNT} errors{NC}"
+    )
+    return 1 if FAIL_COUNT > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scitex_writer/_mcp/handlers/__init__.py
+++ b/src/scitex_writer/_mcp/handlers/__init__.py
@@ -11,6 +11,7 @@ from ._checks import (
     check_media_provenance,
     check_overflow,
     check_paper_symlink,
+    check_ref_integrity,
     check_references,
 )
 from ._claim import (
@@ -36,6 +37,7 @@ __all__ = [
     "check_media_provenance",
     "check_overflow",
     "check_paper_symlink",
+    "check_ref_integrity",
     "check_references",
     "clone_project",
     "compile_manuscript",

--- a/src/scitex_writer/_mcp/handlers/_checks.py
+++ b/src/scitex_writer/_mcp/handlers/_checks.py
@@ -317,6 +317,42 @@ def check_caption_footnote(
     return _run_script(script, project_path, args, timeout)
 
 
+def check_ref_integrity(
+    project_dir: str,
+    doc_type: str = "all",
+    level: str | None = None,
+    timeout: int = 60,
+) -> dict:
+    """Pre-compile reference-integrity gate: validate every reference class.
+
+    Reports ALL problems at once (file:line) across four classes -- figure
+    ``\\ref``, table ``\\ref``, ``\\cite``-key-in-merged-bib, and ``supple-``
+    cross-document xrefs (resolved against the supplement's ``.aux``; a missing
+    supplement ``.aux`` is reported explicitly as "not compiled" rather than as
+    undefined refs) -- then exits non-zero so the compile stage can BLOCK
+    (proceeding only on an explicit ``--yes``). Reuses ``check_references.py``'s
+    extractors.
+
+    Severity precedence (highest -> lowest): ``level`` arg, env
+    ``SCITEX_WRITER_REF_INTEGRITY``, project ``./config.yaml``
+    (``ref_integrity.level``), user ``~/.scitex/writer/config.yaml``, default
+    ``error`` (a broken ref ships a ?-mark / wrong PDF).
+
+    Args:
+        project_dir: Project root.
+        doc_type: ``manuscript``, ``supplementary``, ``revision``, or ``all``.
+        level: One of ``off``, ``warn``, ``error``. When ``None``, env/config
+            precedence resolves the level.
+        timeout: Subprocess timeout in seconds.
+    """
+    project_path = resolve_project_path(project_dir)
+    script = _script_path(project_path, "check_ref_integrity.py")
+    args = ["--doc-type", doc_type]
+    if level is not None:
+        args += ["--level", level]
+    return _run_script(script, project_path, args, timeout)
+
+
 __all__ = [
     "check_references",
     "check_float_order",
@@ -325,6 +361,7 @@ __all__ = [
     "check_paper_symlink",
     "check_media_provenance",
     "check_caption_footnote",
+    "check_ref_integrity",
 ]
 
 # EOF

--- a/src/scitex_writer/checks.py
+++ b/src/scitex_writer/checks.py
@@ -31,6 +31,7 @@ from typing import Optional as _Optional
 
 from ._mcp.handlers import check_caption_footnote as _check_caption_footnote
 from ._mcp.handlers import check_float_order as _check_float_order
+from ._mcp.handlers import check_ref_integrity as _check_ref_integrity
 from ._mcp.handlers import check_limits as _check_limits
 from ._mcp.handlers import check_media_provenance as _check_media_provenance
 from ._mcp.handlers import check_overflow as _check_overflow
@@ -278,6 +279,53 @@ def caption_footnote(
     return handler(project_dir, doc_type, level)
 
 
+def ref_integrity(
+    project_dir: str,
+    doc_type: _Literal["manuscript", "supplementary", "revision", "all"] = "all",
+    level: _Optional[_Literal["off", "warn", "error"]] = None,
+    handler: _Optional[_Callable[..., dict]] = None,
+) -> dict:
+    """Pre-compile reference-integrity gate over all four reference classes.
+
+    Validates, reporting **all** problems at once (file:line):
+
+    * **figure** ``\\ref`` resolves to a figure label / auto-label,
+    * **table** ``\\ref`` resolves to a table label / auto-label,
+    * every ``\\cite`` key exists in the merged bibliography,
+    * every ``supple-`` cross-document xref resolves against the supplement's
+      ``.aux`` — and if the supplement has not been compiled (its ``.aux`` is
+      missing) that is reported explicitly as "not compiled", not as a pile of
+      undefined refs.
+
+    Designed to run FIRST, fail-fast: at ``error`` it exits non-zero so the
+    compile stage blocks (proceeding only on an explicit ``--yes``); ``warn``
+    reports without blocking; ``off`` skips. Reuses the ``check_references``
+    extractors.
+
+    Severity:
+
+    * ``error`` — report and exit 1. **The default** (a broken ref ships a
+      ?-mark / wrong PDF).
+    * ``warn`` — report, exit 0 (does not block).
+    * ``off`` — gate disabled.
+
+    Severity precedence (highest → lowest): the ``level`` argument, env
+    ``SCITEX_WRITER_REF_INTEGRITY``, project ``./config.yaml``
+    (``ref_integrity.level``), user ``~/.scitex/writer/config.yaml``, then the
+    ``error`` default.
+
+    Returns a dict with ``success``, ``exit_code``, ``stdout``, ``stderr``,
+    and ``summary={passed, warnings, errors}``.
+
+    ``handler`` is the underlying check implementation; it defaults to
+    :func:`scitex_writer._mcp.handlers.check_ref_integrity`. Exposed so callers
+    (and tests) can supply an alternate implementation without patching
+    internals.
+    """
+    handler = handler or _check_ref_integrity
+    return handler(project_dir, doc_type, level)
+
+
 __all__ = [
     "references",
     "float_order",
@@ -286,6 +334,7 @@ __all__ = [
     "paper_symlink",
     "media_provenance",
     "caption_footnote",
+    "ref_integrity",
 ]
 
 # EOF

--- a/tests/scitex_writer/test_checks.py
+++ b/tests/scitex_writer/test_checks.py
@@ -36,7 +36,31 @@ def test_module_exports_references_float_order_limits_and_overflow():
         "paper_symlink",
         "media_provenance",
         "caption_footnote",
+        "ref_integrity",
     ]
+
+
+def test_ref_integrity_forwards_all_arguments_to_handler():
+    # Arrange
+    handler = _RecordingHandler({"success": True})
+    # Act
+    checks.ref_integrity(
+        "/path",
+        doc_type="supplementary",
+        level="error",
+        handler=handler,
+    )
+    # Assert
+    assert handler.calls == [("/path", "supplementary", "error")]
+
+
+def test_ref_integrity_defaults_are_all_doctype_none_level():
+    # Arrange
+    handler = _RecordingHandler({"success": True})
+    # Act
+    checks.ref_integrity("/path", handler=handler)
+    # Assert
+    assert handler.calls == [("/path", "all", None)]
 
 
 def test_caption_footnote_forwards_all_arguments_to_handler():

--- a/tests/scripts/python/test_check_ref_integrity.py
+++ b/tests/scripts/python/test_check_ref_integrity.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: check_ref_integrity.py
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from check_ref_integrity import resolve_level  # noqa: E402
+
+_SCRIPT = ROOT_DIR / "scripts" / "python" / "check_ref_integrity.py"
+
+_FIG_MEDIA = "01_manuscript/contents/figures/caption_and_media"
+_TAB_MEDIA = "01_manuscript/contents/tables/caption_and_media"
+
+
+# ============================================================================
+# helpers / fixtures
+# ============================================================================
+
+
+def _write(tmp_path, rel, content):
+    p = tmp_path / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _base_project(tmp_path, body):
+    """A minimal project: fig:01 + tab:01 auto-labels, one bib key, and a
+    results.tex whose body the caller supplies."""
+    _write(tmp_path, f"{_FIG_MEDIA}/01.tex", "Figure one.\n")
+    _write(tmp_path, f"{_TAB_MEDIA}/01.tex", "Table one.\n")
+    _write(tmp_path, "00_shared/bib_files/bibliography.bib", "@article{Known2020, title={x}}\n")
+    _write(tmp_path, "01_manuscript/contents/results.tex", body)
+    return tmp_path
+
+
+def _run(project, *extra):
+    env = dict(os.environ)
+    env.pop("SCITEX_WRITER_REF_INTEGRITY", None)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), str(project), *extra],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+@pytest.fixture
+def clean_env():
+    saved = {k: os.environ.get(k) for k in ("SCITEX_WRITER_REF_INTEGRITY", "HOME")}
+    os.environ.pop("SCITEX_WRITER_REF_INTEGRITY", None)
+    with tempfile.TemporaryDirectory() as home:
+        os.environ["HOME"] = home
+        yield home
+    for key, val in saved.items():
+        if val is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = val
+
+
+# ============================================================================
+# resolve_level
+# ============================================================================
+
+
+def test_resolve_level_defaults_to_error(tmp_path, clean_env):
+    """With no --level, no env, no config, the default level is error."""
+    # Arrange
+    # Act
+    level = resolve_level(None, str(tmp_path))
+    # Assert
+    assert level == "error"
+
+
+# ============================================================================
+# End-to-end (no LaTeX toolchain needed)
+# ============================================================================
+
+
+def test_undefined_figure_ref_errors(tmp_path, clean_env):
+    """A \\ref to a non-existent figure label blocks (exit 1)."""
+    # Arrange
+    _base_project(tmp_path, "See \\ref{fig:99}.\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_resolved_figure_and_table_refs_pass(tmp_path, clean_env):
+    """\\ref to existing fig:/tab: auto-labels resolves (exit 0)."""
+    # Arrange
+    _base_project(tmp_path, "See \\ref{fig:01} and \\ref{tab:01}.\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_undefined_citation_errors(tmp_path, clean_env):
+    """A \\cite key absent from the bib blocks (exit 1)."""
+    # Arrange
+    _base_project(tmp_path, "Cite \\cite{Missing2021}.\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_known_citation_passes(tmp_path, clean_env):
+    """A \\cite key present in the bib resolves (exit 0)."""
+    # Arrange
+    _base_project(tmp_path, "Cite \\cite{Known2020}.\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_supple_ref_without_aux_errors(tmp_path, clean_env):
+    """A supple- xref with no supplement .aux blocks (exit 1)."""
+    # Arrange
+    _base_project(tmp_path, "See \\ref{supple-fig:S01}.\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_supple_ref_without_aux_says_not_compiled(tmp_path, clean_env):
+    """The missing-supplement message is explicit, not a generic undefined ref."""
+    # Arrange
+    _base_project(tmp_path, "See \\ref{supple-fig:S01}.\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert "supplement not compiled" in proc.stdout
+
+
+def test_supple_ref_resolved_by_aux_passes(tmp_path, clean_env):
+    """A supple- xref resolves against the supplement .aux \\newlabel (exit 0)."""
+    # Arrange
+    _base_project(tmp_path, "See \\ref{supple-fig:S01}.\n")
+    _write(tmp_path, "02_supplementary/supplementary.aux", "\\newlabel{fig:S01}{{S1}{1}}\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_reports_all_classes_at_once(tmp_path, clean_env):
+    """One run surfaces every broken class together (3 errors), not one-at-a-time."""
+    # Arrange
+    _base_project(
+        tmp_path,
+        "See \\ref{fig:99}. Cite \\cite{Missing2021}. See \\ref{supple-fig:S01}.\n",
+    )
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert "3 errors" in proc.stdout
+
+
+def test_off_level_skips(tmp_path, clean_env):
+    """--level off disables the gate even with violations (exit 0)."""
+    # Arrange
+    _base_project(tmp_path, "See \\ref{fig:99}.\n")
+    # Act
+    proc = _run(tmp_path, "--level", "off")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_warn_level_does_not_block(tmp_path, clean_env):
+    """--level warn reports but exits 0 (does not block the compile)."""
+    # Arrange
+    _base_project(tmp_path, "See \\ref{fig:99}.\n")
+    # Act
+    proc = _run(tmp_path, "--level", "warn")
+    # Assert
+    assert proc.returncode == 0


### PR DESCRIPTION
## Summary
Pre-compile **reference-integrity gate** — validates every reference class up front and reports **all** problems at once (file:line) so a broken manuscript fails fast *before* a full compile, instead of surfacing `?`-refs in the log afterward.

Four classes:
1. **figure** `\ref` resolves to a figure label / auto-label
2. **table** `\ref` resolves to a table label / auto-label
3. **citation** — every `\cite` key exists in the merged bib
4. **supplementary** — every `supple-` xref resolves against the supplement `.aux` (from #172); a missing supplement `.aux` is reported explicitly as **"not compiled"** (run `compile.sh -s` first), not as a pile of undefined refs

- New `scripts/python/check_ref_integrity.py` **reuses** `check_references.py`'s extractors (no rewrite).
- Severity `off|warn|error`, **default `error`** (`SCITEX_WRITER_REF_INTEGRITY` / `ref_integrity.level`); exits `1` iff `FAIL>0` per the output contract → at `error` it blocks, `warn` reports without blocking, `off` skips.
- Exposed as handler `check_ref_integrity` + public `checks.ref_integrity()` — this PR delivers the **standalone check-only mode** (CI / pre-commit).

## Scope / follow-ups
- The **block-by-default + `--yes` compile-stage wiring** (run FIRST, block unless `--yes`) lands next.
- Consolidation into the unified pluggable **pre-check framework** + the shared `_severity.py` resolver follow (`writer-precheck-framework`, after scitex-dev drives the design §9 sign-off). Severity here already matches the contract's ladder + `Summary`/exit surface, so it migrates cleanly.
- Citation-**trustworthiness** (scitex-scholar) is a separate pluggable rule, pending scholar reachability.

## Verification
- Fully verified in-container against fixtures (no LaTeX): all 4 classes, `supple-`-not-compiled messaging, resolved-`supple-`, report-all (3 errors at once), `off`/`warn` non-blocking, clean→pass.
- Script + tests lint clean (`scitex-dev linter`); handler/API tests = no-mock forwarding + `__all__` pins.

## Test plan
- [ ] CI: audit + matrix green