### PR TITLE
feat(checks): adopt severity model in check_float_order (D3c) — completes 8/8

### DIFF
--- a/scripts/python/check_float_order.py
+++ b/scripts/python/check_float_order.py
@@ -16,6 +16,9 @@ import sys
 from collections import OrderedDict
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
+
 # ANSI colors
 GREEN = "\033[0;32m"
 YELLOW = "\033[1;33m"
@@ -23,6 +26,41 @@ RED = "\033[0;31m"
 DIM = "\033[0;90m"
 BOLD = "\033[1m"
 NC = "\033[0m"
+
+PASS_COUNT = 0
+WARN_COUNT = 0
+FAIL_COUNT = 0
+
+# Effective severity (off|warn|error), set by main() via the shared resolver.
+# Default error preserves the historical "out-of-order float => exit 1" behavior.
+_LEVEL = "error"
+
+
+def log_pass(msg):
+    global PASS_COUNT
+    print(f"  {GREEN}[PASS]{NC} {msg}")
+    PASS_COUNT += 1
+
+
+def log_warn(msg):
+    global WARN_COUNT
+    print(f"  {YELLOW}[WARN]{NC} {msg}")
+    WARN_COUNT += 1
+
+
+def log_fail(msg):
+    """At ``warn``/``off`` a defect is demoted to a non-fatal ``[WARN]``; at
+    ``error`` (default) it is a fatal ``[FAIL]`` that drives exit 1."""
+    global FAIL_COUNT
+    if _LEVEL in ("warn", "off"):
+        log_warn(msg)
+        return
+    print(f"  {RED}[FAIL]{NC} {msg}")
+    FAIL_COUNT += 1
+
+
+def log_detail(msg):
+    print(f"    {DIM}{msg}{NC}")
 
 
 def find_references(content_dir, float_type):
@@ -158,7 +196,7 @@ def check_order(content_dir, float_type, label):
     labels = find_labels(content_dir, float_type)
 
     if not refs:
-        print(f"  {GREEN}[PASS]{NC} {label} references - none found")
+        log_pass(f"{label} references - none found")
         return True, refs, {}
 
     # Check if numbered keys appear in order
@@ -169,7 +207,7 @@ def check_order(content_dir, float_type, label):
             numbered_refs.append((num, name, key, fname, line))
 
     if not numbered_refs:
-        print(f"  {GREEN}[PASS]{NC} {label} references - no numbered references")
+        log_pass(f"{label} references - no numbered references")
         return True, refs, {}
 
     # Check sequential ordering
@@ -181,34 +219,32 @@ def check_order(content_dir, float_type, label):
         expected = list(range(1, len(numbered_refs) + 1))
         actual = numbers
         if actual == expected:
-            print(
-                f"  {GREEN}[PASS]{NC} {label} reference order (1..{len(numbered_refs)})"
-            )
+            log_pass(f"{label} reference order (1..{len(numbered_refs)})")
         else:
-            print(
-                f"  {YELLOW}[WARN]{NC} {label} references sequential but not contiguous: {numbers}"
+            log_warn(
+                f"{label} references sequential but not contiguous: {numbers}"
             )
         return True, refs, {}
 
     # Out of order - build mapping
-    print(f"  {RED}[FAIL]{NC} {label} reference order")
+    log_fail(f"{label} reference order")
     desired_mapping = {}
     for new_num_0, (old_num, name, old_key, fname, line) in enumerate(numbered_refs):
         new_num = new_num_0 + 1
         new_key = f"{new_num:02d}_{name}" if name else f"{new_num:02d}"
         if old_key != new_key:
             desired_mapping[old_key] = new_key
-        print(
-            f"    {DIM}{fname}:{line}: "
-            f"\\ref{{{float_type}:{old_key}}} -> should be {new_num:02d}{NC}"
+        log_detail(
+            f"{fname}:{line}: "
+            f"\\ref{{{float_type}:{old_key}}} -> should be {new_num:02d}"
         )
 
     # Report orphaned labels (defined but never referenced)
     ref_keys = {key for key, _, _ in refs}
     for label_key, info in labels.items():
         if label_key not in ref_keys:
-            print(
-                f"    {YELLOW}[WARN]{NC} \\label{{{float_type}:{label_key}}} "
+            log_warn(
+                f"\\label{{{float_type}:{label_key}}} "
                 f"defined in {info['file'].name}:{info['line']} but never referenced"
             )
 
@@ -348,9 +384,26 @@ def main():
         default="all",
         help="Which document type to check (default: all)",
     )
+    parser.add_argument(
+        "--level",
+        choices=["off", "warn", "error"],
+        default=None,
+        help="Severity: error (default), warn (report but exit 0), or off "
+        "(disable the gate). Overrides env and config. Does NOT disable "
+        "--fix/--dry-run, which always run.",
+    )
     args = parser.parse_args()
 
+    global _LEVEL
     project_dir = Path(args.project_dir).resolve()
+    _LEVEL = resolve_level(
+        "float_order",
+        args.level,
+        project_dir,
+        default="error",
+        env_var="SCITEX_WRITER_FLOAT_ORDER",
+    )
+    fixing = args.fix or args.dry_run
 
     doc_types = []
     if args.doc_type in ("manuscript", "all"):
@@ -365,6 +418,20 @@ def main():
     if not doc_types:
         print(f"{RED}No content directories found in {project_dir}{NC}")
         sys.exit(1)
+
+    # off disables the gate. A requested --fix/--dry-run is an explicit user
+    # action and still runs; level only governs the non-fix gating exit.
+    if _LEVEL == "off" and not fixing:
+        print(f"\n{BOLD}=== Float Reference Order Check (level=off) ==={NC}\n")
+        print(
+            f"  {DIM}[INFO]{NC} float-order check is disabled (level=off). "
+            f"Set float_order.level or --level to enable."
+        )
+        print(
+            f"\n{BOLD}Summary:{NC} {GREEN}0 passed{NC}, "
+            f"{YELLOW}0 warnings{NC}, {RED}0 errors{NC}"
+        )
+        return 0
 
     print(f"\n{BOLD}=== Float Reference Order Check ==={NC}\n")
 
@@ -381,14 +448,18 @@ def main():
                     all_mappings.append((content_dir, float_type, mapping, label))
 
     print()
+    print(
+        f"{BOLD}Summary:{NC} {GREEN}{PASS_COUNT} passed{NC}, "
+        f"{YELLOW}{WARN_COUNT} warnings{NC}, {RED}{FAIL_COUNT} errors{NC}"
+    )
 
     if not has_issues:
-        print(f"{GREEN}All float references are in order.{NC}")
+        print(f"\n{GREEN}All float references are in order.{NC}")
         return 0
 
-    if args.fix or args.dry_run:
+    if fixing:
         mode = "DRY RUN" if args.dry_run else "FIXING"
-        print(f"{BOLD}--- {mode} ---{NC}\n")
+        print(f"\n{BOLD}--- {mode} ---{NC}\n")
         for content_dir, float_type, mapping, label in all_mappings:
             print(f"  {label}: renumbering {len(mapping)} items")
             for old, new in mapping.items():
@@ -399,9 +470,18 @@ def main():
         if not args.dry_run:
             print(f"{GREEN}Renumbering complete. Re-run to verify.{NC}")
         return 0
-    else:
-        print(f"{YELLOW}Run with --fix to auto-renumber, or --dry-run to preview.{NC}")
+
+    # Out-of-order floats, not fixing. At error (default) this gates (exit 1);
+    # at warn the findings were demoted to [WARN] (FAIL_COUNT == 0) and are
+    # non-fatal.
+    if FAIL_COUNT > 0:
+        print(f"\n{YELLOW}Run with --fix to auto-renumber, or --dry-run to preview.{NC}")
         return 1
+    print(
+        f"\n{YELLOW}Out-of-order floats reported (level=warn, non-fatal). "
+        f"Run with --fix to auto-renumber.{NC}"
+    )
+    return 0
 
 
 if __name__ == "__main__":

--- a/src/scitex_writer/_skills/scitex-writer/20_env-vars.md
+++ b/src/scitex_writer/_skills/scitex-writer/20_env-vars.md
@@ -42,8 +42,15 @@ exits non-zero.
 | `SCITEX_WRITER_PAPER_SYMLINK` | Severity for the `paper -> .scitex/writer` symlink check (`off`/`warn`/`error`/`repair`). Private convention — default `warn`. | `warn` | enum |
 | `SCITEX_WRITER_MEDIA_PROVENANCE` | Severity for the media-symlink/provenance check on `caption_and_media/` (`off`/`warn`/`error`). Private convention — default `off`. | `off` | enum |
 | `SCITEX_WRITER_REFERENCES` | Severity for the cross-reference/citation/label check (`off`/`warn`/`error`). Default `error` (a broken `\ref`/`\cite` is a real defect); `warn` reports but exits 0; `off` disables. | `error` | enum |
+| `SCITEX_WRITER_FLOAT_ORDER` | Severity for the figure/table reference-order check (`off`/`warn`/`error`). Default `error`. `--level` governs only the gating exit; `--fix`/`--dry-run` always run regardless of level. | `error` | enum |
 | `SCITEX_WRITER_CAPTION_FOOTNOTE` | Severity for the `\footnote`-in-`\caption{}` lint (`off`/`warn`/`error`). Default `error`. | `error` | enum |
 | `SCITEX_WRITER_REF_INTEGRITY` | Severity for the pre-compile reference-integrity gate (`off`/`warn`/`error`). Default `error`. | `error` | enum |
+
+> **`references` vs `ref_integrity` are separate knobs.** `references` is the
+> advisory cross-reference/citation/label *report*; `ref_integrity` is the
+> *pre-compile integrity gate*. Downgrading `references` (e.g. to `off`) does
+> **not** disable `ref_integrity`, so a broken `\ref` can still block a compile
+> via the gate — defense in depth by design.
 
 ## Branding & naming
 

--- a/tests/scripts/python/test_check_float_order.py
+++ b/tests/scripts/python/test_check_float_order.py
@@ -3,8 +3,12 @@
 # Test file for: check_float_order.py
 
 import os
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
+
+import pytest
 
 # Add scripts/python to path for imports
 ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
@@ -16,6 +20,8 @@ from check_float_order import (  # noqa: E402
     find_labels,
     find_references,
 )
+
+_SCRIPT = ROOT_DIR / "scripts" / "python" / "check_float_order.py"
 
 # ====================================================================
 # Tests for extract_number_and_name
@@ -424,3 +430,95 @@ if __name__ == "__main__":
 # --------------------------------------------------------------------------------
 # End of Source Code from: /home/ywatanabe/proj/scitex-writer/scripts/python/check_float_order.py
 # --------------------------------------------------------------------------------
+
+
+# ============================================================================
+# Severity level (off / warn / error) + --fix×level — D3c adoption
+# ============================================================================
+
+
+@pytest.fixture
+def clean_env():
+    """Isolate SCITEX_WRITER_FLOAT_ORDER + HOME so no stray env/user config
+    leaks into severity resolution."""
+    saved = {k: os.environ.get(k) for k in ("SCITEX_WRITER_FLOAT_ORDER", "HOME")}
+    os.environ.pop("SCITEX_WRITER_FLOAT_ORDER", None)
+    with tempfile.TemporaryDirectory() as home:
+        os.environ["HOME"] = home
+        yield home
+    for key, val in saved.items():
+        if val is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = val
+
+
+def _project_with_out_of_order_floats(tmp_path):
+    """A manuscript referencing fig:02 before fig:01 (out of order)."""
+    contents = tmp_path / "01_manuscript" / "contents"
+    contents.mkdir(parents=True)
+    (contents / "results.tex").write_text(
+        "See \\ref{fig:02} then \\ref{fig:01}.\n", encoding="utf-8"
+    )
+    return tmp_path
+
+
+def _run(project, *extra):
+    env = dict(os.environ)
+    env.pop("SCITEX_WRITER_FLOAT_ORDER", None)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), str(project), "--doc-type", "manuscript", *extra],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_default_level_errors_on_out_of_order(tmp_path, clean_env):
+    """With the default level (error), out-of-order floats exit non-zero."""
+    # Arrange
+    _project_with_out_of_order_floats(tmp_path)
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_warn_level_demotes_out_of_order(tmp_path, clean_env):
+    """At --level warn, out-of-order floats are reported but exit zero."""
+    # Arrange
+    _project_with_out_of_order_floats(tmp_path)
+    # Act
+    proc = _run(tmp_path, "--level", "warn")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_off_level_disables_check(tmp_path, clean_env):
+    """At --level off (no fix), the check is disabled with a loud note."""
+    # Arrange
+    _project_with_out_of_order_floats(tmp_path)
+    # Act
+    proc = _run(tmp_path, "--level", "off")
+    # Assert
+    assert "disabled (level=off)" in proc.stdout
+
+
+def test_off_level_still_runs_dry_run_fix(tmp_path, clean_env):
+    """--dry-run runs regardless of level: off does NOT disable the fixer."""
+    # Arrange
+    _project_with_out_of_order_floats(tmp_path)
+    # Act
+    proc = _run(tmp_path, "--level", "off", "--dry-run")
+    # Assert
+    assert "DRY RUN" in proc.stdout
+
+
+def test_emits_summary_line(tmp_path, clean_env):
+    """check_float_order now emits the contract Summary line."""
+    # Arrange
+    _project_with_out_of_order_floats(tmp_path)
+    # Act
+    proc = _run(tmp_path, "--level", "warn")
+    # Assert
+    assert "Summary:" in proc.stdout


### PR DESCRIPTION
## Summary
Final rollout step — completes the Part-D severity framework across **all 8 checks** (follows D1 #175, D2 #176, D3a #177, D3b #178).

`check_float_order` is a *fixer* (`--fix`/`--dry-run`) with no `Summary` line / counters, so this is **structural**, not a swap:
- Adds `PASS`/`WARN`/`FAIL` counters + `log_pass`/`log_warn`/`log_fail`/`log_detail` and the contract `Summary: N passed, N warnings, N errors` line (was missing, §6); `check_order`'s inline prints route through these.
- Imports the shared `resolve_level`; `--level off|warn|error` + env `SCITEX_WRITER_FLOAT_ORDER` + config `float_order.level`. **Default stays `error`** — today's "out-of-order ⇒ exit 1" is unchanged. A module `_LEVEL` routes `log_fail`: `warn`/`off` demote to a non-fatal `[WARN]`; `error` is `[FAIL]` ⇒ exit 1.

## `--fix` × level precedence (your review point)
`--fix`/`--dry-run` are explicit user actions and **always run regardless of level**; level governs only the *non-fix gating exit*. `off` short-circuits (disabled note + `Summary 0/0/0`) **only when not fixing** — `off` does **not** swallow a requested `--fix`. Smoke-verified: `--level off --dry-run` still renumbers.

## Downgrade-path safety
`off`/`warn` are loud + visible (disabled note / `[WARN]` / `Summary`), and `check_float_order` is **not** in `validate_before_compile`, so `off` can't bypass a compile block.

## Test plan
- [x] Subprocess severity tests: default `error`→exit 1, `--level warn`→exit 0, `--level off`→disabled note, `--level off --dry-run`→fixer still runs, `Summary:` line emitted. No mocks.
- [x] `py_compile` clean; `scitex-dev linter check-files` clean on script + test.
- [x] Env-vars doc: `SCITEX_WRITER_FLOAT_ORDER` row + `references` vs `ref_integrity` clarification note.
- [ ] CI matrix green.

After this merges, the framework covers all 8 checks; next up is folding the ref-integrity `--yes` block-by-default compile gate (`writer-precompile-ref-integrity-gate`) onto it.