### PR TITLE
feat(checks): adopt severity resolver in check_references with off/warn/error (D3b)

### DIFF
--- a/scripts/python/check_references.py
+++ b/scripts/python/check_references.py
@@ -20,6 +20,9 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
+
 # ANSI colors
 GREEN = "\033[0;32m"
 YELLOW = "\033[1;33m"
@@ -31,6 +34,10 @@ NC = "\033[0m"
 PASS_COUNT = 0
 WARN_COUNT = 0
 FAIL_COUNT = 0
+
+# Effective severity (off|warn|error), set by main() via the shared resolver.
+# Default error preserves the historical "broken ref => exit 1" behavior.
+_LEVEL = "error"
 
 
 def log_pass(msg):
@@ -46,7 +53,13 @@ def log_warn(msg):
 
 
 def log_fail(msg):
+    """Report a defect. At level ``warn`` it is demoted to a non-fatal
+    ``[WARN]`` (the severity model: ``warn`` reports findings but exits 0);
+    at ``error`` (default) it is a fatal ``[FAIL]`` that drives exit 1."""
     global FAIL_COUNT
+    if _LEVEL == "warn":
+        log_warn(msg)
+        return
     print(f"  {RED}[FAIL]{NC} {msg}")
     FAIL_COUNT += 1
 
@@ -333,7 +346,7 @@ def check_log_warnings(log_file, doc_label):
 
 
 def main():
-    global PASS_COUNT, WARN_COUNT, FAIL_COUNT
+    global PASS_COUNT, WARN_COUNT, FAIL_COUNT, _LEVEL
 
     parser = argparse.ArgumentParser(
         description="Check cross-references, citations, and labels in LaTeX manuscripts"
@@ -355,9 +368,35 @@ def main():
         action="store_true",
         help="Also parse LaTeX .log files for warnings",
     )
+    parser.add_argument(
+        "--level",
+        choices=["off", "warn", "error"],
+        default=None,
+        help="Severity: error (default), warn (report but exit 0), or off "
+        "(disable). Overrides env and config.",
+    )
     args = parser.parse_args()
 
     project_dir = Path(args.project_dir).resolve()
+    _LEVEL = resolve_level(
+        "references",
+        args.level,
+        project_dir,
+        default="error",
+        env_var="SCITEX_WRITER_REFERENCES",
+    )
+    if _LEVEL == "off":
+        print(f"\n{BOLD}=== Reference Check (level=off) ==={NC}\n")
+        print(
+            f"  {DIM}[INFO]{NC} reference check is disabled (level=off). "
+            f"Set references.level or --level to enable."
+        )
+        print(
+            f"\n{BOLD}Summary:{NC} {GREEN}0 passed{NC}, "
+            f"{YELLOW}0 warnings{NC}, {RED}0 errors{NC}"
+        )
+        return 0
+
     bib_dir = project_dir / "00_shared" / "bib_files"
 
     # Collect document directories

--- a/src/scitex_writer/_skills/scitex-writer/20_env-vars.md
+++ b/src/scitex_writer/_skills/scitex-writer/20_env-vars.md
@@ -41,6 +41,9 @@ exits non-zero.
 | `SCITEX_WRITER_OVERFLOW` | Severity for the off-page overflow check (`off`/`warn`/`error`). Default `warn`; `--strict`/`overflow.strict` tighten to `error`. | `warn` | enum |
 | `SCITEX_WRITER_PAPER_SYMLINK` | Severity for the `paper -> .scitex/writer` symlink check (`off`/`warn`/`error`/`repair`). Private convention — default `warn`. | `warn` | enum |
 | `SCITEX_WRITER_MEDIA_PROVENANCE` | Severity for the media-symlink/provenance check on `caption_and_media/` (`off`/`warn`/`error`). Private convention — default `off`. | `off` | enum |
+| `SCITEX_WRITER_REFERENCES` | Severity for the cross-reference/citation/label check (`off`/`warn`/`error`). Default `error` (a broken `\ref`/`\cite` is a real defect); `warn` reports but exits 0; `off` disables. | `error` | enum |
+| `SCITEX_WRITER_CAPTION_FOOTNOTE` | Severity for the `\footnote`-in-`\caption{}` lint (`off`/`warn`/`error`). Default `error`. | `error` | enum |
+| `SCITEX_WRITER_REF_INTEGRITY` | Severity for the pre-compile reference-integrity gate (`off`/`warn`/`error`). Default `error`. | `error` | enum |
 
 ## Branding & naming
 

--- a/tests/scripts/python/test_check_references.py
+++ b/tests/scripts/python/test_check_references.py
@@ -3,12 +3,18 @@
 # Test file for: check_references.py
 
 import os
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
+
+import pytest
 
 # Add scripts/python to path for imports
 ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+_SCRIPT = ROOT_DIR / "scripts" / "python" / "check_references.py"
 
 from check_references import (  # noqa: E402
     collect_tex_files,
@@ -519,7 +525,78 @@ def test_auto_labels_vs_explicit(tmp_path):
     )
 
 
-if __name__ == "__main__":
-    import pytest
+# ============================================================================
+# Severity level (off / warn / error) — D3b adoption of the shared resolver
+# ============================================================================
 
+
+@pytest.fixture
+def clean_env():
+    """Isolate SCITEX_WRITER_REFERENCES + HOME so no stray env/user config
+    leaks into severity resolution."""
+    saved = {k: os.environ.get(k) for k in ("SCITEX_WRITER_REFERENCES", "HOME")}
+    os.environ.pop("SCITEX_WRITER_REFERENCES", None)
+    with tempfile.TemporaryDirectory() as home:
+        os.environ["HOME"] = home
+        yield home
+    for key, val in saved.items():
+        if val is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = val
+
+
+def _project_with_broken_ref(tmp_path):
+    """A minimal manuscript with one \\ref to a non-existent label."""
+    contents = tmp_path / "01_manuscript" / "contents"
+    contents.mkdir(parents=True)
+    (contents / "results.tex").write_text("See \\ref{fig:missing}.\n", encoding="utf-8")
+    bib = tmp_path / "00_shared" / "bib_files"
+    bib.mkdir(parents=True)
+    (bib / "bibliography.bib").write_text("", encoding="utf-8")
+    return tmp_path
+
+
+def _run(project, *extra):
+    env = dict(os.environ)
+    env.pop("SCITEX_WRITER_REFERENCES", None)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), str(project), "--doc-type", "manuscript", *extra],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_default_level_errors_on_broken_ref(tmp_path, clean_env):
+    """With the default level (error), a broken \\ref exits non-zero."""
+    # Arrange
+    _project_with_broken_ref(tmp_path)
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_warn_level_demotes_broken_ref(tmp_path, clean_env):
+    """At --level warn, a broken \\ref is reported but exits zero."""
+    # Arrange
+    _project_with_broken_ref(tmp_path)
+    # Act
+    proc = _run(tmp_path, "--level", "warn")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_off_level_disables_check(tmp_path, clean_env):
+    """At --level off, the check is disabled and exits zero with a loud note."""
+    # Arrange
+    _project_with_broken_ref(tmp_path)
+    # Act
+    proc = _run(tmp_path, "--level", "off")
+    # Assert
+    assert "disabled (level=off)" in proc.stdout
+
+
+if __name__ == "__main__":
     pytest.main([os.path.abspath(__file__), "-v"])


### PR DESCRIPTION
## Summary
Rollout step **D3b** — the behavior-*expanding* half of D3 (follows D1 #175, D2 #176, D3a #177).

`check_references` now imports the shared `resolve_level` from `_severity.py` and gains a severity knob:
- `--level off|warn|error` + env `SCITEX_WRITER_REFERENCES` + config `references.level`; precedence CLI > env > project config > user config > default. **Default stays `error`** — today's "broken `\ref`/`\cite` ⇒ exit 1" is unchanged.
- A module `_LEVEL` routes `log_fail`: at `warn` a defect is demoted to a non-fatal `[WARN]` (reported, exit 0); at `error` (default) it is `[FAIL]` ⇒ exit 1. `off` short-circuits with a loud "disabled (level=off)" note + the `Summary` line, exit 0.

## Downgrade-path safety (scitex-dev's review concern)
The `off`/`warn` downgrade is **loud and visible** (disabled note / `[WARN]` lines / `Summary`), and `check_references` is **NOT** in `validate_before_compile` (which runs structure + limits only), so `off` **cannot silently bypass a compile block** — it's an explicit, config-visible opt-out. Smoke-verified all three levels.

## Test plan
- [x] Subprocess severity tests: default `error`→exit 1 on a broken `\ref`; `--level warn`→exit 0; `--level off`→"disabled" note. One assertion each, no mocks.
- [x] `py_compile` clean; `scitex-dev linter check-files` clean.
- [x] Env-vars doc gains `SCITEX_WRITER_REFERENCES` / `CAPTION_FOOTNOTE` / `REF_INTEGRITY` rows.
- [ ] CI matrix green.

## Note
`float_order` is **split into a separate PR** (card `writer-severity-d3c-float-order`): it's a fixer with no `Summary` line / `FAIL_COUNT`, so it needs structural work (add the Summary line + severity routing + define `--fix`×level precedence), not a pure swap. After D3c, the framework covers all 8 checks.