### PR TITLE
fix(template): wire shared metadata (title/authors/journal/keywords) through 00_shared SSoT

### DIFF
--- a/00_shared/authors.tex
+++ b/00_shared/authors.tex
@@ -1,4 +1,7 @@
 %% -*- coding: utf-8 -*-
+%% ROLE: SSoT (single source of truth) — EDIT HERE. Consumer-owned; preserved
+%% on re-vendor. The manuscript, supplementary, and revision/diff builds all
+%% \input this file, so the author list can never drift between outputs.
 \author[1]{First Author\corref{cor1}}
 \author[2]{Second Author}
 \author[3]{Third Author}

--- a/00_shared/title.tex
+++ b/00_shared/title.tex
@@ -1,6 +1,11 @@
 %% -*- coding: utf-8 -*-
-\title{
+%% ROLE: SSoT (single source of truth) — EDIT HERE. Consumer-owned; preserved
+%% on re-vendor (update-project never overwrites it). The manuscript,
+%% supplementary, and revision/diff builds all source the title from here, so
+%% it can never drift between outputs. Set the real title in \scitexmanuscripttitle.
+\newcommand{\scitexmanuscripttitle}{%
 Your Manuscript Title Here
 }
+\title{\scitexmanuscripttitle}
 
 %%%% EOF

--- a/01_manuscript/base.tex
+++ b/01_manuscript/base.tex
@@ -14,7 +14,7 @@
 %% ----------------------------------------
 %% JOURNAL NAME
 %% ----------------------------------------
-\input{./01_manuscript/contents/journal_name}
+\input{./00_shared/journal_name}
 
 %% ----------------------------------------
 %% START of DOCUMENT
@@ -26,11 +26,13 @@
 %% ----------------------------------------
 \begin{frontmatter}
 \input{./01_manuscript/contents/highlights}
-\input{./01_manuscript/contents/title}
-\input{./01_manuscript/contents/authors}
+%% Title + authors are sourced from the 00_shared SSoT (NOT per-part copies) so
+%% the manuscript, supplementary, and revision/diff builds can never drift.
+\input{./00_shared/title}
+\input{./00_shared/authors}
 \input{./01_manuscript/contents/graphical_abstract}
 \input{./01_manuscript/contents/abstract}
-\input{./01_manuscript/contents/keywords}
+\input{./00_shared/keywords}
 \end{frontmatter}
 
 %% ----------------------------------------

--- a/01_manuscript/contents/authors.tex
+++ b/01_manuscript/contents/authors.tex
@@ -1,1 +1,0 @@
-../../00_shared/authors.tex

--- a/01_manuscript/contents/journal_name.tex
+++ b/01_manuscript/contents/journal_name.tex
@@ -1,1 +1,0 @@
-../../00_shared/journal_name.tex

--- a/01_manuscript/contents/keywords.tex
+++ b/01_manuscript/contents/keywords.tex
@@ -1,1 +1,0 @@
-../../00_shared/keywords.tex

--- a/01_manuscript/contents/title.tex
+++ b/01_manuscript/contents/title.tex
@@ -1,1 +1,0 @@
-../../00_shared/title.tex

--- a/02_supplementary/base.tex
+++ b/02_supplementary/base.tex
@@ -12,7 +12,7 @@
 %% ----------------------------------------
 %% JOURNAL NAME
 %% ----------------------------------------
-\input{./02_supplementary/contents/journal_name}
+\input{./00_shared/journal_name}
 
 %% ----------------------------------------
 %% START of DOCUMENT
@@ -23,8 +23,13 @@
 %% Frontmatter
 %% ----------------------------------------
 \begin{frontmatter}
-    \title{Supplementary Material}
-	\input{./02_supplementary/contents/authors}
+    %% Title + authors from the 00_shared SSoT. \input{title} defines
+    %% \scitexmanuscripttitle (and sets \title); we then override \title to the
+    %% supplementary form derived from the SAME shared title, so it tracks the
+    %% manuscript automatically.
+    \input{./00_shared/title}
+    \title{Supplementary Material for: \scitexmanuscripttitle}
+    \input{./00_shared/authors}
 \end{frontmatter}
 
 %% ----------------------------------------

--- a/02_supplementary/contents/authors.tex
+++ b/02_supplementary/contents/authors.tex
@@ -1,1 +1,0 @@
-../../00_shared/authors.tex

--- a/02_supplementary/contents/journal_name.tex
+++ b/02_supplementary/contents/journal_name.tex
@@ -1,1 +1,0 @@
-../../00_shared/journal_name.tex

--- a/02_supplementary/contents/keywords.tex
+++ b/02_supplementary/contents/keywords.tex
@@ -1,1 +1,0 @@
-../../00_shared/keywords.tex

--- a/02_supplementary/contents/title.tex
+++ b/02_supplementary/contents/title.tex
@@ -1,1 +1,0 @@
-../../00_shared/title.tex

--- a/03_revision/base.tex
+++ b/03_revision/base.tex
@@ -20,8 +20,10 @@
 %% Frontmatter
 %% ----------------------------------------
 \begin{frontmatter}
-\input{./03_revision/contents/title}
-\input{./03_revision/contents/authors}
+%% Title + authors from the 00_shared SSoT (the manuscript_diff is latexdiff'd
+%% from the assembled manuscript, so it inherits this automatically).
+\input{./00_shared/title}
+\input{./00_shared/authors}
 \end{frontmatter}
 
 %% ----------------------------------------

--- a/03_revision/contents/authors.tex
+++ b/03_revision/contents/authors.tex
@@ -1,1 +1,0 @@
-../../00_shared/authors.tex

--- a/03_revision/contents/journal_name.tex
+++ b/03_revision/contents/journal_name.tex
@@ -1,1 +1,0 @@
-../../00_shared/journal_name.tex

--- a/03_revision/contents/keywords.tex
+++ b/03_revision/contents/keywords.tex
@@ -1,1 +1,0 @@
-../../00_shared/keywords.tex

--- a/03_revision/contents/title.tex
+++ b/03_revision/contents/title.tex
@@ -1,1 +1,0 @@
-../../00_shared/title.tex

--- a/scripts/shell/initialize_contents.sh
+++ b/scripts/shell/initialize_contents.sh
@@ -41,9 +41,10 @@ init_shared() {
 
     cat >"$PROJECT_ROOT/00_shared/title.tex" <<'LATEX'
 %% -*- coding: utf-8 -*-
-\title{
+\newcommand{\scitexmanuscripttitle}{%
 Your Manuscript Title Here
 }
+\title{\scitexmanuscripttitle}
 
 %%%% EOF
 LATEX


### PR DESCRIPTION
## Summary
Operator-requested. The template documented `00_shared` as the metadata single-source-of-truth, but never wired it: `00_shared/{title,authors,journal_name,keywords}.tex` were **orphans** (nothing `\input` them) while each part `\input`'d its own `contents/` copy — so the supplementary drifted to placeholder authors while the manuscript had the real ones (neurovista repro).

Now **all outputs** source shared metadata from `00_shared`, so nothing can drift:
- `01_manuscript`, `02_supplementary`, `03_revision` `base.tex` `\input ./00_shared/{title,authors}` (+ `journal_name`/`keywords` where used). The `manuscript_diff`/`supplementary_diff` are `latexdiff`'d from the assembled docs, so they inherit it automatically.
- **Title as a reusable macro:** `00_shared/title.tex` defines `\scitexmanuscripttitle` and sets `\title{\scitexmanuscripttitle}`. Manuscript `\input`s it directly; supplementary derives its title from the **same** source: `\title{Supplementary Material for: \scitexmanuscripttitle}` — tracks the manuscript automatically, no manual sync.
- Dropped the **12 orphan per-part copies** (`contents/{title,authors,journal_name,keywords}.tex` × 3 parts); verified no other file referenced them.
- `initialize_contents.sh`'s `shared` reset regenerates `title.tex` in the macro form (kept compatible with the supplementary wrap).
- Role hint-comments on the SSoT files. `00_shared/{title,authors}.tex` are in update-project's `PRESERVED_PATHS` (**verified**) — re-vendor never clobbers real metadata.

## Test plan
- [x] No dangling references to the removed `contents/*` files (scripts/src/tests).
- [x] `00_shared/{title,authors}` confirmed consumer-owned (`PRESERVED_PATHS`); `base.tex` are engine-vendored (`LEGACY_ENGINE_PATHS`) so the rewire reaches consumers on re-vendor.
- [ ] CI green.
- [ ] **Host-verify** (no LaTeX in the agent container): manuscript shows the real title; supplementary shows "Supplementary Material for: \<title\>"; revision + both diffs render; all share one author list.

## Consumer migration
Put real title/authors in `00_shared/*` (preserved), then the stale per-part `contents/` copies are unused and can be deleted.

## Follow-up (PR-B, carded)
Repo-wide role hint-comments + read-only permissions on engine-vendored files (the self-documenting-vendored-tree request) — separate PR, needs the update-project perms mechanism.