### PR TITLE
feat(checks): adopt shared severity resolver in caption_footnote + ref_integrity (D3a)

### DIFF
--- a/scripts/python/check_caption_footnote.py
+++ b/scripts/python/check_caption_footnote.py
@@ -49,6 +49,9 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
+
 # ANSI colors (match check_media_provenance.py / check_paper_symlink.py)
 GREEN = "\033[0;32m"
 YELLOW = "\033[1;33m"
@@ -62,7 +65,6 @@ WARN_COUNT = 0
 FAIL_COUNT = 0
 
 _LEVELS = ("off", "warn", "error")
-_DEFAULT_LEVEL = "error"
 
 _DOC_DIRS = {
     "manuscript": "01_manuscript",
@@ -100,44 +102,6 @@ def log_fail(msg):
 
 def log_detail(msg):
     print(f"    {DIM}{msg}{NC}")
-
-
-def _read_block(config_path):
-    """Read the ``caption_footnote`` mapping from a YAML config, or ``{}``."""
-    if not config_path.exists():
-        return {}
-    try:
-        import yaml
-    except ImportError:
-        return {}
-    try:
-        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
-    except Exception:
-        return {}
-    if not isinstance(data, dict):
-        return {}
-    block = data.get("caption_footnote")
-    return block if isinstance(block, dict) else {}
-
-
-def _config_blocks(project_dir):
-    proj = _read_block(Path(project_dir) / "config.yaml")
-    user = _read_block(Path.home() / ".scitex" / "writer" / "config.yaml")
-    return proj, user
-
-
-def resolve_level(cli_level, proj_block, user_block):
-    """Resolve the effective severity level via the documented precedence."""
-    if cli_level:
-        return cli_level.lower()
-    env = os.environ.get("SCITEX_WRITER_CAPTION_FOOTNOTE", "").strip().lower()
-    if env in _LEVELS:
-        return env
-    for block in (proj_block, user_block):
-        level = block.get("level")
-        if isinstance(level, str) and level.lower() in _LEVELS:
-            return level.lower()
-    return _DEFAULT_LEVEL
 
 
 def _strip_comments(text):
@@ -278,8 +242,13 @@ def main():
     args = parser.parse_args()
 
     project_dir = Path(args.project_dir).resolve()
-    proj_block, user_block = _config_blocks(project_dir)
-    level = resolve_level(args.level, proj_block, user_block)
+    level = resolve_level(
+        "caption_footnote",
+        args.level,
+        project_dir,
+        default="error",
+        env_var="SCITEX_WRITER_CAPTION_FOOTNOTE",
+    )
 
     print(f"\n{BOLD}=== Caption Footnote Check (level={level}) ==={NC}\n")
 

--- a/scripts/python/check_ref_integrity.py
+++ b/scripts/python/check_ref_integrity.py
@@ -36,13 +36,13 @@
 # check_references.py (same scripts/python/ dir).
 
 import argparse
-import os
 import re
 import sys
 from pathlib import Path
 
 # Reuse the proven extractors from the sibling check (same dir).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
 from check_references import (  # noqa: E402
     collect_tex_files,
     extract_bib_keys,
@@ -64,7 +64,6 @@ WARN_COUNT = 0
 FAIL_COUNT = 0
 
 _LEVELS = ("off", "warn", "error")
-_DEFAULT_LEVEL = "error"
 
 _DOC_DIRS = {
     "manuscript": "01_manuscript",
@@ -102,37 +101,6 @@ def log_detail(msg):
     print(f"    {DIM}{msg}{NC}")
 
 
-def _read_block(config_path):
-    if not config_path.exists():
-        return {}
-    try:
-        import yaml
-    except ImportError:
-        return {}
-    try:
-        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
-    except Exception:
-        return {}
-    if not isinstance(data, dict):
-        return {}
-    block = data.get("ref_integrity")
-    return block if isinstance(block, dict) else {}
-
-
-def resolve_level(cli_level, project_dir):
-    """Resolve severity via CLI > env > project config > user config > default."""
-    if cli_level:
-        return cli_level.lower()
-    env = os.environ.get("SCITEX_WRITER_REF_INTEGRITY", "").strip().lower()
-    if env in _LEVELS:
-        return env
-    proj = _read_block(Path(project_dir) / "config.yaml")
-    user = _read_block(Path.home() / ".scitex" / "writer" / "config.yaml")
-    for block in (proj, user):
-        level = block.get("level")
-        if isinstance(level, str) and level.lower() in _LEVELS:
-            return level.lower()
-    return _DEFAULT_LEVEL
 
 
 def _read_aux_labels(aux_path):
@@ -175,7 +143,13 @@ def main():
     args = parser.parse_args()
 
     project_dir = Path(args.project_dir).resolve()
-    level = resolve_level(args.level, project_dir)
+    level = resolve_level(
+        "ref_integrity",
+        args.level,
+        project_dir,
+        default="error",
+        env_var="SCITEX_WRITER_REF_INTEGRITY",
+    )
 
     print(f"\n{BOLD}=== Reference Integrity Gate (level={level}) ==={NC}\n")
     if level == "off":

--- a/tests/scripts/python/test_check_caption_footnote.py
+++ b/tests/scripts/python/test_check_caption_footnote.py
@@ -72,20 +72,34 @@ def clean_env():
 # ============================================================================
 
 
-def test_resolve_level_defaults_to_error(clean_env):
+def test_resolve_level_defaults_to_error(tmp_path, clean_env):
     """With no --level, no env, no config, the default level is error."""
     # Arrange
     # Act
-    level = resolve_level(None, {}, {})
+    level = resolve_level(
+        "caption_footnote",
+        None,
+        tmp_path,
+        default="error",
+        env_var="SCITEX_WRITER_CAPTION_FOOTNOTE",
+    )
     # Assert
     assert level == "error"
 
 
-def test_resolve_level_cli_overrides(clean_env):
-    """An explicit --level wins over everything else."""
+def test_resolve_level_cli_overrides(tmp_path, clean_env):
+    """An explicit --level wins over a config-set level."""
     # Arrange
+    pytest.importorskip("yaml")
+    _write(tmp_path, "config.yaml", "caption_footnote:\n  level: error\n")
     # Act
-    level = resolve_level("warn", {"level": "error"}, {})
+    level = resolve_level(
+        "caption_footnote",
+        "warn",
+        tmp_path,
+        default="error",
+        env_var="SCITEX_WRITER_CAPTION_FOOTNOTE",
+    )
     # Assert
     assert level == "warn"
 

--- a/tests/scripts/python/test_check_ref_integrity.py
+++ b/tests/scripts/python/test_check_ref_integrity.py
@@ -77,7 +77,13 @@ def test_resolve_level_defaults_to_error(tmp_path, clean_env):
     """With no --level, no env, no config, the default level is error."""
     # Arrange
     # Act
-    level = resolve_level(None, str(tmp_path))
+    level = resolve_level(
+        "ref_integrity",
+        None,
+        str(tmp_path),
+        default="error",
+        env_var="SCITEX_WRITER_REF_INTEGRITY",
+    )
     # Assert
     assert level == "error"
 


### PR DESCRIPTION
## Summary
Rollout step **D3a** — the *pure-swap* half of D3 (follows D1 #175, D2 #176).

- **`caption_footnote` + `ref_integrity`** now import the shared `resolve_level` from `_severity.py`; their local `resolve_level` / `_read_block` / `_config_blocks` bodies are removed.
- **No behavior change**: per-check defaults unchanged (both `error`), env unchanged (`SCITEX_WRITER_CAPTION_FOOTNOTE` / `SCITEX_WRITER_REF_INTEGRITY`), `<check>.level` config + precedence identical. Both now also inherit the D2 YAML-bool config-`level` coercion + fail-loud-on-invalid for free.
- Dropped the now-unused `import os` from `ref_integrity` (`caption_footnote` keeps it for `os.walk`).

The remaining D3 — `references` + `float_order` — is deliberately split into a **separate PR** because that one *expands behavior* (those checks gain new `--level`/env plumbing and the ability to set `off`/`warn`, making a broken ref non-fatal), unlike these pure swaps. Keeping it separate so the behavior-expanding change is reviewed on its own.

## Test plan
- [x] Both checks' `resolve_level` tests updated to the shared signature (default `error`; CLI overrides config).
- [x] Smoke-verified: default `error` path + `--level off` disables, for both checks.
- [x] No leftover refs to removed helpers; `py_compile` clean; `scitex-dev linter check-files` clean on both test files.
- [ ] CI matrix green.

D3b (references + float_order) follows.