### PR TITLE
feat(checks): shared severity resolver (_severity.py) + adopt in limits/overflow (D1)

### DIFF
--- a/docs/03_DESIGN_SEVERITY_MODEL_CONTRACT.md
+++ b/docs/03_DESIGN_SEVERITY_MODEL_CONTRACT.md
@@ -1,8 +1,9 @@
 # Shared Severity Model — Design Contract (checker redesign, Part D)
 
-> **STATUS: PROPOSAL — awaiting operator sign-off. NO implementation code lands
-> until this contract is approved.** This document defines the target contract
-> and the migration; it changes no behavior on its own.
+> **STATUS: RATIFIED — operator signed off §9 on 2026-06-27.** The locked
+> resolver `resolve_level(...)` ships in `scripts/python/_severity.py` and is
+> adopted incrementally (D1: `limits` + `overflow`; D2/D3 follow). No check
+> changes its effective default behavior; the contract unifies the knob.
 
 ## 1. Motivation
 
@@ -43,25 +44,31 @@ Every check resolves a single `level`:
 | `overflow`         | **warn**      | today's default (overfull box is advisory)             |
 | `paper_symlink`    | **warn**      | private convention; surfaced but non-fatal (PR #158)   |
 | `media_provenance` | **off**       | private convention; opt-in (PR #157)                   |
+| `caption_footnote` | **error**     | `\footnote` in a `\caption{}` is fatal mid-compile (PR #173) |
+| `ref_integrity`    | **error**     | an unresolved `\ref`/`\cite`/supple- xref is a real defect (PR #174) |
 
-These defaults **preserve current behavior** (see §6).
+These defaults **preserve current behavior** (see §6). `repair` is valid
+**only** for `paper_symlink` (the sole check with a safe deterministic
+self-fix); every other check tops out at `error`.
 
 ## 4. Precedence ladder (identical for every check)
 
 Resolved top-down; first match wins:
 
 1. **CLI flag** — `--level {off,warn,error}` (or the legacy `--strict` alias, §5)
-2. **per-check env** — `SCITEX_WRITER_<CHECK>` (existing:
-   `SCITEX_WRITER_PAPER_SYMLINK`, `SCITEX_WRITER_MEDIA_PROVENANCE`; new, additive:
+2. **per-check env** — `SCITEX_WRITER_<CHECK>`, one per check:
+   `SCITEX_WRITER_PAPER_SYMLINK`, `SCITEX_WRITER_MEDIA_PROVENANCE`,
    `SCITEX_WRITER_LIMITS`, `SCITEX_WRITER_OVERFLOW`, `SCITEX_WRITER_REFERENCES`,
-   `SCITEX_WRITER_FLOAT_ORDER`)
+   `SCITEX_WRITER_FLOAT_ORDER`, `SCITEX_WRITER_CAPTION_FOOTNOTE`,
+   `SCITEX_WRITER_REF_INTEGRITY`
 3. **project config** — `./config.yaml` → `<check>.level`
 4. **user config** — `~/.scitex/writer/config.yaml` → `<check>.level`
 5. **per-check default** (§3)
 
-**Global `SCITEX_WRITER_LINT_STRICT`** is a **tightening-only overlay applied
-AFTER resolution**: if truthy, it raises a resolved `warn` to `error` (never
-loosens, never touches `off`). Its scope is the open question in §7 Q1.
+**`SCITEX_WRITER_LINT_STRICT`** is a **tightening-only overlay applied AFTER
+resolution**: if truthy, it raises a resolved `warn` to `error` (never loosens,
+never touches `off`). Per the §9 sign-off it is **scoped to `limits` + `overflow`
+only** (exact back-compat) — it is NOT a global tighten-all.
 
 ## 5. Back-compat — NON-NEGOTIABLE
 
@@ -88,16 +95,17 @@ Everything below keeps working **identically to today**:
 - Exit code is `1` iff `FAIL_COUNT > 0` (i.e. `level=error` with ≥1 finding),
   else `0`. `off` is always `0`.
 
-## 7. Implementation sketch (for AFTER sign-off)
+## 7. Implementation (locked — §9 sign-off 2026-06-27)
 
 - A tiny **stdlib-only** helper `scripts/python/_severity.py` (the check scripts
-  are self-contained stdlib + optional PyYAML, so the helper must be too),
-  exposing one resolver:
+  are self-contained stdlib + optional PyYAML, so the helper is too), exposing
+  the locked resolver:
   `resolve_level(check, cli_level, project_dir, *, default, env_var, legacy_strict=None)`
-  → `level`, plus the `LINT_STRICT` overlay. Each `check_*.py` imports it; the
-  current per-check `resolve_level`/`_read_config_level` bodies collapse into it.
+  → `{off,warn,error,repair}`, plus the scoped `LINT_STRICT` overlay. Each
+  `check_*.py` imports it; the per-check `resolve_level`/`_read_config_level`
+  bodies collapse into it.
 - Public API (`checks.*`) and MCP handlers keep their signatures; `strict` bools
-  stay as aliases.
+  stay as aliases (passed in via `legacy_strict`).
 
 ## 8. Migration & risk (for the operator to assess)
 
@@ -109,6 +117,8 @@ Everything below keeps working **identically to today**:
 | `overflow`         | none — as `limits`                        | low  |
 | `paper_symlink`    | none beyond PR #158 (`warn`); adopts shared resolver | low |
 | `media_provenance` | none — `off` (PR #157); adopts shared resolver | none |
+| `caption_footnote` | none — `error` (PR #173); adopts shared resolver | low |
+| `ref_integrity`    | none — `error` (PR #174); adopts shared resolver | low |
 
 **Rollout — multiple small, independently CI-gated PRs:**
 1. **D1**: add `_severity.py`; adopt in `limits` + `overflow` (proves back-compat
@@ -118,15 +128,28 @@ Everything below keeps working **identically to today**:
    `--level`/env).
 
 No check changes its *effective* default behavior; the value is one consistent
-knob, env, config key, and hint style across all six.
+knob, env, config key, and hint style across all eight.
 
-## 9. Open questions for sign-off
+## 9. Sign-off — RESOLVED (operator, 2026-06-27)
 
-1. **`SCITEX_WRITER_LINT_STRICT` scope** — keep it scoped to `limits` + `overflow`
-   (exact back-compat; **recommended**), or make it a global "tighten every
-   check to error"? The latter would change behavior for `references`/`float_order`
-   (already error) and could surprise on `paper_symlink`/`media_provenance`.
-2. **`repair` for `media_provenance`?** Proposed **no** — it cannot safely
-   auto-generate a missing artifact from a script; surfacing is the right action.
-3. **New per-check env var names** (`SCITEX_WRITER_LIMITS`, `…_OVERFLOW`,
-   `…_REFERENCES`, `…_FLOAT_ORDER`) — acceptable, or prefer a different scheme?
+All three questions ratified by the operator (relayed via scitex-dev). The
+resolver `resolve_level(...)` in `scripts/python/_severity.py` is locked to:
+
+1. **`SCITEX_WRITER_LINT_STRICT` scope** — **scoped to `limits` + `overflow`
+   only** (exact back-compat). It does NOT tighten the other checks;
+   `references`/`float_order` keep their `error` default and
+   `paper_symlink`/`media_provenance`/`caption_footnote`/`ref_integrity` keep
+   their own per-check defaults regardless of `LINT_STRICT`.
+2. **`repair` level** — **`paper_symlink` only.** `media_provenance` gets **no
+   `repair`** (no safe deterministic auto-fix) and its default **stays `off`**
+   (the PR #157 opt-in back-compat is non-negotiable, §5); when enabled its max
+   severity is `error`.
+3. **Per-check env vars** — `SCITEX_WRITER_<CHECK>` **approved for all eight**
+   (`…_REFERENCES`, `…_FLOAT_ORDER`, `…_LIMITS`, `…_OVERFLOW`, `…_PAPER_SYMLINK`,
+   `…_MEDIA_PROVENANCE`, `…_CAPTION_FOOTNOTE`, `…_REF_INTEGRITY`), each mapping to
+   the `<check>.level` config key, with precedence CLI > per-check env > project
+   config > user config > per-check default.
+
+`ref_integrity` (#174, added after this doc's first draft) folds in under the
+same scheme: env `SCITEX_WRITER_REF_INTEGRITY`, key `ref_integrity.level`,
+default `error`, and is **outside** the `LINT_STRICT` scope.

--- a/scripts/python/_severity.py
+++ b/scripts/python/_severity.py
@@ -113,12 +113,16 @@ def resolve_level(
         The legacy strict alias (``--strict`` / ``<check>.strict``). None/False
         is a no-op; True tightens a resolved ``warn`` to ``error``.
     """
+    # `default` runs through the same gate as every other source: a default of
+    # `repair` for a non-self-fixing check is rejected (falls to `error`), so
+    # the repair gate is airtight even against a mis-specified caller default.
     level = (
         _norm(cli_level, check)
         or _norm(os.environ.get(env_var, ""), check)
         or _read_config_level(Path(project_dir) / "config.yaml", check)
         or _read_config_level(_USER_CONFIG, check)
-        or default
+        or _norm(default, check)
+        or "error"
     )
 
     # Tightening-only overlays: warn -> error. Never loosen; never touch off.

--- a/scripts/python/_severity.py
+++ b/scripts/python/_severity.py
@@ -42,7 +42,6 @@ _LINT_STRICT_CHECKS = frozenset({"limits", "overflow"})
 _REPAIR_CHECKS = frozenset({"paper_symlink"})
 
 _TRUTHY = ("1", "true", "yes")
-_USER_CONFIG = Path.home() / ".scitex" / "writer" / "config.yaml"
 
 
 def _valid_levels(check):
@@ -120,7 +119,11 @@ def resolve_level(
         _norm(cli_level, check)
         or _norm(os.environ.get(env_var, ""), check)
         or _read_config_level(Path(project_dir) / "config.yaml", check)
-        or _read_config_level(_USER_CONFIG, check)
+        # Path.home() is resolved at call time (not import) so a changed $HOME
+        # is honored -- matches the sibling check_*.py resolvers.
+        or _read_config_level(
+            Path.home() / ".scitex" / "writer" / "config.yaml", check
+        )
         or _norm(default, check)
         or "error"
     )

--- a/scripts/python/_severity.py
+++ b/scripts/python/_severity.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/_severity.py
+# Purpose: Shared severity-model resolver for the writer pre-compile / lint
+#          checks. Single source of truth for resolving a check's effective
+#          `level` from the documented precedence ladder, plus the two
+#          tightening-only overlays (the per-check `strict` alias and the
+#          scoped `SCITEX_WRITER_LINT_STRICT` global).
+#
+#          Ratified contract: docs/03_DESIGN_SEVERITY_MODEL_CONTRACT.md
+#          (Part D; §9 sign-off 2026-06-27).
+#
+#          Precedence (first match wins):
+#            1. CLI --level                          (cli_level)
+#            2. per-check env SCITEX_WRITER_<CHECK>   (env_var)
+#            3. project ./config.yaml                -> <check>.level
+#            4. user ~/.scitex/writer/config.yaml    -> <check>.level
+#            5. per-check default                    (default)
+#          Then warn -> error tightening (never loosens, never touches off):
+#            * legacy_strict truthy   (--strict / <check>.strict alias)
+#            * SCITEX_WRITER_LINT_STRICT truthy AND check in {limits, overflow}
+#
+# Self-contained: stdlib + optional PyYAML (config files are silently skipped
+# when PyYAML is absent, so CLI + env still resolve). Imported by the sibling
+# `check_*.py` standalones.
+
+import os
+from pathlib import Path
+
+# off < warn < error < repair. `repair` is error-semantics plus a safe
+# deterministic self-fix and is valid ONLY for checks that can auto-fix.
+LEVELS = ("off", "warn", "error", "repair")
+
+LINT_STRICT_ENV = "SCITEX_WRITER_LINT_STRICT"
+
+# SCITEX_WRITER_LINT_STRICT is a SCOPED overlay -- it tightens only these two
+# checks (exact back-compat with the historical `strict` bool). It is NOT a
+# global tighten-all (operator §9 sign-off, 2026-06-27).
+_LINT_STRICT_CHECKS = frozenset({"limits", "overflow"})
+
+# Only these checks accept the `repair` level (they can self-fix safely).
+_REPAIR_CHECKS = frozenset({"paper_symlink"})
+
+_TRUTHY = ("1", "true", "yes")
+_USER_CONFIG = Path.home() / ".scitex" / "writer" / "config.yaml"
+
+
+def _valid_levels(check):
+    """Levels accepted for ``check`` (``repair`` only for self-fixing checks)."""
+    return LEVELS if check in _REPAIR_CHECKS else LEVELS[:3]
+
+
+def _norm(value, check):
+    """Lowercased ``value`` iff it is a level valid for ``check``, else None."""
+    if isinstance(value, str):
+        low = value.strip().lower()
+        if low in _valid_levels(check):
+            return low
+    return None
+
+
+def env_truthy(name):
+    """True iff env var ``name`` is set to a truthy token (1/true/yes)."""
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
+
+
+def _read_config_level(config_path, check):
+    """Read ``<check>.level`` from a YAML config, or None.
+
+    A missing file/key is None (not an error). PyYAML is optional -- absent it,
+    config files are silently skipped so CLI + env still resolve.
+    """
+    if not config_path.exists():
+        return None
+    try:
+        import yaml
+    except ImportError:
+        return None
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    block = data.get(check)
+    if not isinstance(block, dict):
+        return None
+    return _norm(block.get("level"), check)
+
+
+def resolve_level(
+    check, cli_level, project_dir, *, default, env_var, legacy_strict=None
+):
+    """Resolve a check's effective severity level.
+
+    See the module header for the precedence ladder and the two tightening
+    overlays. ``repair`` from any source is ignored for checks that cannot
+    self-fix. Returns one of ``off`` / ``warn`` / ``error`` / ``repair``.
+
+    Parameters
+    ----------
+    check : str
+        Check name; also the ``<check>`` config-block stem.
+    cli_level : str or None
+        The check's ``--level`` value (None when unset).
+    project_dir : str or Path
+        Project root (holds ``./config.yaml``).
+    default : str
+        Per-check default when nothing else matches.
+    env_var : str
+        The check's ``SCITEX_WRITER_<CHECK>`` env var name.
+    legacy_strict : bool or None
+        The legacy strict alias (``--strict`` / ``<check>.strict``). None/False
+        is a no-op; True tightens a resolved ``warn`` to ``error``.
+    """
+    level = (
+        _norm(cli_level, check)
+        or _norm(os.environ.get(env_var, ""), check)
+        or _read_config_level(Path(project_dir) / "config.yaml", check)
+        or _read_config_level(_USER_CONFIG, check)
+        or default
+    )
+
+    # Tightening-only overlays: warn -> error. Never loosen; never touch off.
+    if level == "warn":
+        if legacy_strict:
+            level = "error"
+        elif check in _LINT_STRICT_CHECKS and env_truthy(LINT_STRICT_ENV):
+            level = "error"
+
+    return level
+
+
+__all__ = ["resolve_level", "env_truthy", "LEVELS", "LINT_STRICT_ENV"]
+
+# EOF

--- a/scripts/python/check_limits.py
+++ b/scripts/python/check_limits.py
@@ -20,11 +20,13 @@
 # (the same family of commands check_references.py recognises).
 
 import argparse
-import os
 import re
 import subprocess
 import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
 
 # ANSI colors (match check_references.py)
 GREEN = "\033[0;32m"
@@ -202,6 +204,13 @@ def main():
         action="store_true",
         help="Promote over-limit warnings to errors (non-zero exit).",
     )
+    parser.add_argument(
+        "--level",
+        choices=["off", "warn", "error"],
+        default=None,
+        help="Severity: warn (default), off, or error. Overrides env and "
+        "config; --strict is a tightening alias for error.",
+    )
     args = parser.parse_args()
 
     project_dir = Path(args.project_dir).resolve()
@@ -224,12 +233,25 @@ def main():
         )
         return 0
 
-    strict = (
-        args.strict
-        or bool(limits.get("strict", False))
-        or os.environ.get("SCITEX_WRITER_LINT_STRICT", "").lower()
-        in ("1", "true", "yes")
+    level = resolve_level(
+        "limits",
+        args.level,
+        project_dir,
+        default="warn",
+        env_var="SCITEX_WRITER_LIMITS",
+        legacy_strict=args.strict or bool(limits.get("strict", False)),
     )
+    if level == "off":
+        print(
+            f"  {DIM}[INFO]{NC} limit check is disabled (level=off). "
+            f"Set limits.level or --level to enable."
+        )
+        print(
+            f"\n{BOLD}Summary:{NC} {GREEN}0 passed{NC}, "
+            f"{YELLOW}0 warnings{NC}, {RED}0 errors{NC}"
+        )
+        return 0
+    strict = level == "error"
 
     if not doc_dir.exists():
         print(f"{RED}ERROR:{NC} {doc_dir} not found", file=sys.stderr)

--- a/scripts/python/check_overflow.py
+++ b/scripts/python/check_overflow.py
@@ -21,10 +21,12 @@
 # check_limits.py which runs before. Self-contained: stdlib + optional PyYAML.
 
 import argparse
-import os
 import re
 import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
 
 # ANSI colors (match check_limits.py / check_references.py)
 GREEN = "\033[0;32m"
@@ -201,6 +203,13 @@ def main():
         help="Promote overflow warnings to errors (non-zero exit).",
     )
     parser.add_argument(
+        "--level",
+        choices=["off", "warn", "error"],
+        default=None,
+        help="Severity: warn (default), off, or error. Overrides env and "
+        "config; --strict is a tightening alias for error.",
+    )
+    parser.add_argument(
         "--max-pt",
         type=float,
         default=None,
@@ -219,12 +228,25 @@ def main():
     if cfg is None:
         return 1  # hard error already printed loudly
 
-    strict = (
-        args.strict
-        or bool(cfg.get("strict", False))
-        or os.environ.get("SCITEX_WRITER_LINT_STRICT", "").lower()
-        in ("1", "true", "yes")
+    level = resolve_level(
+        "overflow",
+        args.level,
+        project_dir,
+        default="warn",
+        env_var="SCITEX_WRITER_OVERFLOW",
+        legacy_strict=args.strict or bool(cfg.get("strict", False)),
     )
+    if level == "off":
+        print(
+            f"  {DIM}[INFO]{NC} overflow check is disabled (level=off). "
+            f"Set overflow.level or --level to enable."
+        )
+        print(
+            f"\n{BOLD}Summary:{NC} {GREEN}0 passed{NC}, "
+            f"{YELLOW}0 warnings{NC}, {RED}0 errors{NC}"
+        )
+        return 0
+    strict = level == "error"
     if args.max_pt is not None:
         min_pt = args.max_pt
     elif cfg.get("max_pt") is not None:

--- a/src/scitex_writer/_skills/scitex-writer/20_env-vars.md
+++ b/src/scitex_writer/_skills/scitex-writer/20_env-vars.md
@@ -36,7 +36,9 @@ exits non-zero.
 
 | Variable | Purpose | Default | Type |
 |---|---|---|---|
-| `SCITEX_WRITER_LINT_STRICT` | Tighten `check-limits` + `check-overflow` warnings to errors (the legacy strict toggle). | `false` | bool |
+| `SCITEX_WRITER_LINT_STRICT` | Tighten `check-limits` + `check-overflow` warnings to errors (the legacy strict toggle). Scoped to those two checks only. | `false` | bool |
+| `SCITEX_WRITER_LIMITS` | Severity for the word/reference-limit check (`off`/`warn`/`error`). Default `warn`; `--strict`/`limits.strict` tighten to `error`. | `warn` | enum |
+| `SCITEX_WRITER_OVERFLOW` | Severity for the off-page overflow check (`off`/`warn`/`error`). Default `warn`; `--strict`/`overflow.strict` tighten to `error`. | `warn` | enum |
 | `SCITEX_WRITER_PAPER_SYMLINK` | Severity for the `paper -> .scitex/writer` symlink check (`off`/`warn`/`error`/`repair`). Private convention — default `warn`. | `warn` | enum |
 | `SCITEX_WRITER_MEDIA_PROVENANCE` | Severity for the media-symlink/provenance check on `caption_and_media/` (`off`/`warn`/`error`). Private convention — default `off`. | `off` | enum |
 

--- a/tests/scripts/python/test__severity.py
+++ b/tests/scripts/python/test__severity.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: _severity.py (shared severity-model resolver, Part D §9)
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from _severity import (  # noqa: E402
+    LEVELS,
+    LINT_STRICT_ENV,
+    env_truthy,
+    resolve_level,
+)
+
+# Every per-check env var the resolver may read, isolated per test.
+_ENV_KEYS = (
+    "SCITEX_WRITER_LIMITS",
+    "SCITEX_WRITER_OVERFLOW",
+    "SCITEX_WRITER_PAPER_SYMLINK",
+    "SCITEX_WRITER_REFERENCES",
+    "SCITEX_WRITER_LINT_STRICT",
+)
+
+
+# ============================================================================
+# helpers / fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def clean_env():
+    """Isolate the severity env vars + HOME so config/env never leak in."""
+    saved = {k: os.environ.get(k) for k in (*_ENV_KEYS, "HOME")}
+    for key in _ENV_KEYS:
+        os.environ.pop(key, None)
+    with tempfile.TemporaryDirectory() as home:
+        os.environ["HOME"] = home
+        yield home
+    for key, val in saved.items():
+        if val is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = val
+
+
+def _write_yaml(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+# ============================================================================
+# precedence ladder
+# ============================================================================
+
+
+def test_default_when_nothing_set(tmp_path, clean_env):
+    """With no CLI/env/config, the per-check default is returned."""
+    # Arrange
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "warn"
+
+
+def test_cli_overrides_default(tmp_path, clean_env):
+    """An explicit --level wins over the default."""
+    # Arrange
+    # Act
+    level = resolve_level(
+        "limits", "error", tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "error"
+
+
+def test_cli_overrides_env(tmp_path, clean_env):
+    """CLI --level beats the per-check env var."""
+    # Arrange
+    os.environ["SCITEX_WRITER_LIMITS"] = "off"
+    # Act
+    level = resolve_level(
+        "limits", "error", tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "error"
+
+
+def test_env_overrides_project_config(tmp_path, clean_env):
+    """The per-check env var beats project ./config.yaml."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write_yaml(tmp_path / "config.yaml", "limits:\n  level: error\n")
+    os.environ["SCITEX_WRITER_LIMITS"] = "off"
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "off"
+
+
+def test_project_config_level_honored(tmp_path, clean_env):
+    """`<check>.level` in project ./config.yaml is used when no CLI/env."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write_yaml(tmp_path / "config.yaml", "limits:\n  level: error\n")
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "error"
+
+
+def test_project_config_overrides_user_config(tmp_path, clean_env):
+    """Project ./config.yaml wins over user ~/.scitex/writer/config.yaml."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write_yaml(tmp_path / "config.yaml", "limits:\n  level: error\n")
+    _write_yaml(
+        Path(clean_env) / ".scitex" / "writer" / "config.yaml",
+        "limits:\n  level: off\n",
+    )
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "error"
+
+
+def test_user_config_honored_when_no_project_config(tmp_path, clean_env):
+    """User-wide config supplies the level when the project has none."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write_yaml(
+        Path(clean_env) / ".scitex" / "writer" / "config.yaml",
+        "limits:\n  level: error\n",
+    )
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "error"
+
+
+def test_invalid_env_value_falls_through(tmp_path, clean_env):
+    """A bogus env value is ignored and the default applies."""
+    # Arrange
+    os.environ["SCITEX_WRITER_LIMITS"] = "nonsense"
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "warn"
+
+
+# ============================================================================
+# legacy_strict tightening (the --strict / <check>.strict alias)
+# ============================================================================
+
+
+def test_legacy_strict_tightens_warn_to_error(tmp_path, clean_env):
+    """legacy_strict promotes a resolved warn to error."""
+    # Arrange
+    # Act
+    level = resolve_level(
+        "limits",
+        None,
+        tmp_path,
+        default="warn",
+        env_var="SCITEX_WRITER_LIMITS",
+        legacy_strict=True,
+    )
+    # Assert
+    assert level == "error"
+
+
+def test_legacy_strict_does_not_touch_off(tmp_path, clean_env):
+    """legacy_strict never tightens an explicit off."""
+    # Arrange
+    # Act
+    level = resolve_level(
+        "limits",
+        "off",
+        tmp_path,
+        default="warn",
+        env_var="SCITEX_WRITER_LIMITS",
+        legacy_strict=True,
+    )
+    # Assert
+    assert level == "off"
+
+
+# ============================================================================
+# SCITEX_WRITER_LINT_STRICT — scoped to limits + overflow only
+# ============================================================================
+
+
+def test_lint_strict_tightens_limits(tmp_path, clean_env):
+    """LINT_STRICT promotes limits warn -> error (in scope)."""
+    # Arrange
+    os.environ[LINT_STRICT_ENV] = "1"
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "error"
+
+
+def test_lint_strict_tightens_overflow(tmp_path, clean_env):
+    """LINT_STRICT promotes overflow warn -> error (in scope)."""
+    # Arrange
+    os.environ[LINT_STRICT_ENV] = "1"
+    # Act
+    level = resolve_level(
+        "overflow", None, tmp_path, default="warn", env_var="SCITEX_WRITER_OVERFLOW"
+    )
+    # Assert
+    assert level == "error"
+
+
+def test_lint_strict_does_not_affect_unscoped_check(tmp_path, clean_env):
+    """LINT_STRICT leaves a non-scoped check (references) at warn."""
+    # Arrange
+    os.environ[LINT_STRICT_ENV] = "1"
+    # Act
+    level = resolve_level(
+        "references",
+        None,
+        tmp_path,
+        default="warn",
+        env_var="SCITEX_WRITER_REFERENCES",
+    )
+    # Assert
+    assert level == "warn"
+
+
+# ============================================================================
+# repair level — only for self-fixing checks (paper_symlink)
+# ============================================================================
+
+
+def test_repair_honored_for_paper_symlink(tmp_path, clean_env):
+    """paper_symlink accepts the repair level."""
+    # Arrange
+    # Act
+    level = resolve_level(
+        "paper_symlink",
+        "repair",
+        tmp_path,
+        default="warn",
+        env_var="SCITEX_WRITER_PAPER_SYMLINK",
+    )
+    # Assert
+    assert level == "repair"
+
+
+def test_repair_ignored_for_non_repair_check(tmp_path, clean_env):
+    """A repair value for a non-self-fixing check falls through to default."""
+    # Arrange
+    # Act
+    level = resolve_level(
+        "limits", "repair", tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "warn"
+
+
+# ============================================================================
+# env_truthy + module constants
+# ============================================================================
+
+
+def test_env_truthy_true_for_yes(clean_env):
+    """env_truthy recognizes a truthy token."""
+    # Arrange
+    os.environ["SCITEX_WRITER_LINT_STRICT"] = "yes"
+    # Act
+    result = env_truthy("SCITEX_WRITER_LINT_STRICT")
+    # Assert
+    assert result is True
+
+
+def test_env_truthy_false_for_zero(clean_env):
+    """env_truthy treats 0 as not truthy."""
+    # Arrange
+    os.environ["SCITEX_WRITER_LINT_STRICT"] = "0"
+    # Act
+    result = env_truthy("SCITEX_WRITER_LINT_STRICT")
+    # Assert
+    assert result is False
+
+
+def test_levels_tuple_is_canonical_order(clean_env):
+    """LEVELS exposes the canonical off<warn<error<repair order."""
+    # Arrange
+    # Act
+    levels = LEVELS
+    # Assert
+    assert levels == ("off", "warn", "error", "repair")
+
+
+# EOF

--- a/tests/scripts/python/test__severity.py
+++ b/tests/scripts/python/test__severity.py
@@ -279,6 +279,17 @@ def test_repair_ignored_for_non_repair_check(tmp_path, clean_env):
     assert level == "warn"
 
 
+def test_repair_default_gated_for_non_repair_check(tmp_path, clean_env):
+    """Even a repair *default* cannot smuggle repair into a non-repair check."""
+    # Arrange
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="repair", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "error"
+
+
 # ============================================================================
 # env_truthy + module constants
 # ============================================================================


### PR DESCRIPTION
## Summary
Lands the ratified **Part-D shared severity model** (operator §9 sign-off 2026-06-27, relayed via scitex-dev) and adopts it in the back-compat-critical pair (`limits` + `overflow`) — rollout step **D1**.

- **`scripts/python/_severity.py`** (new, stdlib-only): the locked resolver
  `resolve_level(check, cli_level, project_dir, *, default, env_var, legacy_strict=None) -> {off,warn,error,repair}`.
  - Precedence: CLI `--level` > per-check env `SCITEX_WRITER_<CHECK>` > project `./config.yaml` `<check>.level` > user `~/.scitex/writer/config.yaml` > per-check default.
  - Two **tightening-only** overlays (raise `warn`→`error`, never loosen, never touch `off`): the `legacy_strict` alias (`--strict` / `<check>.strict`) and `SCITEX_WRITER_LINT_STRICT` **scoped to `limits`+`overflow` only**.
  - `repair` honored only for `paper_symlink`.
- **`check_limits` / `check_overflow`**: adopt the resolver. Additive `--level` flag + `SCITEX_WRITER_LIMITS` / `SCITEX_WRITER_OVERFLOW` env. Existing `strict` / `limits.strict` / `overflow.strict` / `LINT_STRICT` behavior preserved **exactly**; new `--level off` disables a check.
- **`docs/03_DESIGN_SEVERITY_MODEL_CONTRACT.md`**: §9 marked **RESOLVED**; check list updated to **8** (adds `caption_footnote` #173, `ref_integrity` #174); `LINT_STRICT` scope locked.
- **`20_env-vars.md`**: document the two newly-wired env knobs.

D2 (`paper_symlink` + `media_provenance`) and D3 (`references` + `float_order`, + `caption_footnote`/`ref_integrity`) follow as separate PRs.

## Test plan
- [x] `_severity.py` unit tests (no mocks; one-assert/AAA): precedence ladder, both tightening overlays + their scope, repair-gating, `env_truthy`.
- [x] `limits`/`overflow` `strict`→error / non-strict→warn back-compat regression-covered by the existing `test_check_limits.py` / `test_check_overflow.py`.
- [x] Smoke-tested in-container: default→exit 0, `--strict`→exit 1, `--level off`→disabled+exit 0 (both checks).
- [x] `py_compile` clean; `scitex-dev linter check-files` clean (PA/TQ).
- [ ] CI matrix green.