### PR TITLE
feat(checks): adopt severity resolver in paper_symlink + media_provenance + YAML-bool level fix (D2)

### DIFF
--- a/docs/03_DESIGN_SEVERITY_MODEL_CONTRACT.md
+++ b/docs/03_DESIGN_SEVERITY_MODEL_CONTRACT.md
@@ -106,6 +106,13 @@ Everything below keeps working **identically to today**:
   bodies collapse into it.
 - Public API (`checks.*`) and MCP handlers keep their signatures; `strict` bools
   stay as aliases (passed in via `legacy_strict`).
+- **Config `level` YAML-bool coercion (D2):** PyYAML (YAML 1.1) coerces a bare
+  `off`/`no`/`false` to `False`, so `level: off` arrives as a bool. Per §2 ("off
+  disables") the shared `_read_config_level` maps `False` → `"off"`. A genuinely
+  invalid value (`True` from `on`/`yes`, or a typo) is **not** silently dropped:
+  one precise `[WARN]` hint is printed and the value is treated as unset (falls
+  through to the default) — never crashing the build over a config typo. A
+  missing key stays a silent no-op.
 
 ## 8. Migration & risk (for the operator to assess)
 

--- a/scripts/python/_severity.py
+++ b/scripts/python/_severity.py
@@ -25,6 +25,7 @@
 # `check_*.py` standalones.
 
 import os
+import sys
 from pathlib import Path
 
 # off < warn < error < repair. `repair` is error-semantics plus a safe
@@ -58,6 +59,41 @@ def _norm(value, check):
     return None
 
 
+def _coerce_config_level(raw, check, source):
+    """Coerce a raw config ``level`` value to a valid level, or None.
+
+    YAML 1.1 coerces a bare ``off``/``no``/``false`` to Python ``False``, so
+    ``level: off`` arrives as ``False`` rather than the string ``"off"`` -- per
+    the §2 contract ruling this MUST still disable the check, so ``False`` maps
+    to ``"off"``. A genuinely invalid value (``True`` from ``on``/``yes``, or a
+    typo'd string) is NOT silently dropped: a one-line hint is printed and the
+    value is treated as unset (caller falls through to its default). A missing
+    key (``None``) stays a silent no-op.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        if raw is False:  # YAML off / no / false -> disable
+            return "off"
+        # True came from on / yes / true -- not a meaningful severity level.
+        _warn_invalid_level(raw, check, source)
+        return None
+    norm = _norm(raw, check)
+    if norm is not None:
+        return norm
+    _warn_invalid_level(raw, check, source)
+    return None
+
+
+def _warn_invalid_level(raw, check, source):
+    """Fail loud (one line) on an invalid config ``level``; never crash."""
+    valid = "/".join(_valid_levels(check))
+    sys.stderr.write(
+        f"[WARN] {source}: {check}.level must be one of {valid}; got {raw!r} "
+        f"-- ignoring (using default). Quote string values, e.g. level: \"off\".\n"
+    )
+
+
 def env_truthy(name):
     """True iff env var ``name`` is set to a truthy token (1/true/yes)."""
     return os.environ.get(name, "").strip().lower() in _TRUTHY
@@ -84,7 +120,7 @@ def _read_config_level(config_path, check):
     block = data.get(check)
     if not isinstance(block, dict):
         return None
-    return _norm(block.get("level"), check)
+    return _coerce_config_level(block.get("level"), check, str(config_path))
 
 
 def resolve_level(

--- a/scripts/python/check_media_provenance.py
+++ b/scripts/python/check_media_provenance.py
@@ -50,6 +50,9 @@ import os
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
+
 # ANSI colors (match check_paper_symlink.py / check_overflow.py)
 GREEN = "\033[0;32m"
 YELLOW = "\033[1;33m"
@@ -63,7 +66,6 @@ WARN_COUNT = 0
 FAIL_COUNT = 0
 
 _LEVELS = ("off", "warn", "error")
-_DEFAULT_LEVEL = "off"
 
 _DOC_DIRS = {
     "manuscript": "01_manuscript",
@@ -128,23 +130,6 @@ def _config_blocks(project_dir):
     proj = _read_block(Path(project_dir) / "config.yaml")
     user = _read_block(Path.home() / ".scitex" / "writer" / "config.yaml")
     return proj, user
-
-
-def resolve_level(cli_level, proj_block, user_block):
-    """Resolve the effective severity level via the documented precedence."""
-    if cli_level:
-        return cli_level.lower()
-
-    env = os.environ.get("SCITEX_WRITER_MEDIA_PROVENANCE", "").strip().lower()
-    if env in _LEVELS:
-        return env
-
-    for block in (proj_block, user_block):
-        level = block.get("level")
-        if isinstance(level, str) and level.lower() in _LEVELS:
-            return level.lower()
-
-    return _DEFAULT_LEVEL
 
 
 def resolve_require_under_scripts(cli_flag, proj_block, user_block):
@@ -219,7 +204,13 @@ def main():
 
     project_dir = Path(args.project_dir).resolve()
     proj_block, user_block = _config_blocks(project_dir)
-    level = resolve_level(args.level, proj_block, user_block)
+    level = resolve_level(
+        "media_provenance",
+        args.level,
+        project_dir,
+        default="off",
+        env_var="SCITEX_WRITER_MEDIA_PROVENANCE",
+    )
     require_under_scripts = resolve_require_under_scripts(
         args.require_under_scripts, proj_block, user_block
     )

--- a/scripts/python/check_paper_symlink.py
+++ b/scripts/python/check_paper_symlink.py
@@ -50,6 +50,9 @@ import os
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
+
 # ANSI colors (match check_overflow.py / check_limits.py)
 GREEN = "\033[0;32m"
 YELLOW = "\033[1;33m"
@@ -63,7 +66,6 @@ WARN_COUNT = 0
 FAIL_COUNT = 0
 
 _LEVELS = ("off", "warn", "error", "repair")
-_DEFAULT_LEVEL = "warn"
 _CANONICAL_REL = ".scitex/writer"
 
 # How many diverged file paths to print before truncating.
@@ -90,63 +92,6 @@ def log_fail(msg):
 
 def log_detail(msg):
     print(f"    {DIM}{msg}{NC}")
-
-
-def _read_config_level(config_path):
-    """Read ``paper_symlink.level`` from a YAML config, or None.
-
-    Returns the level string when present and valid, else None. A missing
-    file or missing key is simply None (not an error). PyYAML is optional --
-    if it is absent we silently skip config files (env + CLI still work).
-    """
-    if not config_path.exists():
-        return None
-    try:
-        import yaml
-    except ImportError:
-        return None
-    try:
-        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
-    except Exception:
-        return None
-    if not isinstance(data, dict):
-        return None
-    block = data.get("paper_symlink")
-    if not isinstance(block, dict):
-        return None
-    level = block.get("level")
-    if isinstance(level, str) and level.lower() in _LEVELS:
-        return level.lower()
-    return None
-
-
-def resolve_level(cli_level, project_dir):
-    """Resolve the effective severity level via the documented precedence.
-
-    1. CLI --level
-    2. env SCITEX_WRITER_PAPER_SYMLINK
-    3. project ./config.yaml -> paper_symlink.level
-    4. user ~/.scitex/writer/config.yaml -> paper_symlink.level
-    5. default off
-    """
-    if cli_level:
-        return cli_level.lower()
-
-    env = os.environ.get("SCITEX_WRITER_PAPER_SYMLINK", "").strip().lower()
-    if env in _LEVELS:
-        return env
-
-    proj_level = _read_config_level(Path(project_dir) / "config.yaml")
-    if proj_level:
-        return proj_level
-
-    user_level = _read_config_level(
-        Path.home() / ".scitex" / "writer" / "config.yaml"
-    )
-    if user_level:
-        return user_level
-
-    return _DEFAULT_LEVEL
 
 
 def _sha256(path):
@@ -235,7 +180,13 @@ def main():
     link = project_dir / "paper"
     canonical = project_dir / _CANONICAL_REL
 
-    level = resolve_level(args.level, project_dir)
+    level = resolve_level(
+        "paper_symlink",
+        args.level,
+        project_dir,
+        default="warn",
+        env_var="SCITEX_WRITER_PAPER_SYMLINK",
+    )
 
     print(f"\n{BOLD}=== Paper Symlink Check (level={level}) ==={NC}\n")
 

--- a/tests/scripts/python/test__severity.py
+++ b/tests/scripts/python/test__severity.py
@@ -19,12 +19,18 @@ from _severity import (  # noqa: E402
     resolve_level,
 )
 
-# Every per-check env var the resolver may read, isolated per test.
+# Every per-check env var the resolver may read, isolated per test. The shared
+# self-hosted runners export many SCITEX_* vars in-profile, so a per-check leak
+# would make a test pass/fail by host -- list them all (cheap insurance).
 _ENV_KEYS = (
     "SCITEX_WRITER_LIMITS",
     "SCITEX_WRITER_OVERFLOW",
     "SCITEX_WRITER_PAPER_SYMLINK",
+    "SCITEX_WRITER_MEDIA_PROVENANCE",
     "SCITEX_WRITER_REFERENCES",
+    "SCITEX_WRITER_FLOAT_ORDER",
+    "SCITEX_WRITER_CAPTION_FOOTNOTE",
+    "SCITEX_WRITER_REF_INTEGRITY",
     "SCITEX_WRITER_LINT_STRICT",
 )
 
@@ -158,6 +164,50 @@ def test_invalid_env_value_falls_through(tmp_path, clean_env):
     """A bogus env value is ignored and the default applies."""
     # Arrange
     os.environ["SCITEX_WRITER_LIMITS"] = "nonsense"
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "warn"
+
+
+# ============================================================================
+# config `level` YAML-bool coercion (§2 ruling: `level: off` must disable)
+# ============================================================================
+
+
+def test_config_level_off_yaml_bool_disables(tmp_path, clean_env):
+    """`level: off` (YAML 1.1 -> bool False) still disables the check."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write_yaml(tmp_path / "config.yaml", "limits:\n  level: off\n")
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "off"
+
+
+def test_config_level_on_yaml_bool_falls_through(tmp_path, clean_env):
+    """`level: on` (YAML -> bool True) is invalid and falls through to default."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write_yaml(tmp_path / "config.yaml", "limits:\n  level: on\n")
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "warn"
+
+
+def test_config_level_typo_falls_through(tmp_path, clean_env):
+    """A typo'd config level is ignored (treated as unset), not a crash."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write_yaml(tmp_path / "config.yaml", "limits:\n  level: bogus\n")
     # Act
     level = resolve_level(
         "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"

--- a/tests/scripts/python/test_check_paper_symlink.py
+++ b/tests/scripts/python/test_check_paper_symlink.py
@@ -73,7 +73,13 @@ def test_resolve_level_defaults_to_warn(tmp_path, clean_paper_env):
     # Arrange
     project_dir = str(tmp_path)
     # Act
-    level = resolve_level(None, project_dir)
+    level = resolve_level(
+        "paper_symlink",
+        None,
+        project_dir,
+        default="warn",
+        env_var="SCITEX_WRITER_PAPER_SYMLINK",
+    )
     # Assert
     assert level == "warn"
 


### PR DESCRIPTION
## Summary
Rollout step **D2** of the ratified Part-D severity contract (follows D1 #175).

- **`paper_symlink` + `media_provenance`** now import the shared `resolve_level` from `_severity.py`; their per-check `resolve_level`/`_read_config_level` bodies are removed. Defaults unchanged (`paper_symlink`=`warn` incl. `repair`; `media_provenance`=`off`), env/CLI/config precedence identical. Smoke-verified: defaults preserved + `--level off` disables.
- **YAML-bool config-`level` fix** (scitex-dev §2 ruling — card `writer-config-level-yaml-bool-footgun`): PyYAML (YAML 1.1) coerces a bare `level: off` to bool `False`, which the old `isinstance(str)` gate silently dropped (config-set `off` was a no-op). `_read_config_level` now maps `False`→`"off"` (honors §2 "off disables"). A genuinely invalid value (bool `True` from `on`/`yes`, or a typo) prints **one** precise stderr hint and is treated as unset (falls through to default) — **never crashes the build**. Missing key stays a silent no-op.
  - **Note for reviewer:** I used the *targeted* coercion in `_read_config_level` rather than a global no-implicit-bool SafeLoader. Reason: a global no-bool loader would regress legitimate booleans parsed elsewhere — `media_provenance.require_under_scripts: true` and `limits.strict: true` would become the strings `"true"` and fail their `isinstance(bool)` checks. The targeted approach fixes the `level` enum without touching genuine bool fields. Matches the "minimal equivalent" you offered; flagging since you preferred the loader variant.

## Test plan
- [x] YAML-bool coercion unit tests: `off`-bool disables, `on`-bool + typo fall through to default (no crash).
- [x] `clean_env` `_ENV_KEYS` broadened to all per-check vars (your note b — host env-leak insurance).
- [x] `paper_symlink` `resolve_level` test updated to the shared signature.
- [x] Smoke-tested: `paper_symlink` default (no link)→0, `--level off`→disabled; `media_provenance` default off→disabled, `--level error`→0.
- [x] `py_compile` clean; `scitex-dev linter check-files` clean.
- [ ] CI matrix green.

D3 (references + float_order + caption_footnote + ref_integrity) follows.