### PR TITLE
fix(tables): dark-mode-aware zebra stripe (theme lightgray, not literal gray!10)

### DIFF
--- a/00_shared/latex_styles/dark_mode.tex
+++ b/00_shared/latex_styles/dark_mode.tex
@@ -46,8 +46,11 @@
   singlelinecheck=false
 }
 
-% Adjust table colors for dark mode
-\definecolor{lightgray}{gray}{0.2}  % Darker "light" gray for table rows
+% Zebra-stripe colour for tables. csv_to_latex.py emits \rowcolor{lightgray}
+% for alternate rows; here we darken it so the stripe stays distinct from the
+% dark page AND keeps the light body text legible (light mode defines it as
+% gray 0.95 in packages.tex). gray 0.2 (~#333) sits just above the #1E1E1E page.
+\definecolor{lightgray}{gray}{0.2}
 
 % Override color commands to work well in dark mode
 \renewcommand{\REDENDS}{\color{white}}    % Reset to white instead of black

--- a/scripts/python/csv_to_latex.py
+++ b/scripts/python/csv_to_latex.py
@@ -227,9 +227,13 @@ def csv_to_latex(csv_file, output_file, caption=None, label=None, max_rows=30):
             )
             lines.append("\\midrule")
         else:
-            # Add row coloring for readability (skip separator in count)
+            # Add row coloring for readability (skip separator in count).
+            # Use the theme color `lightgray` (gray 0.95 light mode; redefined to
+            # gray 0.2 in dark_mode.tex) so the zebra stripe stays legible in
+            # BOTH modes. A literal gray!10 stayed light under dark mode, hiding
+            # the light text on the striped rows.
             if idx % 2 == 1:
-                lines.append("\\rowcolor{gray!10}")
+                lines.append("\\rowcolor{lightgray}")
             lines.append(" & ".join(values) + " \\\\")
 
     lines.append("\\bottomrule")

--- a/tests/scripts/python/test_csv_to_latex.py
+++ b/tests/scripts/python/test_csv_to_latex.py
@@ -495,6 +495,19 @@ class TestCsvToLatex:
         # Assert
         assert "$p<0.001$" in content
 
+    def test_csv_to_latex_zebra_stripe_uses_dark_aware_color(self, tmp_path):
+        """Zebra stripe uses the dark-aware `lightgray` theme color, not a
+        literal gray!10 (which stays light and hides text in dark mode)."""
+        # Arrange
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text("Name,Age\nAlice,30\nBob,25\nCarol,40")
+        output_file = tmp_path / "output.tex"
+        csv_to_latex(csv_file, output_file)
+        # Act
+        content = output_file.read_text()
+        # Assert
+        assert ("\\rowcolor{lightgray}" in content) and ("gray!10" not in content)
+
 
 if __name__ == "__main__":
     pytest.main([os.path.abspath(__file__), "-v"])


### PR DESCRIPTION
## Summary
In dark mode, table zebra-stripes stayed **light** while body text is light, so striped rows (P02/P04/…) were unreadable — reported on neurovista Table 1 compiled with `--dark_mode`.

**Root cause:** `csv_to_latex.py` hardcoded `\rowcolor{gray!10}`, bypassing the theme's dark-aware `lightgray` colour. The styling layer was *already* set up for this: `packages.tex` defines `lightgray` = gray 0.95 (light mode) and `dark_mode.tex` redefines it to gray 0.2 ("for table rows") — but nothing used it.

**Fix:** the converter now emits `\rowcolor{lightgray}`, so the stripe follows the mode (0.95 light / 0.2 dark) and text stays legible in both. Durable root fix in the shared styling layer, not a per-table `\rowcolors` override.

## Why it's safe
- Only `csv_to_latex.py` emits the stripe (the AWK fallback doesn't zebra; the package `csv2latex` uses pandas `to_latex`). Single call site.
- LaTeX `lightgray` is used **solely** for table rows (the one other hit is ImageMagick's `xc:lightgray`, unrelated). No collision.
- Light-mode stripe goes gray 0.90→0.95 (marginally fainter, still light); dark-mode stripe is now gray 0.2 (legible with the light body text).

## Test plan
- [x] Regression test: converter emits `\rowcolor{lightgray}` and no longer `gray!10`.
- [x] `py_compile` clean; `scitex-dev linter check-files` clean.
- [ ] CI matrix green.
- [ ] **Visual dark-mode legibility host-confirmed by neurovista** (no LaTeX in the agent container — I can't render). The dark shade (gray 0.2) can be tuned in `dark_mode.tex` if more row contrast is wanted.