### PR TITLE
Release 2.23.0

### DIFF
--- a/00_shared/authors.tex
+++ b/00_shared/authors.tex
@@ -1,4 +1,7 @@
 %% -*- coding: utf-8 -*-
+%% ROLE: SSoT (single source of truth) — EDIT HERE. Consumer-owned; preserved
+%% on re-vendor. The manuscript, supplementary, and revision/diff builds all
+%% \input this file, so the author list can never drift between outputs.
 \author[1]{First Author\corref{cor1}}
 \author[2]{Second Author}
 \author[3]{Third Author}

--- a/00_shared/latex_styles/dark_mode.tex
+++ b/00_shared/latex_styles/dark_mode.tex
@@ -46,8 +46,11 @@
   singlelinecheck=false
 }
 
-% Adjust table colors for dark mode
-\definecolor{lightgray}{gray}{0.2}  % Darker "light" gray for table rows
+% Zebra-stripe colour for tables. csv_to_latex.py emits \rowcolor{lightgray}
+% for alternate rows; here we darken it so the stripe stays distinct from the
+% dark page AND keeps the light body text legible (light mode defines it as
+% gray 0.95 in packages.tex). gray 0.2 (~#333) sits just above the #1E1E1E page.
+\definecolor{lightgray}{gray}{0.2}
 
 % Override color commands to work well in dark mode
 \renewcommand{\REDENDS}{\color{white}}    % Reset to white instead of black

--- a/00_shared/latex_styles/packages.tex
+++ b/00_shared/latex_styles/packages.tex
@@ -12,6 +12,11 @@
 % Include all common color options: table (for colortbl), svgnames (for tcolorbox)
 \usepackage[table,svgnames]{xcolor}
 
+%% Line numbers — MUST load before siunitx: lineno patches the output routine
+%% with \interlinepenalty\linenopenalty, which siunitx's number parser otherwise
+%% chokes on ("Invalid number" at \end{frontmatter}).
+\usepackage{lineno}
+
 %% Mathematics
 \usepackage{amsmath, amssymb, amsthm}
 \usepackage{siunitx}
@@ -46,8 +51,8 @@
 \usepackage{hyperref}
 \usepackage{xurl}  % break long URLs / DOIs at any character so they wrap instead of overflowing the margin
 
-%% Document features
-\usepackage{accsupp, lineno, bashful, lipsum}
+%% Document features (lineno loaded earlier, before siunitx)
+\usepackage{accsupp, bashful, lipsum}
 
 %% Visual enhancements
 \usepackage[most]{tcolorbox}

--- a/00_shared/title.tex
+++ b/00_shared/title.tex
@@ -1,6 +1,11 @@
 %% -*- coding: utf-8 -*-
-\title{
+%% ROLE: SSoT (single source of truth) — EDIT HERE. Consumer-owned; preserved
+%% on re-vendor (update-project never overwrites it). The manuscript,
+%% supplementary, and revision/diff builds all source the title from here, so
+%% it can never drift between outputs. Set the real title in \scitexmanuscripttitle.
+\newcommand{\scitexmanuscripttitle}{%
 Your Manuscript Title Here
 }
+\title{\scitexmanuscripttitle}
 
 %%%% EOF

--- a/01_manuscript/base.tex
+++ b/01_manuscript/base.tex
@@ -14,7 +14,7 @@
 %% ----------------------------------------
 %% JOURNAL NAME
 %% ----------------------------------------
-\input{./01_manuscript/contents/journal_name}
+\input{./00_shared/journal_name}
 
 %% ----------------------------------------
 %% START of DOCUMENT
@@ -26,11 +26,13 @@
 %% ----------------------------------------
 \begin{frontmatter}
 \input{./01_manuscript/contents/highlights}
-\input{./01_manuscript/contents/title}
-\input{./01_manuscript/contents/authors}
+%% Title + authors are sourced from the 00_shared SSoT (NOT per-part copies) so
+%% the manuscript, supplementary, and revision/diff builds can never drift.
+\input{./00_shared/title}
+\input{./00_shared/authors}
 \input{./01_manuscript/contents/graphical_abstract}
 \input{./01_manuscript/contents/abstract}
-\input{./01_manuscript/contents/keywords}
+\input{./00_shared/keywords}
 \end{frontmatter}
 
 %% ----------------------------------------

--- a/01_manuscript/contents/authors.tex
+++ b/01_manuscript/contents/authors.tex
@@ -1,1 +1,0 @@
-../../00_shared/authors.tex

--- a/01_manuscript/contents/journal_name.tex
+++ b/01_manuscript/contents/journal_name.tex
@@ -1,1 +1,0 @@
-../../00_shared/journal_name.tex

--- a/01_manuscript/contents/keywords.tex
+++ b/01_manuscript/contents/keywords.tex
@@ -1,1 +1,0 @@
-../../00_shared/keywords.tex

--- a/01_manuscript/contents/title.tex
+++ b/01_manuscript/contents/title.tex
@@ -1,1 +1,0 @@
-../../00_shared/title.tex

--- a/02_supplementary/base.tex
+++ b/02_supplementary/base.tex
@@ -12,7 +12,7 @@
 %% ----------------------------------------
 %% JOURNAL NAME
 %% ----------------------------------------
-\input{./02_supplementary/contents/journal_name}
+\input{./00_shared/journal_name}
 
 %% ----------------------------------------
 %% START of DOCUMENT
@@ -23,8 +23,13 @@
 %% Frontmatter
 %% ----------------------------------------
 \begin{frontmatter}
-    \title{Supplementary Material}
-	\input{./02_supplementary/contents/authors}
+    %% Title + authors from the 00_shared SSoT. \input{title} defines
+    %% \scitexmanuscripttitle (and sets \title); we then override \title to the
+    %% supplementary form derived from the SAME shared title, so it tracks the
+    %% manuscript automatically.
+    \input{./00_shared/title}
+    \title{Supplementary Material for: \scitexmanuscripttitle}
+    \input{./00_shared/authors}
 \end{frontmatter}
 
 %% ----------------------------------------

--- a/02_supplementary/contents/authors.tex
+++ b/02_supplementary/contents/authors.tex
@@ -1,1 +1,0 @@
-../../00_shared/authors.tex

--- a/02_supplementary/contents/journal_name.tex
+++ b/02_supplementary/contents/journal_name.tex
@@ -1,1 +1,0 @@
-../../00_shared/journal_name.tex

--- a/02_supplementary/contents/keywords.tex
+++ b/02_supplementary/contents/keywords.tex
@@ -1,1 +1,0 @@
-../../00_shared/keywords.tex

--- a/02_supplementary/contents/title.tex
+++ b/02_supplementary/contents/title.tex
@@ -1,1 +1,0 @@
-../../00_shared/title.tex

--- a/03_revision/base.tex
+++ b/03_revision/base.tex
@@ -20,8 +20,10 @@
 %% Frontmatter
 %% ----------------------------------------
 \begin{frontmatter}
-\input{./03_revision/contents/title}
-\input{./03_revision/contents/authors}
+%% Title + authors from the 00_shared SSoT (the manuscript_diff is latexdiff'd
+%% from the assembled manuscript, so it inherits this automatically).
+\input{./00_shared/title}
+\input{./00_shared/authors}
 \end{frontmatter}
 
 %% ----------------------------------------

--- a/03_revision/contents/authors.tex
+++ b/03_revision/contents/authors.tex
@@ -1,1 +1,0 @@
-../../00_shared/authors.tex

--- a/03_revision/contents/journal_name.tex
+++ b/03_revision/contents/journal_name.tex
@@ -1,1 +1,0 @@
-../../00_shared/journal_name.tex

--- a/03_revision/contents/keywords.tex
+++ b/03_revision/contents/keywords.tex
@@ -1,1 +1,0 @@
-../../00_shared/keywords.tex

--- a/03_revision/contents/title.tex
+++ b/03_revision/contents/title.tex
@@ -1,1 +1,0 @@
-../../00_shared/title.tex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.23.0] - 2026-06-29
+
+### Added
+- **Unified pre-check severity framework — all 8 checks on one shared resolver.**
+  New stdlib-only `scripts/python/_severity.py::resolve_level(...)` is the single
+  source of truth for a check's effective level, resolved by the documented
+  precedence (CLI `--level` > per-check `SCITEX_WRITER_<CHECK>` env > project
+  `./config.yaml` `<check>.level` > user config > per-check default), with two
+  tightening-only overlays: the legacy `strict` alias and `SCITEX_WRITER_LINT_STRICT`
+  (scoped to `limits`+`overflow`). `repair` is honored only for `paper_symlink`.
+  Adopted across `limits`, `overflow`, `paper_symlink`, `media_provenance`,
+  `caption_footnote`, `ref_integrity`, `references`, `float_order`. Per-check
+  defaults preserved (back-compat exact); see
+  `docs/03_DESIGN_SEVERITY_MODEL_CONTRACT.md` (§9 ratified). `references` and
+  `float_order` gain an `--level`/env severity knob (default stays `error`); a
+  config `level: off` (which YAML coerces to bool) is honored, with a loud hint
+  on a genuinely invalid value (never crashes the build).
+- **Reference-integrity pre-compile gate** (`scitex-writer check-ref-integrity`,
+  `checks.ref_integrity()`): validates figure/table `\ref`, `\cite`-in-bib, and
+  `supple-` xrefs (with explicit "supplement not compiled" messaging), reports all
+  at once. Default `error`; env `SCITEX_WRITER_REF_INTEGRITY`.
+- **`\footnote`-in-`\caption{}` lint** (`check-caption-footnote`,
+  `checks.caption_footnote()`) — errors by default on a fatal footnote inside a
+  caption argument. Env `SCITEX_WRITER_CAPTION_FOOTNOTE`.
+- **Shared-metadata single source of truth.** Title, authors, journal name, and
+  keywords are now sourced from `00_shared/` by the manuscript, supplementary,
+  AND revision builds (diffs inherit via `latexdiff`), so they can never drift.
+  `00_shared/title.tex` exposes `\scitexmanuscripttitle`; the supplementary title
+  derives from it (`Supplementary Material for: <title>`). `00_shared/{title,
+  authors,...}.tex` are consumer-owned (preserved on re-vendor).
+
+### Fixed
+- **`lineno`↔`siunitx` frontmatter error.** Load `lineno` before `siunitx` so a
+  `siunitx` "Invalid number" no longer aborts at `\end{frontmatter}`.
+- **bibtex not re-run on a `.bib`-only edit (stale `.bbl` → wrong PDF).** The
+  bibliography-merge step clears a stale `.bbl`/`.fdb_latexmk` when any source
+  `.bib` is newer, forcing bibtex to regenerate.
+- **Supplement cross-references rendered as `?`.** The supplement `.aux` is now
+  exposed at doc-root (after the cleanup stage) so `xr-hyper` resolves `supple-`
+  refs from the main document.
+- **Dark-mode table zebra stripe was illegible.** The csv→LaTeX converter emits
+  `\rowcolor{lightgray}` (the theme color, dark-aware: gray 0.95 light / 0.2 dark)
+  instead of a literal `gray!10`, so striped-row text stays readable in both modes.
+
 ## [2.22.0] - 2026-06-26
 
 ### Added

--- a/docs/03_DESIGN_SEVERITY_MODEL_CONTRACT.md
+++ b/docs/03_DESIGN_SEVERITY_MODEL_CONTRACT.md
@@ -106,6 +106,13 @@ Everything below keeps working **identically to today**:
   bodies collapse into it.
 - Public API (`checks.*`) and MCP handlers keep their signatures; `strict` bools
   stay as aliases (passed in via `legacy_strict`).
+- **Config `level` YAML-bool coercion (D2):** PyYAML (YAML 1.1) coerces a bare
+  `off`/`no`/`false` to `False`, so `level: off` arrives as a bool. Per §2 ("off
+  disables") the shared `_read_config_level` maps `False` → `"off"`. A genuinely
+  invalid value (`True` from `on`/`yes`, or a typo) is **not** silently dropped:
+  one precise `[WARN]` hint is printed and the value is treated as unset (falls
+  through to the default) — never crashing the build over a config typo. A
+  missing key stays a silent no-op.
 
 ## 8. Migration & risk (for the operator to assess)
 

--- a/docs/03_DESIGN_SEVERITY_MODEL_CONTRACT.md
+++ b/docs/03_DESIGN_SEVERITY_MODEL_CONTRACT.md
@@ -1,8 +1,9 @@
 # Shared Severity Model — Design Contract (checker redesign, Part D)
 
-> **STATUS: PROPOSAL — awaiting operator sign-off. NO implementation code lands
-> until this contract is approved.** This document defines the target contract
-> and the migration; it changes no behavior on its own.
+> **STATUS: RATIFIED — operator signed off §9 on 2026-06-27.** The locked
+> resolver `resolve_level(...)` ships in `scripts/python/_severity.py` and is
+> adopted incrementally (D1: `limits` + `overflow`; D2/D3 follow). No check
+> changes its effective default behavior; the contract unifies the knob.
 
 ## 1. Motivation
 
@@ -43,25 +44,31 @@ Every check resolves a single `level`:
 | `overflow`         | **warn**      | today's default (overfull box is advisory)             |
 | `paper_symlink`    | **warn**      | private convention; surfaced but non-fatal (PR #158)   |
 | `media_provenance` | **off**       | private convention; opt-in (PR #157)                   |
+| `caption_footnote` | **error**     | `\footnote` in a `\caption{}` is fatal mid-compile (PR #173) |
+| `ref_integrity`    | **error**     | an unresolved `\ref`/`\cite`/supple- xref is a real defect (PR #174) |
 
-These defaults **preserve current behavior** (see §6).
+These defaults **preserve current behavior** (see §6). `repair` is valid
+**only** for `paper_symlink` (the sole check with a safe deterministic
+self-fix); every other check tops out at `error`.
 
 ## 4. Precedence ladder (identical for every check)
 
 Resolved top-down; first match wins:
 
 1. **CLI flag** — `--level {off,warn,error}` (or the legacy `--strict` alias, §5)
-2. **per-check env** — `SCITEX_WRITER_<CHECK>` (existing:
-   `SCITEX_WRITER_PAPER_SYMLINK`, `SCITEX_WRITER_MEDIA_PROVENANCE`; new, additive:
+2. **per-check env** — `SCITEX_WRITER_<CHECK>`, one per check:
+   `SCITEX_WRITER_PAPER_SYMLINK`, `SCITEX_WRITER_MEDIA_PROVENANCE`,
    `SCITEX_WRITER_LIMITS`, `SCITEX_WRITER_OVERFLOW`, `SCITEX_WRITER_REFERENCES`,
-   `SCITEX_WRITER_FLOAT_ORDER`)
+   `SCITEX_WRITER_FLOAT_ORDER`, `SCITEX_WRITER_CAPTION_FOOTNOTE`,
+   `SCITEX_WRITER_REF_INTEGRITY`
 3. **project config** — `./config.yaml` → `<check>.level`
 4. **user config** — `~/.scitex/writer/config.yaml` → `<check>.level`
 5. **per-check default** (§3)
 
-**Global `SCITEX_WRITER_LINT_STRICT`** is a **tightening-only overlay applied
-AFTER resolution**: if truthy, it raises a resolved `warn` to `error` (never
-loosens, never touches `off`). Its scope is the open question in §7 Q1.
+**`SCITEX_WRITER_LINT_STRICT`** is a **tightening-only overlay applied AFTER
+resolution**: if truthy, it raises a resolved `warn` to `error` (never loosens,
+never touches `off`). Per the §9 sign-off it is **scoped to `limits` + `overflow`
+only** (exact back-compat) — it is NOT a global tighten-all.
 
 ## 5. Back-compat — NON-NEGOTIABLE
 
@@ -88,16 +95,17 @@ Everything below keeps working **identically to today**:
 - Exit code is `1` iff `FAIL_COUNT > 0` (i.e. `level=error` with ≥1 finding),
   else `0`. `off` is always `0`.
 
-## 7. Implementation sketch (for AFTER sign-off)
+## 7. Implementation (locked — §9 sign-off 2026-06-27)
 
 - A tiny **stdlib-only** helper `scripts/python/_severity.py` (the check scripts
-  are self-contained stdlib + optional PyYAML, so the helper must be too),
-  exposing one resolver:
+  are self-contained stdlib + optional PyYAML, so the helper is too), exposing
+  the locked resolver:
   `resolve_level(check, cli_level, project_dir, *, default, env_var, legacy_strict=None)`
-  → `level`, plus the `LINT_STRICT` overlay. Each `check_*.py` imports it; the
-  current per-check `resolve_level`/`_read_config_level` bodies collapse into it.
+  → `{off,warn,error,repair}`, plus the scoped `LINT_STRICT` overlay. Each
+  `check_*.py` imports it; the per-check `resolve_level`/`_read_config_level`
+  bodies collapse into it.
 - Public API (`checks.*`) and MCP handlers keep their signatures; `strict` bools
-  stay as aliases.
+  stay as aliases (passed in via `legacy_strict`).
 
 ## 8. Migration & risk (for the operator to assess)
 
@@ -109,6 +117,8 @@ Everything below keeps working **identically to today**:
 | `overflow`         | none — as `limits`                        | low  |
 | `paper_symlink`    | none beyond PR #158 (`warn`); adopts shared resolver | low |
 | `media_provenance` | none — `off` (PR #157); adopts shared resolver | none |
+| `caption_footnote` | none — `error` (PR #173); adopts shared resolver | low |
+| `ref_integrity`    | none — `error` (PR #174); adopts shared resolver | low |
 
 **Rollout — multiple small, independently CI-gated PRs:**
 1. **D1**: add `_severity.py`; adopt in `limits` + `overflow` (proves back-compat
@@ -118,15 +128,28 @@ Everything below keeps working **identically to today**:
    `--level`/env).
 
 No check changes its *effective* default behavior; the value is one consistent
-knob, env, config key, and hint style across all six.
+knob, env, config key, and hint style across all eight.
 
-## 9. Open questions for sign-off
+## 9. Sign-off — RESOLVED (operator, 2026-06-27)
 
-1. **`SCITEX_WRITER_LINT_STRICT` scope** — keep it scoped to `limits` + `overflow`
-   (exact back-compat; **recommended**), or make it a global "tighten every
-   check to error"? The latter would change behavior for `references`/`float_order`
-   (already error) and could surprise on `paper_symlink`/`media_provenance`.
-2. **`repair` for `media_provenance`?** Proposed **no** — it cannot safely
-   auto-generate a missing artifact from a script; surfacing is the right action.
-3. **New per-check env var names** (`SCITEX_WRITER_LIMITS`, `…_OVERFLOW`,
-   `…_REFERENCES`, `…_FLOAT_ORDER`) — acceptable, or prefer a different scheme?
+All three questions ratified by the operator (relayed via scitex-dev). The
+resolver `resolve_level(...)` in `scripts/python/_severity.py` is locked to:
+
+1. **`SCITEX_WRITER_LINT_STRICT` scope** — **scoped to `limits` + `overflow`
+   only** (exact back-compat). It does NOT tighten the other checks;
+   `references`/`float_order` keep their `error` default and
+   `paper_symlink`/`media_provenance`/`caption_footnote`/`ref_integrity` keep
+   their own per-check defaults regardless of `LINT_STRICT`.
+2. **`repair` level** — **`paper_symlink` only.** `media_provenance` gets **no
+   `repair`** (no safe deterministic auto-fix) and its default **stays `off`**
+   (the PR #157 opt-in back-compat is non-negotiable, §5); when enabled its max
+   severity is `error`.
+3. **Per-check env vars** — `SCITEX_WRITER_<CHECK>` **approved for all eight**
+   (`…_REFERENCES`, `…_FLOAT_ORDER`, `…_LIMITS`, `…_OVERFLOW`, `…_PAPER_SYMLINK`,
+   `…_MEDIA_PROVENANCE`, `…_CAPTION_FOOTNOTE`, `…_REF_INTEGRITY`), each mapping to
+   the `<check>.level` config key, with precedence CLI > per-check env > project
+   config > user config > per-check default.
+
+`ref_integrity` (#174, added after this doc's first draft) folds in under the
+same scheme: env `SCITEX_WRITER_REF_INTEGRITY`, key `ref_integrity.level`,
+default `error`, and is **outside** the `LINT_STRICT` scope.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.22.0"
+version = "2.23.0"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/scripts/python/_severity.py
+++ b/scripts/python/_severity.py
@@ -25,6 +25,7 @@
 # `check_*.py` standalones.
 
 import os
+import sys
 from pathlib import Path
 
 # off < warn < error < repair. `repair` is error-semantics plus a safe
@@ -58,6 +59,41 @@ def _norm(value, check):
     return None
 
 
+def _coerce_config_level(raw, check, source):
+    """Coerce a raw config ``level`` value to a valid level, or None.
+
+    YAML 1.1 coerces a bare ``off``/``no``/``false`` to Python ``False``, so
+    ``level: off`` arrives as ``False`` rather than the string ``"off"`` -- per
+    the §2 contract ruling this MUST still disable the check, so ``False`` maps
+    to ``"off"``. A genuinely invalid value (``True`` from ``on``/``yes``, or a
+    typo'd string) is NOT silently dropped: a one-line hint is printed and the
+    value is treated as unset (caller falls through to its default). A missing
+    key (``None``) stays a silent no-op.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, bool):
+        if raw is False:  # YAML off / no / false -> disable
+            return "off"
+        # True came from on / yes / true -- not a meaningful severity level.
+        _warn_invalid_level(raw, check, source)
+        return None
+    norm = _norm(raw, check)
+    if norm is not None:
+        return norm
+    _warn_invalid_level(raw, check, source)
+    return None
+
+
+def _warn_invalid_level(raw, check, source):
+    """Fail loud (one line) on an invalid config ``level``; never crash."""
+    valid = "/".join(_valid_levels(check))
+    sys.stderr.write(
+        f"[WARN] {source}: {check}.level must be one of {valid}; got {raw!r} "
+        f"-- ignoring (using default). Quote string values, e.g. level: \"off\".\n"
+    )
+
+
 def env_truthy(name):
     """True iff env var ``name`` is set to a truthy token (1/true/yes)."""
     return os.environ.get(name, "").strip().lower() in _TRUTHY
@@ -84,7 +120,7 @@ def _read_config_level(config_path, check):
     block = data.get(check)
     if not isinstance(block, dict):
         return None
-    return _norm(block.get("level"), check)
+    return _coerce_config_level(block.get("level"), check, str(config_path))
 
 
 def resolve_level(

--- a/scripts/python/_severity.py
+++ b/scripts/python/_severity.py
@@ -113,12 +113,16 @@ def resolve_level(
         The legacy strict alias (``--strict`` / ``<check>.strict``). None/False
         is a no-op; True tightens a resolved ``warn`` to ``error``.
     """
+    # `default` runs through the same gate as every other source: a default of
+    # `repair` for a non-self-fixing check is rejected (falls to `error`), so
+    # the repair gate is airtight even against a mis-specified caller default.
     level = (
         _norm(cli_level, check)
         or _norm(os.environ.get(env_var, ""), check)
         or _read_config_level(Path(project_dir) / "config.yaml", check)
         or _read_config_level(_USER_CONFIG, check)
-        or default
+        or _norm(default, check)
+        or "error"
     )
 
     # Tightening-only overlays: warn -> error. Never loosen; never touch off.

--- a/scripts/python/_severity.py
+++ b/scripts/python/_severity.py
@@ -42,7 +42,6 @@ _LINT_STRICT_CHECKS = frozenset({"limits", "overflow"})
 _REPAIR_CHECKS = frozenset({"paper_symlink"})
 
 _TRUTHY = ("1", "true", "yes")
-_USER_CONFIG = Path.home() / ".scitex" / "writer" / "config.yaml"
 
 
 def _valid_levels(check):
@@ -120,7 +119,11 @@ def resolve_level(
         _norm(cli_level, check)
         or _norm(os.environ.get(env_var, ""), check)
         or _read_config_level(Path(project_dir) / "config.yaml", check)
-        or _read_config_level(_USER_CONFIG, check)
+        # Path.home() is resolved at call time (not import) so a changed $HOME
+        # is honored -- matches the sibling check_*.py resolvers.
+        or _read_config_level(
+            Path.home() / ".scitex" / "writer" / "config.yaml", check
+        )
         or _norm(default, check)
         or "error"
     )

--- a/scripts/python/_severity.py
+++ b/scripts/python/_severity.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/_severity.py
+# Purpose: Shared severity-model resolver for the writer pre-compile / lint
+#          checks. Single source of truth for resolving a check's effective
+#          `level` from the documented precedence ladder, plus the two
+#          tightening-only overlays (the per-check `strict` alias and the
+#          scoped `SCITEX_WRITER_LINT_STRICT` global).
+#
+#          Ratified contract: docs/03_DESIGN_SEVERITY_MODEL_CONTRACT.md
+#          (Part D; §9 sign-off 2026-06-27).
+#
+#          Precedence (first match wins):
+#            1. CLI --level                          (cli_level)
+#            2. per-check env SCITEX_WRITER_<CHECK>   (env_var)
+#            3. project ./config.yaml                -> <check>.level
+#            4. user ~/.scitex/writer/config.yaml    -> <check>.level
+#            5. per-check default                    (default)
+#          Then warn -> error tightening (never loosens, never touches off):
+#            * legacy_strict truthy   (--strict / <check>.strict alias)
+#            * SCITEX_WRITER_LINT_STRICT truthy AND check in {limits, overflow}
+#
+# Self-contained: stdlib + optional PyYAML (config files are silently skipped
+# when PyYAML is absent, so CLI + env still resolve). Imported by the sibling
+# `check_*.py` standalones.
+
+import os
+from pathlib import Path
+
+# off < warn < error < repair. `repair` is error-semantics plus a safe
+# deterministic self-fix and is valid ONLY for checks that can auto-fix.
+LEVELS = ("off", "warn", "error", "repair")
+
+LINT_STRICT_ENV = "SCITEX_WRITER_LINT_STRICT"
+
+# SCITEX_WRITER_LINT_STRICT is a SCOPED overlay -- it tightens only these two
+# checks (exact back-compat with the historical `strict` bool). It is NOT a
+# global tighten-all (operator §9 sign-off, 2026-06-27).
+_LINT_STRICT_CHECKS = frozenset({"limits", "overflow"})
+
+# Only these checks accept the `repair` level (they can self-fix safely).
+_REPAIR_CHECKS = frozenset({"paper_symlink"})
+
+_TRUTHY = ("1", "true", "yes")
+_USER_CONFIG = Path.home() / ".scitex" / "writer" / "config.yaml"
+
+
+def _valid_levels(check):
+    """Levels accepted for ``check`` (``repair`` only for self-fixing checks)."""
+    return LEVELS if check in _REPAIR_CHECKS else LEVELS[:3]
+
+
+def _norm(value, check):
+    """Lowercased ``value`` iff it is a level valid for ``check``, else None."""
+    if isinstance(value, str):
+        low = value.strip().lower()
+        if low in _valid_levels(check):
+            return low
+    return None
+
+
+def env_truthy(name):
+    """True iff env var ``name`` is set to a truthy token (1/true/yes)."""
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
+
+
+def _read_config_level(config_path, check):
+    """Read ``<check>.level`` from a YAML config, or None.
+
+    A missing file/key is None (not an error). PyYAML is optional -- absent it,
+    config files are silently skipped so CLI + env still resolve.
+    """
+    if not config_path.exists():
+        return None
+    try:
+        import yaml
+    except ImportError:
+        return None
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    block = data.get(check)
+    if not isinstance(block, dict):
+        return None
+    return _norm(block.get("level"), check)
+
+
+def resolve_level(
+    check, cli_level, project_dir, *, default, env_var, legacy_strict=None
+):
+    """Resolve a check's effective severity level.
+
+    See the module header for the precedence ladder and the two tightening
+    overlays. ``repair`` from any source is ignored for checks that cannot
+    self-fix. Returns one of ``off`` / ``warn`` / ``error`` / ``repair``.
+
+    Parameters
+    ----------
+    check : str
+        Check name; also the ``<check>`` config-block stem.
+    cli_level : str or None
+        The check's ``--level`` value (None when unset).
+    project_dir : str or Path
+        Project root (holds ``./config.yaml``).
+    default : str
+        Per-check default when nothing else matches.
+    env_var : str
+        The check's ``SCITEX_WRITER_<CHECK>`` env var name.
+    legacy_strict : bool or None
+        The legacy strict alias (``--strict`` / ``<check>.strict``). None/False
+        is a no-op; True tightens a resolved ``warn`` to ``error``.
+    """
+    level = (
+        _norm(cli_level, check)
+        or _norm(os.environ.get(env_var, ""), check)
+        or _read_config_level(Path(project_dir) / "config.yaml", check)
+        or _read_config_level(_USER_CONFIG, check)
+        or default
+    )
+
+    # Tightening-only overlays: warn -> error. Never loosen; never touch off.
+    if level == "warn":
+        if legacy_strict:
+            level = "error"
+        elif check in _LINT_STRICT_CHECKS and env_truthy(LINT_STRICT_ENV):
+            level = "error"
+
+    return level
+
+
+__all__ = ["resolve_level", "env_truthy", "LEVELS", "LINT_STRICT_ENV"]
+
+# EOF

--- a/scripts/python/check_caption_footnote.py
+++ b/scripts/python/check_caption_footnote.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/check_caption_footnote.py
+# Purpose: Catch \footnote (and \footnotetext used as an in-caption workaround)
+#          inside a \caption{} at LINT time, before compile.
+#
+#          \footnote inside \caption{} is a fatal LaTeX pattern: the caption
+#          argument is reprocessed (list-of-figures + heading), which yields
+#          "Argument of \caption@ydblarg has an extra }" and a runaway
+#          \@xfootnote -- fatal inside figure*/table* spanning floats. The
+#          blessed pattern is \caption[short]{long\protect\footnotemark} with
+#          \footnotetext AFTER the float, so \footnotemark in a caption is SAFE
+#          and is NOT flagged here.
+#
+#          Two detection modes:
+#            - caption_and_media/*.tex : the WHOLE file is the caption body the
+#              engine wraps in \caption{}, so any \footnote/\footnotetext in it
+#              is in-caption.
+#            - other source *.tex      : brace-match each \caption{...} arg and
+#              flag \footnote/\footnotetext within it.
+#          The generated assembled doc (e.g. 01_manuscript/manuscript.tex) is
+#          NOT scanned -- it duplicates the sources above and is a build
+#          artifact; scanning sources keeps this a pre-compile lint.
+#
+#          Severity is a user-level knob:
+#            off    -- check disabled
+#            warn   -- report as a warning (exit 0)
+#            error  -- report as an error (exit 1)   [DEFAULT]
+#          Default is error because the pattern is always a fatal compile bug;
+#          a clean manuscript never triggers it.
+#
+#          Severity precedence (highest -> lowest):
+#            1. --level {off,warn,error} CLI flag
+#            2. env SCITEX_WRITER_CAPTION_FOOTNOTE
+#            3. project ./config.yaml key caption_footnote.level
+#            4. user-wide ~/.scitex/writer/config.yaml key caption_footnote.level
+#            5. default error
+#
+# Usage:
+#   python check_caption_footnote.py [project_dir]
+#                                    [--doc-type manuscript|supplementary|revision|all]
+#                                    [--level off|warn|error]
+#
+# Self-contained: stdlib + optional PyYAML (only to read config files).
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+# ANSI colors (match check_media_provenance.py / check_paper_symlink.py)
+GREEN = "\033[0;32m"
+YELLOW = "\033[1;33m"
+RED = "\033[0;31m"
+DIM = "\033[0;90m"
+BOLD = "\033[1m"
+NC = "\033[0m"
+
+PASS_COUNT = 0
+WARN_COUNT = 0
+FAIL_COUNT = 0
+
+_LEVELS = ("off", "warn", "error")
+_DEFAULT_LEVEL = "error"
+
+_DOC_DIRS = {
+    "manuscript": "01_manuscript",
+    "supplementary": "02_supplementary",
+    "revision": "03_revision",
+}
+
+# \footnote and \footnotetext, but NOT \footnotemark (the blessed in-caption
+# pattern). The negative lookahead rejects a following letter, so \footnotemark
+# (\footnote + "mark") is excluded while \footnote{ / \footnote[ / \footnotetext
+# match.
+_FOOTNOTE_RE = re.compile(r"\\footnote(?:text)?(?![A-Za-z])")
+_CAPTION_RE = re.compile(r"\\caption\b")
+
+_MAX_LIST = 50
+
+
+def log_pass(msg):
+    global PASS_COUNT
+    print(f"  {GREEN}[PASS]{NC} {msg}")
+    PASS_COUNT += 1
+
+
+def log_warn(msg):
+    global WARN_COUNT
+    print(f"  {YELLOW}[WARN]{NC} {msg}")
+    WARN_COUNT += 1
+
+
+def log_fail(msg):
+    global FAIL_COUNT
+    print(f"  {RED}[FAIL]{NC} {msg}")
+    FAIL_COUNT += 1
+
+
+def log_detail(msg):
+    print(f"    {DIM}{msg}{NC}")
+
+
+def _read_block(config_path):
+    """Read the ``caption_footnote`` mapping from a YAML config, or ``{}``."""
+    if not config_path.exists():
+        return {}
+    try:
+        import yaml
+    except ImportError:
+        return {}
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    block = data.get("caption_footnote")
+    return block if isinstance(block, dict) else {}
+
+
+def _config_blocks(project_dir):
+    proj = _read_block(Path(project_dir) / "config.yaml")
+    user = _read_block(Path.home() / ".scitex" / "writer" / "config.yaml")
+    return proj, user
+
+
+def resolve_level(cli_level, proj_block, user_block):
+    """Resolve the effective severity level via the documented precedence."""
+    if cli_level:
+        return cli_level.lower()
+    env = os.environ.get("SCITEX_WRITER_CAPTION_FOOTNOTE", "").strip().lower()
+    if env in _LEVELS:
+        return env
+    for block in (proj_block, user_block):
+        level = block.get("level")
+        if isinstance(level, str) and level.lower() in _LEVELS:
+            return level.lower()
+    return _DEFAULT_LEVEL
+
+
+def _strip_comments(text):
+    """Blank out LaTeX comments (unescaped % to EOL) while preserving newlines
+    and column offsets, so line/col reporting stays accurate."""
+    out = []
+    for line in text.splitlines(keepends=True):
+        i = 0
+        cut = None
+        while i < len(line):
+            ch = line[i]
+            if ch == "\\":
+                i += 2  # escaped char (incl. \%); skip both
+                continue
+            if ch == "%":
+                cut = i
+                break
+            i += 1
+        if cut is None:
+            out.append(line)
+        else:
+            nl = "\n" if line.endswith("\n") else ""
+            out.append(line[:cut] + nl)
+    return "".join(out)
+
+
+def _line_of(text, idx):
+    """1-based line number of character offset ``idx``."""
+    return text.count("\n", 0, idx) + 1
+
+
+def _caption_arg_spans(text):
+    """Yield (start, end) char offsets of each \\caption{...} argument body.
+
+    Skips an optional ``*`` and an optional ``[...]`` short-caption arg, then
+    brace-matches the mandatory ``{...}`` (honoring escaped braces). ``start``
+    is just after the opening brace, ``end`` is the matching close brace index.
+    """
+    for m in _CAPTION_RE.finditer(text):
+        i = m.end()
+        n = len(text)
+        if i < n and text[i] == "*":
+            i += 1
+        while i < n and text[i] in " \t\r\n":
+            i += 1
+        # Optional [short] arg (brace/bracket-escaped chars skipped).
+        if i < n and text[i] == "[":
+            depth = 1
+            i += 1
+            while i < n and depth:
+                if text[i] == "\\":
+                    i += 2
+                    continue
+                if text[i] == "[":
+                    depth += 1
+                elif text[i] == "]":
+                    depth -= 1
+                i += 1
+            while i < n and text[i] in " \t\r\n":
+                i += 1
+        if i >= n or text[i] != "{":
+            continue
+        start = i + 1
+        depth = 1
+        j = start
+        while j < n and depth:
+            if text[j] == "\\":
+                j += 2
+                continue
+            if text[j] == "{":
+                depth += 1
+            elif text[j] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            j += 1
+        if depth == 0:
+            yield start, j
+
+
+def _iter_source_tex(project_dir, doc_types):
+    """Yield (path, is_caption_media) for each source .tex under the docs.
+
+    Walks ``<doc>/contents/`` (NOT the generated assembled ``<doc>.tex``).
+    ``is_caption_media`` is True for files under a ``caption_and_media/`` dir --
+    those whole files are caption bodies.
+    """
+    for doc_type in doc_types:
+        contents = project_dir / _DOC_DIRS[doc_type] / "contents"
+        if not contents.is_dir():
+            continue
+        for root, _dirs, files in os.walk(contents):
+            in_caption_media = (os.sep + "caption_and_media") in (
+                os.sep + os.path.relpath(root, contents)
+            ) or root.endswith("caption_and_media")
+            for name in files:
+                if name.endswith(".tex"):
+                    yield Path(root) / name, in_caption_media
+
+
+def _offenses_in(path, is_caption_media):
+    """Return [(line, snippet), ...] for footnote-in-caption hits in ``path``."""
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    text = _strip_comments(raw)
+    hits = []
+    if is_caption_media:
+        # The whole file becomes the \caption{} body.
+        for m in _FOOTNOTE_RE.finditer(text):
+            hits.append((_line_of(text, m.start()), m.group(0)))
+    else:
+        for start, end in _caption_arg_spans(text):
+            for m in _FOOTNOTE_RE.finditer(text, start, end):
+                hits.append((_line_of(text, m.start()), m.group(0)))
+    return hits
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Lint: ERROR when \\footnote/\\footnotetext appears inside a "
+        "\\caption{} (a fatal LaTeX pattern). \\footnotemark is allowed."
+    )
+    parser.add_argument("project_dir", nargs="?", default=".")
+    parser.add_argument(
+        "--doc-type",
+        choices=[*_DOC_DIRS, "all"],
+        default="all",
+        help="Which document(s) to scan (default: all present).",
+    )
+    parser.add_argument(
+        "--level",
+        choices=list(_LEVELS),
+        default=None,
+        help="Severity: off, warn, or error (default). Overrides env and config.",
+    )
+    args = parser.parse_args()
+
+    project_dir = Path(args.project_dir).resolve()
+    proj_block, user_block = _config_blocks(project_dir)
+    level = resolve_level(args.level, proj_block, user_block)
+
+    print(f"\n{BOLD}=== Caption Footnote Check (level={level}) ==={NC}\n")
+
+    if level == "off":
+        print(
+            f"  {DIM}[INFO]{NC} caption-footnote check is disabled (level=off)."
+        )
+        print(
+            f"\n{BOLD}Summary:{NC} {GREEN}0 passed{NC}, "
+            f"{YELLOW}0 warnings{NC}, {RED}0 errors{NC}"
+        )
+        return 0
+
+    doc_types = list(_DOC_DIRS) if args.doc_type == "all" else [args.doc_type]
+    report = log_fail if level == "error" else log_warn
+
+    offenders = []
+    scanned = 0
+    for path, is_caption_media in _iter_source_tex(project_dir, doc_types):
+        scanned += 1
+        for line, snippet in _offenses_in(path, is_caption_media):
+            rel = path.relative_to(project_dir)
+            offenders.append((f"{rel}:{line}", snippet))
+
+    if not offenders:
+        log_pass(
+            f"no \\footnote/\\footnotetext inside \\caption{{}} "
+            f"({scanned} source .tex scanned)"
+        )
+    else:
+        for loc, snippet in offenders[:_MAX_LIST]:
+            report(f"{loc}: {snippet} inside a \\caption{{}}")
+        if len(offenders) > _MAX_LIST:
+            log_detail(f"... and {len(offenders) - _MAX_LIST} more")
+        log_detail(
+            "fix: move the note out of the caption. Use "
+            "\\caption[short]{long\\protect\\footnotemark} and place "
+            "\\footnotetext{...} AFTER the float (\\footnotemark in a caption "
+            "is allowed); or inline the disclosure into the caption text."
+        )
+
+    print()
+    print(
+        f"{BOLD}Summary:{NC} {GREEN}{PASS_COUNT} passed{NC}, "
+        f"{YELLOW}{WARN_COUNT} warnings{NC}, {RED}{FAIL_COUNT} errors{NC}"
+    )
+    return 1 if FAIL_COUNT > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/python/check_caption_footnote.py
+++ b/scripts/python/check_caption_footnote.py
@@ -49,6 +49,9 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
+
 # ANSI colors (match check_media_provenance.py / check_paper_symlink.py)
 GREEN = "\033[0;32m"
 YELLOW = "\033[1;33m"
@@ -62,7 +65,6 @@ WARN_COUNT = 0
 FAIL_COUNT = 0
 
 _LEVELS = ("off", "warn", "error")
-_DEFAULT_LEVEL = "error"
 
 _DOC_DIRS = {
     "manuscript": "01_manuscript",
@@ -100,44 +102,6 @@ def log_fail(msg):
 
 def log_detail(msg):
     print(f"    {DIM}{msg}{NC}")
-
-
-def _read_block(config_path):
-    """Read the ``caption_footnote`` mapping from a YAML config, or ``{}``."""
-    if not config_path.exists():
-        return {}
-    try:
-        import yaml
-    except ImportError:
-        return {}
-    try:
-        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
-    except Exception:
-        return {}
-    if not isinstance(data, dict):
-        return {}
-    block = data.get("caption_footnote")
-    return block if isinstance(block, dict) else {}
-
-
-def _config_blocks(project_dir):
-    proj = _read_block(Path(project_dir) / "config.yaml")
-    user = _read_block(Path.home() / ".scitex" / "writer" / "config.yaml")
-    return proj, user
-
-
-def resolve_level(cli_level, proj_block, user_block):
-    """Resolve the effective severity level via the documented precedence."""
-    if cli_level:
-        return cli_level.lower()
-    env = os.environ.get("SCITEX_WRITER_CAPTION_FOOTNOTE", "").strip().lower()
-    if env in _LEVELS:
-        return env
-    for block in (proj_block, user_block):
-        level = block.get("level")
-        if isinstance(level, str) and level.lower() in _LEVELS:
-            return level.lower()
-    return _DEFAULT_LEVEL
 
 
 def _strip_comments(text):
@@ -278,8 +242,13 @@ def main():
     args = parser.parse_args()
 
     project_dir = Path(args.project_dir).resolve()
-    proj_block, user_block = _config_blocks(project_dir)
-    level = resolve_level(args.level, proj_block, user_block)
+    level = resolve_level(
+        "caption_footnote",
+        args.level,
+        project_dir,
+        default="error",
+        env_var="SCITEX_WRITER_CAPTION_FOOTNOTE",
+    )
 
     print(f"\n{BOLD}=== Caption Footnote Check (level={level}) ==={NC}\n")
 

--- a/scripts/python/check_float_order.py
+++ b/scripts/python/check_float_order.py
@@ -16,6 +16,9 @@ import sys
 from collections import OrderedDict
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
+
 # ANSI colors
 GREEN = "\033[0;32m"
 YELLOW = "\033[1;33m"
@@ -23,6 +26,41 @@ RED = "\033[0;31m"
 DIM = "\033[0;90m"
 BOLD = "\033[1m"
 NC = "\033[0m"
+
+PASS_COUNT = 0
+WARN_COUNT = 0
+FAIL_COUNT = 0
+
+# Effective severity (off|warn|error), set by main() via the shared resolver.
+# Default error preserves the historical "out-of-order float => exit 1" behavior.
+_LEVEL = "error"
+
+
+def log_pass(msg):
+    global PASS_COUNT
+    print(f"  {GREEN}[PASS]{NC} {msg}")
+    PASS_COUNT += 1
+
+
+def log_warn(msg):
+    global WARN_COUNT
+    print(f"  {YELLOW}[WARN]{NC} {msg}")
+    WARN_COUNT += 1
+
+
+def log_fail(msg):
+    """At ``warn``/``off`` a defect is demoted to a non-fatal ``[WARN]``; at
+    ``error`` (default) it is a fatal ``[FAIL]`` that drives exit 1."""
+    global FAIL_COUNT
+    if _LEVEL in ("warn", "off"):
+        log_warn(msg)
+        return
+    print(f"  {RED}[FAIL]{NC} {msg}")
+    FAIL_COUNT += 1
+
+
+def log_detail(msg):
+    print(f"    {DIM}{msg}{NC}")
 
 
 def find_references(content_dir, float_type):
@@ -158,7 +196,7 @@ def check_order(content_dir, float_type, label):
     labels = find_labels(content_dir, float_type)
 
     if not refs:
-        print(f"  {GREEN}[PASS]{NC} {label} references - none found")
+        log_pass(f"{label} references - none found")
         return True, refs, {}
 
     # Check if numbered keys appear in order
@@ -169,7 +207,7 @@ def check_order(content_dir, float_type, label):
             numbered_refs.append((num, name, key, fname, line))
 
     if not numbered_refs:
-        print(f"  {GREEN}[PASS]{NC} {label} references - no numbered references")
+        log_pass(f"{label} references - no numbered references")
         return True, refs, {}
 
     # Check sequential ordering
@@ -181,34 +219,32 @@ def check_order(content_dir, float_type, label):
         expected = list(range(1, len(numbered_refs) + 1))
         actual = numbers
         if actual == expected:
-            print(
-                f"  {GREEN}[PASS]{NC} {label} reference order (1..{len(numbered_refs)})"
-            )
+            log_pass(f"{label} reference order (1..{len(numbered_refs)})")
         else:
-            print(
-                f"  {YELLOW}[WARN]{NC} {label} references sequential but not contiguous: {numbers}"
+            log_warn(
+                f"{label} references sequential but not contiguous: {numbers}"
             )
         return True, refs, {}
 
     # Out of order - build mapping
-    print(f"  {RED}[FAIL]{NC} {label} reference order")
+    log_fail(f"{label} reference order")
     desired_mapping = {}
     for new_num_0, (old_num, name, old_key, fname, line) in enumerate(numbered_refs):
         new_num = new_num_0 + 1
         new_key = f"{new_num:02d}_{name}" if name else f"{new_num:02d}"
         if old_key != new_key:
             desired_mapping[old_key] = new_key
-        print(
-            f"    {DIM}{fname}:{line}: "
-            f"\\ref{{{float_type}:{old_key}}} -> should be {new_num:02d}{NC}"
+        log_detail(
+            f"{fname}:{line}: "
+            f"\\ref{{{float_type}:{old_key}}} -> should be {new_num:02d}"
         )
 
     # Report orphaned labels (defined but never referenced)
     ref_keys = {key for key, _, _ in refs}
     for label_key, info in labels.items():
         if label_key not in ref_keys:
-            print(
-                f"    {YELLOW}[WARN]{NC} \\label{{{float_type}:{label_key}}} "
+            log_warn(
+                f"\\label{{{float_type}:{label_key}}} "
                 f"defined in {info['file'].name}:{info['line']} but never referenced"
             )
 
@@ -348,9 +384,26 @@ def main():
         default="all",
         help="Which document type to check (default: all)",
     )
+    parser.add_argument(
+        "--level",
+        choices=["off", "warn", "error"],
+        default=None,
+        help="Severity: error (default), warn (report but exit 0), or off "
+        "(disable the gate). Overrides env and config. Does NOT disable "
+        "--fix/--dry-run, which always run.",
+    )
     args = parser.parse_args()
 
+    global _LEVEL
     project_dir = Path(args.project_dir).resolve()
+    _LEVEL = resolve_level(
+        "float_order",
+        args.level,
+        project_dir,
+        default="error",
+        env_var="SCITEX_WRITER_FLOAT_ORDER",
+    )
+    fixing = args.fix or args.dry_run
 
     doc_types = []
     if args.doc_type in ("manuscript", "all"):
@@ -365,6 +418,20 @@ def main():
     if not doc_types:
         print(f"{RED}No content directories found in {project_dir}{NC}")
         sys.exit(1)
+
+    # off disables the gate. A requested --fix/--dry-run is an explicit user
+    # action and still runs; level only governs the non-fix gating exit.
+    if _LEVEL == "off" and not fixing:
+        print(f"\n{BOLD}=== Float Reference Order Check (level=off) ==={NC}\n")
+        print(
+            f"  {DIM}[INFO]{NC} float-order check is disabled (level=off). "
+            f"Set float_order.level or --level to enable."
+        )
+        print(
+            f"\n{BOLD}Summary:{NC} {GREEN}0 passed{NC}, "
+            f"{YELLOW}0 warnings{NC}, {RED}0 errors{NC}"
+        )
+        return 0
 
     print(f"\n{BOLD}=== Float Reference Order Check ==={NC}\n")
 
@@ -381,14 +448,18 @@ def main():
                     all_mappings.append((content_dir, float_type, mapping, label))
 
     print()
+    print(
+        f"{BOLD}Summary:{NC} {GREEN}{PASS_COUNT} passed{NC}, "
+        f"{YELLOW}{WARN_COUNT} warnings{NC}, {RED}{FAIL_COUNT} errors{NC}"
+    )
 
     if not has_issues:
-        print(f"{GREEN}All float references are in order.{NC}")
+        print(f"\n{GREEN}All float references are in order.{NC}")
         return 0
 
-    if args.fix or args.dry_run:
+    if fixing:
         mode = "DRY RUN" if args.dry_run else "FIXING"
-        print(f"{BOLD}--- {mode} ---{NC}\n")
+        print(f"\n{BOLD}--- {mode} ---{NC}\n")
         for content_dir, float_type, mapping, label in all_mappings:
             print(f"  {label}: renumbering {len(mapping)} items")
             for old, new in mapping.items():
@@ -399,9 +470,18 @@ def main():
         if not args.dry_run:
             print(f"{GREEN}Renumbering complete. Re-run to verify.{NC}")
         return 0
-    else:
-        print(f"{YELLOW}Run with --fix to auto-renumber, or --dry-run to preview.{NC}")
+
+    # Out-of-order floats, not fixing. At error (default) this gates (exit 1);
+    # at warn the findings were demoted to [WARN] (FAIL_COUNT == 0) and are
+    # non-fatal.
+    if FAIL_COUNT > 0:
+        print(f"\n{YELLOW}Run with --fix to auto-renumber, or --dry-run to preview.{NC}")
         return 1
+    print(
+        f"\n{YELLOW}Out-of-order floats reported (level=warn, non-fatal). "
+        f"Run with --fix to auto-renumber.{NC}"
+    )
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/python/check_limits.py
+++ b/scripts/python/check_limits.py
@@ -20,11 +20,13 @@
 # (the same family of commands check_references.py recognises).
 
 import argparse
-import os
 import re
 import subprocess
 import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
 
 # ANSI colors (match check_references.py)
 GREEN = "\033[0;32m"
@@ -202,6 +204,13 @@ def main():
         action="store_true",
         help="Promote over-limit warnings to errors (non-zero exit).",
     )
+    parser.add_argument(
+        "--level",
+        choices=["off", "warn", "error"],
+        default=None,
+        help="Severity: warn (default), off, or error. Overrides env and "
+        "config; --strict is a tightening alias for error.",
+    )
     args = parser.parse_args()
 
     project_dir = Path(args.project_dir).resolve()
@@ -224,12 +233,25 @@ def main():
         )
         return 0
 
-    strict = (
-        args.strict
-        or bool(limits.get("strict", False))
-        or os.environ.get("SCITEX_WRITER_LINT_STRICT", "").lower()
-        in ("1", "true", "yes")
+    level = resolve_level(
+        "limits",
+        args.level,
+        project_dir,
+        default="warn",
+        env_var="SCITEX_WRITER_LIMITS",
+        legacy_strict=args.strict or bool(limits.get("strict", False)),
     )
+    if level == "off":
+        print(
+            f"  {DIM}[INFO]{NC} limit check is disabled (level=off). "
+            f"Set limits.level or --level to enable."
+        )
+        print(
+            f"\n{BOLD}Summary:{NC} {GREEN}0 passed{NC}, "
+            f"{YELLOW}0 warnings{NC}, {RED}0 errors{NC}"
+        )
+        return 0
+    strict = level == "error"
 
     if not doc_dir.exists():
         print(f"{RED}ERROR:{NC} {doc_dir} not found", file=sys.stderr)

--- a/scripts/python/check_media_provenance.py
+++ b/scripts/python/check_media_provenance.py
@@ -50,6 +50,9 @@ import os
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
+
 # ANSI colors (match check_paper_symlink.py / check_overflow.py)
 GREEN = "\033[0;32m"
 YELLOW = "\033[1;33m"
@@ -63,7 +66,6 @@ WARN_COUNT = 0
 FAIL_COUNT = 0
 
 _LEVELS = ("off", "warn", "error")
-_DEFAULT_LEVEL = "off"
 
 _DOC_DIRS = {
     "manuscript": "01_manuscript",
@@ -128,23 +130,6 @@ def _config_blocks(project_dir):
     proj = _read_block(Path(project_dir) / "config.yaml")
     user = _read_block(Path.home() / ".scitex" / "writer" / "config.yaml")
     return proj, user
-
-
-def resolve_level(cli_level, proj_block, user_block):
-    """Resolve the effective severity level via the documented precedence."""
-    if cli_level:
-        return cli_level.lower()
-
-    env = os.environ.get("SCITEX_WRITER_MEDIA_PROVENANCE", "").strip().lower()
-    if env in _LEVELS:
-        return env
-
-    for block in (proj_block, user_block):
-        level = block.get("level")
-        if isinstance(level, str) and level.lower() in _LEVELS:
-            return level.lower()
-
-    return _DEFAULT_LEVEL
 
 
 def resolve_require_under_scripts(cli_flag, proj_block, user_block):
@@ -219,7 +204,13 @@ def main():
 
     project_dir = Path(args.project_dir).resolve()
     proj_block, user_block = _config_blocks(project_dir)
-    level = resolve_level(args.level, proj_block, user_block)
+    level = resolve_level(
+        "media_provenance",
+        args.level,
+        project_dir,
+        default="off",
+        env_var="SCITEX_WRITER_MEDIA_PROVENANCE",
+    )
     require_under_scripts = resolve_require_under_scripts(
         args.require_under_scripts, proj_block, user_block
     )

--- a/scripts/python/check_overflow.py
+++ b/scripts/python/check_overflow.py
@@ -21,10 +21,12 @@
 # check_limits.py which runs before. Self-contained: stdlib + optional PyYAML.
 
 import argparse
-import os
 import re
 import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
 
 # ANSI colors (match check_limits.py / check_references.py)
 GREEN = "\033[0;32m"
@@ -201,6 +203,13 @@ def main():
         help="Promote overflow warnings to errors (non-zero exit).",
     )
     parser.add_argument(
+        "--level",
+        choices=["off", "warn", "error"],
+        default=None,
+        help="Severity: warn (default), off, or error. Overrides env and "
+        "config; --strict is a tightening alias for error.",
+    )
+    parser.add_argument(
         "--max-pt",
         type=float,
         default=None,
@@ -219,12 +228,25 @@ def main():
     if cfg is None:
         return 1  # hard error already printed loudly
 
-    strict = (
-        args.strict
-        or bool(cfg.get("strict", False))
-        or os.environ.get("SCITEX_WRITER_LINT_STRICT", "").lower()
-        in ("1", "true", "yes")
+    level = resolve_level(
+        "overflow",
+        args.level,
+        project_dir,
+        default="warn",
+        env_var="SCITEX_WRITER_OVERFLOW",
+        legacy_strict=args.strict or bool(cfg.get("strict", False)),
     )
+    if level == "off":
+        print(
+            f"  {DIM}[INFO]{NC} overflow check is disabled (level=off). "
+            f"Set overflow.level or --level to enable."
+        )
+        print(
+            f"\n{BOLD}Summary:{NC} {GREEN}0 passed{NC}, "
+            f"{YELLOW}0 warnings{NC}, {RED}0 errors{NC}"
+        )
+        return 0
+    strict = level == "error"
     if args.max_pt is not None:
         min_pt = args.max_pt
     elif cfg.get("max_pt") is not None:

--- a/scripts/python/check_paper_symlink.py
+++ b/scripts/python/check_paper_symlink.py
@@ -50,6 +50,9 @@ import os
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
+
 # ANSI colors (match check_overflow.py / check_limits.py)
 GREEN = "\033[0;32m"
 YELLOW = "\033[1;33m"
@@ -63,7 +66,6 @@ WARN_COUNT = 0
 FAIL_COUNT = 0
 
 _LEVELS = ("off", "warn", "error", "repair")
-_DEFAULT_LEVEL = "warn"
 _CANONICAL_REL = ".scitex/writer"
 
 # How many diverged file paths to print before truncating.
@@ -90,63 +92,6 @@ def log_fail(msg):
 
 def log_detail(msg):
     print(f"    {DIM}{msg}{NC}")
-
-
-def _read_config_level(config_path):
-    """Read ``paper_symlink.level`` from a YAML config, or None.
-
-    Returns the level string when present and valid, else None. A missing
-    file or missing key is simply None (not an error). PyYAML is optional --
-    if it is absent we silently skip config files (env + CLI still work).
-    """
-    if not config_path.exists():
-        return None
-    try:
-        import yaml
-    except ImportError:
-        return None
-    try:
-        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
-    except Exception:
-        return None
-    if not isinstance(data, dict):
-        return None
-    block = data.get("paper_symlink")
-    if not isinstance(block, dict):
-        return None
-    level = block.get("level")
-    if isinstance(level, str) and level.lower() in _LEVELS:
-        return level.lower()
-    return None
-
-
-def resolve_level(cli_level, project_dir):
-    """Resolve the effective severity level via the documented precedence.
-
-    1. CLI --level
-    2. env SCITEX_WRITER_PAPER_SYMLINK
-    3. project ./config.yaml -> paper_symlink.level
-    4. user ~/.scitex/writer/config.yaml -> paper_symlink.level
-    5. default off
-    """
-    if cli_level:
-        return cli_level.lower()
-
-    env = os.environ.get("SCITEX_WRITER_PAPER_SYMLINK", "").strip().lower()
-    if env in _LEVELS:
-        return env
-
-    proj_level = _read_config_level(Path(project_dir) / "config.yaml")
-    if proj_level:
-        return proj_level
-
-    user_level = _read_config_level(
-        Path.home() / ".scitex" / "writer" / "config.yaml"
-    )
-    if user_level:
-        return user_level
-
-    return _DEFAULT_LEVEL
 
 
 def _sha256(path):
@@ -235,7 +180,13 @@ def main():
     link = project_dir / "paper"
     canonical = project_dir / _CANONICAL_REL
 
-    level = resolve_level(args.level, project_dir)
+    level = resolve_level(
+        "paper_symlink",
+        args.level,
+        project_dir,
+        default="warn",
+        env_var="SCITEX_WRITER_PAPER_SYMLINK",
+    )
 
     print(f"\n{BOLD}=== Paper Symlink Check (level={level}) ==={NC}\n")
 

--- a/scripts/python/check_ref_integrity.py
+++ b/scripts/python/check_ref_integrity.py
@@ -36,13 +36,13 @@
 # check_references.py (same scripts/python/ dir).
 
 import argparse
-import os
 import re
 import sys
 from pathlib import Path
 
 # Reuse the proven extractors from the sibling check (same dir).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
 from check_references import (  # noqa: E402
     collect_tex_files,
     extract_bib_keys,
@@ -64,7 +64,6 @@ WARN_COUNT = 0
 FAIL_COUNT = 0
 
 _LEVELS = ("off", "warn", "error")
-_DEFAULT_LEVEL = "error"
 
 _DOC_DIRS = {
     "manuscript": "01_manuscript",
@@ -102,37 +101,6 @@ def log_detail(msg):
     print(f"    {DIM}{msg}{NC}")
 
 
-def _read_block(config_path):
-    if not config_path.exists():
-        return {}
-    try:
-        import yaml
-    except ImportError:
-        return {}
-    try:
-        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
-    except Exception:
-        return {}
-    if not isinstance(data, dict):
-        return {}
-    block = data.get("ref_integrity")
-    return block if isinstance(block, dict) else {}
-
-
-def resolve_level(cli_level, project_dir):
-    """Resolve severity via CLI > env > project config > user config > default."""
-    if cli_level:
-        return cli_level.lower()
-    env = os.environ.get("SCITEX_WRITER_REF_INTEGRITY", "").strip().lower()
-    if env in _LEVELS:
-        return env
-    proj = _read_block(Path(project_dir) / "config.yaml")
-    user = _read_block(Path.home() / ".scitex" / "writer" / "config.yaml")
-    for block in (proj, user):
-        level = block.get("level")
-        if isinstance(level, str) and level.lower() in _LEVELS:
-            return level.lower()
-    return _DEFAULT_LEVEL
 
 
 def _read_aux_labels(aux_path):
@@ -175,7 +143,13 @@ def main():
     args = parser.parse_args()
 
     project_dir = Path(args.project_dir).resolve()
-    level = resolve_level(args.level, project_dir)
+    level = resolve_level(
+        "ref_integrity",
+        args.level,
+        project_dir,
+        default="error",
+        env_var="SCITEX_WRITER_REF_INTEGRITY",
+    )
 
     print(f"\n{BOLD}=== Reference Integrity Gate (level={level}) ==={NC}\n")
     if level == "off":

--- a/scripts/python/check_ref_integrity.py
+++ b/scripts/python/check_ref_integrity.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/check_ref_integrity.py
+# Purpose: Pre-compile REFERENCE-INTEGRITY gate. Validate every reference class
+#          up front, report ALL problems at once (file:line), then exit non-zero
+#          so the caller can BLOCK the compile (the compile stage proceeds only
+#          on an explicit --yes/--force). Catches ?-refs and undefined \cite
+#          BEFORE a full compile instead of after, buried in the log.
+#
+#          Four classes:
+#            1. FIGURE  \ref  -> resolves to a \label / auto-label (fig:STEM)
+#            2. TABLE   \ref  -> resolves to a \label / auto-label (tab:STEM)
+#            3. CITATION      -> every \cite key exists in the merged bib
+#            4. SUPPLEMENTARY -> every supple- xref resolves against the
+#               supplement's .aux (base.tex \link[supple-]{...}); if the
+#               supplement hasn't been compiled (its .aux is missing), say so
+#               explicitly rather than reporting every supple- ref as undefined.
+#
+#          Reuses scripts/python/check_references.py's extractors (don't
+#          rewrite). Severity off|warn|error (DEFAULT error -- a broken ref ships
+#          a ?-mark / wrong PDF):
+#            off   -- skip the gate
+#            warn  -- report problems, exit 0 (does NOT block)
+#            error -- report problems, exit 1 (caller blocks the compile)
+#          Precedence (highest -> lowest): --level, env SCITEX_WRITER_REF_INTEGRITY,
+#          project ./config.yaml ref_integrity.level, user
+#          ~/.scitex/writer/config.yaml, default error. (To migrate onto the
+#          unified scripts/python/_severity.py resolver once that lands.)
+#
+# Usage:
+#   python check_ref_integrity.py [project_dir]
+#                                 [--doc-type manuscript|supplementary|revision|all]
+#                                 [--level off|warn|error]
+#
+# Self-contained: stdlib + optional PyYAML (config only) + sibling
+# check_references.py (same scripts/python/ dir).
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+# Reuse the proven extractors from the sibling check (same dir).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_references import (  # noqa: E402
+    collect_tex_files,
+    extract_bib_keys,
+    extract_citations,
+    extract_labels,
+    extract_refs,
+    infer_auto_labels,
+)
+
+GREEN = "\033[0;32m"
+YELLOW = "\033[1;33m"
+RED = "\033[0;31m"
+DIM = "\033[0;90m"
+BOLD = "\033[1m"
+NC = "\033[0m"
+
+PASS_COUNT = 0
+WARN_COUNT = 0
+FAIL_COUNT = 0
+
+_LEVELS = ("off", "warn", "error")
+_DEFAULT_LEVEL = "error"
+
+_DOC_DIRS = {
+    "manuscript": "01_manuscript",
+    "supplementary": "02_supplementary",
+    "revision": "03_revision",
+}
+
+# The supplement's labels are pulled into the main doc with this prefix
+# (base.tex: \link[supple-]{./02_supplementary/supplementary}).
+_SUPPLE_PREFIX = "supple-"
+_SUPPLE_AUX = Path("02_supplementary") / "supplementary.aux"
+
+_MAX_LIST = 100
+
+
+def log_pass(msg):
+    global PASS_COUNT
+    print(f"  {GREEN}[PASS]{NC} {msg}")
+    PASS_COUNT += 1
+
+
+def log_warn(msg):
+    global WARN_COUNT
+    print(f"  {YELLOW}[WARN]{NC} {msg}")
+    WARN_COUNT += 1
+
+
+def log_fail(msg):
+    global FAIL_COUNT
+    print(f"  {RED}[FAIL]{NC} {msg}")
+    FAIL_COUNT += 1
+
+
+def log_detail(msg):
+    print(f"    {DIM}{msg}{NC}")
+
+
+def _read_block(config_path):
+    if not config_path.exists():
+        return {}
+    try:
+        import yaml
+    except ImportError:
+        return {}
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    block = data.get("ref_integrity")
+    return block if isinstance(block, dict) else {}
+
+
+def resolve_level(cli_level, project_dir):
+    """Resolve severity via CLI > env > project config > user config > default."""
+    if cli_level:
+        return cli_level.lower()
+    env = os.environ.get("SCITEX_WRITER_REF_INTEGRITY", "").strip().lower()
+    if env in _LEVELS:
+        return env
+    proj = _read_block(Path(project_dir) / "config.yaml")
+    user = _read_block(Path.home() / ".scitex" / "writer" / "config.yaml")
+    for block in (proj, user):
+        level = block.get("level")
+        if isinstance(level, str) and level.lower() in _LEVELS:
+            return level.lower()
+    return _DEFAULT_LEVEL
+
+
+def _read_aux_labels(aux_path):
+    """Return the set of \\newlabel keys recorded in a LaTeX .aux file."""
+    if not aux_path.exists():
+        return None  # distinguish "not compiled" from "compiled, zero labels"
+    text = aux_path.read_text(encoding="utf-8", errors="replace")
+    return set(re.findall(r"\\newlabel\{([^}]+)\}", text))
+
+
+def _classify(key):
+    """Human label for a ref key by its prefix."""
+    if key.startswith(_SUPPLE_PREFIX):
+        return "supplementary"
+    if key.startswith("fig:"):
+        return "figure"
+    if key.startswith("tab:"):
+        return "table"
+    return "reference"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Pre-compile reference-integrity gate: validate figure/table "
+        "\\ref, \\cite-in-bib, and supple- xrefs; report all, then block."
+    )
+    parser.add_argument("project_dir", nargs="?", default=".")
+    parser.add_argument(
+        "--doc-type",
+        choices=[*_DOC_DIRS, "all"],
+        default="all",
+        help="Which document(s) to scan (default: all present).",
+    )
+    parser.add_argument(
+        "--level",
+        choices=list(_LEVELS),
+        default=None,
+        help="Severity: off, warn, or error (default). Overrides env and config.",
+    )
+    args = parser.parse_args()
+
+    project_dir = Path(args.project_dir).resolve()
+    level = resolve_level(args.level, project_dir)
+
+    print(f"\n{BOLD}=== Reference Integrity Gate (level={level}) ==={NC}\n")
+    if level == "off":
+        print(f"  {DIM}[INFO]{NC} reference-integrity gate is disabled (level=off).")
+        print(
+            f"\n{BOLD}Summary:{NC} {GREEN}0 passed{NC}, "
+            f"{YELLOW}0 warnings{NC}, {RED}0 errors{NC}"
+        )
+        return 0
+
+    report = log_fail if level == "error" else log_warn
+    doc_types = list(_DOC_DIRS) if args.doc_type == "all" else [args.doc_type]
+    bib_keys = extract_bib_keys(project_dir / "00_shared" / "bib_files")
+
+    # Supplement labels (for the supple- class). None => supplement not compiled.
+    supp_labels = _read_aux_labels(project_dir / _SUPPLE_AUX)
+
+    any_doc = False
+    for doc_type in doc_types:
+        doc_dir = project_dir / _DOC_DIRS[doc_type]
+        if not doc_dir.is_dir():
+            continue
+        any_doc = True
+        tex_files = collect_tex_files(doc_dir)
+        refs = extract_refs(tex_files)
+        labels = set(extract_labels(tex_files)) | set(infer_auto_labels(doc_dir))
+        cites = extract_citations(tex_files)
+
+        # Classes 1, 2, (other) + 4: every \ref resolves.
+        supple_refs = {k: v for k, v in refs.items() if k.startswith(_SUPPLE_PREFIX)}
+        local_refs = {k: v for k, v in refs.items() if not k.startswith(_SUPPLE_PREFIX)}
+
+        for key, locs in sorted(local_refs.items()):
+            if key in labels:
+                continue
+            for f, line in locs:
+                report(f"{doc_type}: {f.name}:{line}: {_classify(key)} \\ref{{{key}}} -> ?? (no \\label)")
+
+        # Class 4: supple- xrefs need the supplement .aux.
+        if supple_refs:
+            if supp_labels is None:
+                report(
+                    f"{doc_type}: supplement not compiled -- "
+                    f"{(project_dir / _SUPPLE_AUX)} missing; "
+                    f"{len(supple_refs)} supple- xref(s) cannot resolve"
+                )
+                log_detail("fix: run `compile.sh -s` before `compile.sh -m` so the supplement .aux exists.")
+            else:
+                for key, locs in sorted(supple_refs.items()):
+                    bare = key[len(_SUPPLE_PREFIX):]
+                    if bare in supp_labels:
+                        continue
+                    for f, line in locs:
+                        report(
+                            f"{doc_type}: {f.name}:{line}: supplementary \\ref{{{key}}} "
+                            f"-> ?? (no \\label{{{bare}}} in supplement)"
+                        )
+
+        # Class 3: every \cite key exists in the merged bib.
+        for key, locs in sorted(cites.items()):
+            if key in bib_keys:
+                continue
+            for f, line in locs:
+                report(f"{doc_type}: {f.name}:{line}: \\cite{{{key}}} -> not in bibliography")
+
+    if not any_doc:
+        log_pass("no document directories found to check")
+    elif FAIL_COUNT == 0 and WARN_COUNT == 0:
+        log_pass("all references, citations, and supple- xrefs resolve")
+
+    print()
+    print(
+        f"{BOLD}Summary:{NC} {GREEN}{PASS_COUNT} passed{NC}, "
+        f"{YELLOW}{WARN_COUNT} warnings{NC}, {RED}{FAIL_COUNT} errors{NC}"
+    )
+    return 1 if FAIL_COUNT > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/python/check_references.py
+++ b/scripts/python/check_references.py
@@ -20,6 +20,9 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
+
 # ANSI colors
 GREEN = "\033[0;32m"
 YELLOW = "\033[1;33m"
@@ -31,6 +34,10 @@ NC = "\033[0m"
 PASS_COUNT = 0
 WARN_COUNT = 0
 FAIL_COUNT = 0
+
+# Effective severity (off|warn|error), set by main() via the shared resolver.
+# Default error preserves the historical "broken ref => exit 1" behavior.
+_LEVEL = "error"
 
 
 def log_pass(msg):
@@ -46,7 +53,13 @@ def log_warn(msg):
 
 
 def log_fail(msg):
+    """Report a defect. At level ``warn`` it is demoted to a non-fatal
+    ``[WARN]`` (the severity model: ``warn`` reports findings but exits 0);
+    at ``error`` (default) it is a fatal ``[FAIL]`` that drives exit 1."""
     global FAIL_COUNT
+    if _LEVEL == "warn":
+        log_warn(msg)
+        return
     print(f"  {RED}[FAIL]{NC} {msg}")
     FAIL_COUNT += 1
 
@@ -333,7 +346,7 @@ def check_log_warnings(log_file, doc_label):
 
 
 def main():
-    global PASS_COUNT, WARN_COUNT, FAIL_COUNT
+    global PASS_COUNT, WARN_COUNT, FAIL_COUNT, _LEVEL
 
     parser = argparse.ArgumentParser(
         description="Check cross-references, citations, and labels in LaTeX manuscripts"
@@ -355,9 +368,35 @@ def main():
         action="store_true",
         help="Also parse LaTeX .log files for warnings",
     )
+    parser.add_argument(
+        "--level",
+        choices=["off", "warn", "error"],
+        default=None,
+        help="Severity: error (default), warn (report but exit 0), or off "
+        "(disable). Overrides env and config.",
+    )
     args = parser.parse_args()
 
     project_dir = Path(args.project_dir).resolve()
+    _LEVEL = resolve_level(
+        "references",
+        args.level,
+        project_dir,
+        default="error",
+        env_var="SCITEX_WRITER_REFERENCES",
+    )
+    if _LEVEL == "off":
+        print(f"\n{BOLD}=== Reference Check (level=off) ==={NC}\n")
+        print(
+            f"  {DIM}[INFO]{NC} reference check is disabled (level=off). "
+            f"Set references.level or --level to enable."
+        )
+        print(
+            f"\n{BOLD}Summary:{NC} {GREEN}0 passed{NC}, "
+            f"{YELLOW}0 warnings{NC}, {RED}0 errors{NC}"
+        )
+        return 0
+
     bib_dir = project_dir / "00_shared" / "bib_files"
 
     # Collect document directories

--- a/scripts/python/csv_to_latex.py
+++ b/scripts/python/csv_to_latex.py
@@ -227,9 +227,13 @@ def csv_to_latex(csv_file, output_file, caption=None, label=None, max_rows=30):
             )
             lines.append("\\midrule")
         else:
-            # Add row coloring for readability (skip separator in count)
+            # Add row coloring for readability (skip separator in count).
+            # Use the theme color `lightgray` (gray 0.95 light mode; redefined to
+            # gray 0.2 in dark_mode.tex) so the zebra stripe stays legible in
+            # BOTH modes. A literal gray!10 stayed light under dark mode, hiding
+            # the light text on the striped rows.
             if idx % 2 == 1:
-                lines.append("\\rowcolor{gray!10}")
+                lines.append("\\rowcolor{lightgray}")
             lines.append(" & ".join(values) + " \\\\")
 
     lines.append("\\bottomrule")

--- a/scripts/shell/compile_supplementary.sh
+++ b/scripts/shell/compile_supplementary.sh
@@ -338,6 +338,18 @@ main() {
     ./scripts/shell/modules/cleanup.sh
     log_stage_end "Cleanup"
 
+    # Expose the supplement .aux at doc-root for the main compile's
+    # \externaldocument (base.tex \link{./02_supplementary/supplementary} via
+    # xr-hyper reads ./02_supplementary/supplementary.aux). cleanup.sh sweeps
+    # doc-root *.aux into LOG_DIR, so this MUST run AFTER the Cleanup stage,
+    # else it gets swept back. Co-locating .aux with the doc-root .pdf keeps
+    # both the cross-ref numbers and the hyperlink targets correct.
+    _supp_aux="${LOG_DIR}/${SCITEX_WRITER_DOC_TYPE}.aux"
+    if [ -f "$_supp_aux" ]; then
+        cp -f "$_supp_aux" "./02_supplementary/${SCITEX_WRITER_DOC_TYPE}.aux"
+        echo_info "Exposed $_supp_aux -> ./02_supplementary/${SCITEX_WRITER_DOC_TYPE}.aux (xr-hyper)"
+    fi
+
     # Final steps
     log_stage_start "Directory Tree"
     ./scripts/shell/modules/custom_tree.sh

--- a/scripts/shell/initialize_contents.sh
+++ b/scripts/shell/initialize_contents.sh
@@ -41,9 +41,10 @@ init_shared() {
 
     cat >"$PROJECT_ROOT/00_shared/title.tex" <<'LATEX'
 %% -*- coding: utf-8 -*-
-\title{
+\newcommand{\scitexmanuscripttitle}{%
 Your Manuscript Title Here
 }
+\title{\scitexmanuscripttitle}
 
 %%%% EOF
 LATEX

--- a/scripts/shell/modules/merge_bibliographies.sh
+++ b/scripts/shell/modules/merge_bibliographies.sh
@@ -44,4 +44,27 @@ elif [ "$bib_file_count" -eq 0 ]; then
     fi
 fi
 
+# ============================================================================
+# Bib freshness guard
+# ============================================================================
+# Force a bibtex rerun when a source .bib is newer than the compiled .bbl.
+# Under latexmk -output-directory + custom BIBINPUTS, a source-only .bib edit
+# can leave the .bbl/.fdb_latexmk looking up-to-date, so bibtex is skipped and
+# the PDF ships with the OLD bibliography (silent wrong output). Clearing the
+# stale .bbl (and latexmk's fdb) forces regeneration. Confirmed on neurovista's
+# manuscript. Safe: worst case is one extra bibtex pass.
+if [ -n "${LOG_DIR:-}" ] && [ -n "${SCITEX_WRITER_DOC_TYPE:-}" ]; then
+    _bbl="${LOG_DIR}/${SCITEX_WRITER_DOC_TYPE}.bbl"
+    if [ -f "$_bbl" ]; then
+        for _bib in "$BIB_DIR"/*.bib ./"$BIB_OUTPUT"; do
+            [ -f "$_bib" ] || continue
+            if [ "$_bib" -nt "$_bbl" ]; then
+                echo_info "Source bib $_bib newer than $_bbl → clearing stale .bbl to force bibtex"
+                rm -f "$_bbl" "${LOG_DIR}/${SCITEX_WRITER_DOC_TYPE}.fdb_latexmk"
+                break
+            fi
+        done
+    fi
+fi
+
 # EOF

--- a/scripts/shell/modules/run_provenance_checks.sh
+++ b/scripts/shell/modules/run_provenance_checks.sh
@@ -2,15 +2,18 @@
 # -*- coding: utf-8 -*-
 # File: scripts/shell/modules/run_provenance_checks.sh
 #
-# Run the config-driven provenance/symlink checks at their RESOLVED severity
+# Run the config-driven pre-compile checks at their RESOLVED severity
 # (off|warn|error via CLI/env/config). Each underlying script
-# (scripts/python/check_{paper_symlink,media_provenance}.py) resolves its own
-# level and exits non-zero ONLY at error-level with a violation. So:
+# (scripts/python/check_{paper_symlink,media_provenance,caption_footnote}.py)
+# resolves its own level and exits non-zero ONLY at error-level with a
+# violation. So:
 #   off   -> no-op (exit 0)
 #   warn  -> reports, exit 0 (does NOT block the compile)
 #   error -> exit 1 (blocks the compile, fail-loud)
-# This is what makes `paper_symlink: error` / `media_provenance: error` actually
-# enforce at compile time -- previously the compile ran neither check.
+# This is what makes `paper_symlink: error` / `media_provenance: error` /
+# `caption_footnote: error` actually enforce at compile time -- previously the
+# compile ran none of them. caption_footnote defaults to error (a \footnote in
+# a \caption{} is always a fatal compile pattern).
 #
 # Returns the worst exit code across the checks (0 unless a check errored).
 
@@ -21,7 +24,7 @@ PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$THIS_DIR/../../.." && pwd)}"
 PY="${SCITEX_WRITER_PYTHON:-python3}"
 
 rc=0
-for chk in check_paper_symlink check_media_provenance; do
+for chk in check_paper_symlink check_media_provenance check_caption_footnote; do
     script="$THIS_DIR/../../python/${chk}.py"
     [ -f "$script" ] || continue
     "$PY" "$script" "$PROJECT_ROOT" || rc=$?

--- a/src/scitex_writer/_mcp/handlers/__init__.py
+++ b/src/scitex_writer/_mcp/handlers/__init__.py
@@ -5,6 +5,7 @@
 """MCP Handler implementations for SciTeX Writer."""
 
 from ._checks import (
+    check_caption_footnote,
     check_float_order,
     check_limits,
     check_media_provenance,
@@ -29,6 +30,7 @@ from ._update import update_project  # noqa: F401 -- now a package
 
 __all__ = [
     "add_claim",
+    "check_caption_footnote",
     "check_float_order",
     "check_limits",
     "check_media_provenance",

--- a/src/scitex_writer/_mcp/handlers/__init__.py
+++ b/src/scitex_writer/_mcp/handlers/__init__.py
@@ -11,6 +11,7 @@ from ._checks import (
     check_media_provenance,
     check_overflow,
     check_paper_symlink,
+    check_ref_integrity,
     check_references,
 )
 from ._claim import (
@@ -36,6 +37,7 @@ __all__ = [
     "check_media_provenance",
     "check_overflow",
     "check_paper_symlink",
+    "check_ref_integrity",
     "check_references",
     "clone_project",
     "compile_manuscript",

--- a/src/scitex_writer/_mcp/handlers/_checks.py
+++ b/src/scitex_writer/_mcp/handlers/_checks.py
@@ -317,6 +317,42 @@ def check_caption_footnote(
     return _run_script(script, project_path, args, timeout)
 
 
+def check_ref_integrity(
+    project_dir: str,
+    doc_type: str = "all",
+    level: str | None = None,
+    timeout: int = 60,
+) -> dict:
+    """Pre-compile reference-integrity gate: validate every reference class.
+
+    Reports ALL problems at once (file:line) across four classes -- figure
+    ``\\ref``, table ``\\ref``, ``\\cite``-key-in-merged-bib, and ``supple-``
+    cross-document xrefs (resolved against the supplement's ``.aux``; a missing
+    supplement ``.aux`` is reported explicitly as "not compiled" rather than as
+    undefined refs) -- then exits non-zero so the compile stage can BLOCK
+    (proceeding only on an explicit ``--yes``). Reuses ``check_references.py``'s
+    extractors.
+
+    Severity precedence (highest -> lowest): ``level`` arg, env
+    ``SCITEX_WRITER_REF_INTEGRITY``, project ``./config.yaml``
+    (``ref_integrity.level``), user ``~/.scitex/writer/config.yaml``, default
+    ``error`` (a broken ref ships a ?-mark / wrong PDF).
+
+    Args:
+        project_dir: Project root.
+        doc_type: ``manuscript``, ``supplementary``, ``revision``, or ``all``.
+        level: One of ``off``, ``warn``, ``error``. When ``None``, env/config
+            precedence resolves the level.
+        timeout: Subprocess timeout in seconds.
+    """
+    project_path = resolve_project_path(project_dir)
+    script = _script_path(project_path, "check_ref_integrity.py")
+    args = ["--doc-type", doc_type]
+    if level is not None:
+        args += ["--level", level]
+    return _run_script(script, project_path, args, timeout)
+
+
 __all__ = [
     "check_references",
     "check_float_order",
@@ -325,6 +361,7 @@ __all__ = [
     "check_paper_symlink",
     "check_media_provenance",
     "check_caption_footnote",
+    "check_ref_integrity",
 ]
 
 # EOF

--- a/src/scitex_writer/_mcp/handlers/_checks.py
+++ b/src/scitex_writer/_mcp/handlers/_checks.py
@@ -281,6 +281,42 @@ def check_media_provenance(
     return _run_script(script, project_path, args, timeout)
 
 
+def check_caption_footnote(
+    project_dir: str,
+    doc_type: str = "all",
+    level: str | None = None,
+    timeout: int = 60,
+) -> dict:
+    """Lint: flag ``\\footnote``/``\\footnotetext`` inside a ``\\caption{}``.
+
+    ``\\footnote`` in a caption is a fatal LaTeX pattern (the caption arg is
+    reprocessed -> ``\\caption@ydblarg`` "extra }" + runaway ``\\@xfootnote``,
+    fatal in figure*/table* floats). ``\\footnotemark`` is the blessed in-caption
+    pattern and is NOT flagged. Scans the source ``.tex`` under
+    ``<doc>/contents/`` (caption_and_media/*.tex whole-file, plus brace-matched
+    ``\\caption{}`` args elsewhere); the generated assembled doc is not scanned.
+
+    Severity precedence (highest -> lowest): ``level`` arg, env
+    ``SCITEX_WRITER_CAPTION_FOOTNOTE``, project ``./config.yaml``
+    (``caption_footnote.level``), user ``~/.scitex/writer/config.yaml``, default
+    ``error`` (the pattern is always a fatal compile bug; a clean manuscript
+    never triggers it).
+
+    Args:
+        project_dir: Project root.
+        doc_type: ``manuscript``, ``supplementary``, ``revision``, or ``all``.
+        level: One of ``off``, ``warn``, ``error``. When ``None``, env/config
+            precedence resolves the level.
+        timeout: Subprocess timeout in seconds.
+    """
+    project_path = resolve_project_path(project_dir)
+    script = _script_path(project_path, "check_caption_footnote.py")
+    args = ["--doc-type", doc_type]
+    if level is not None:
+        args += ["--level", level]
+    return _run_script(script, project_path, args, timeout)
+
+
 __all__ = [
     "check_references",
     "check_float_order",
@@ -288,6 +324,7 @@ __all__ = [
     "check_overflow",
     "check_paper_symlink",
     "check_media_provenance",
+    "check_caption_footnote",
 ]
 
 # EOF

--- a/src/scitex_writer/_skills/scitex-writer/20_env-vars.md
+++ b/src/scitex_writer/_skills/scitex-writer/20_env-vars.md
@@ -36,7 +36,9 @@ exits non-zero.
 
 | Variable | Purpose | Default | Type |
 |---|---|---|---|
-| `SCITEX_WRITER_LINT_STRICT` | Tighten `check-limits` + `check-overflow` warnings to errors (the legacy strict toggle). | `false` | bool |
+| `SCITEX_WRITER_LINT_STRICT` | Tighten `check-limits` + `check-overflow` warnings to errors (the legacy strict toggle). Scoped to those two checks only. | `false` | bool |
+| `SCITEX_WRITER_LIMITS` | Severity for the word/reference-limit check (`off`/`warn`/`error`). Default `warn`; `--strict`/`limits.strict` tighten to `error`. | `warn` | enum |
+| `SCITEX_WRITER_OVERFLOW` | Severity for the off-page overflow check (`off`/`warn`/`error`). Default `warn`; `--strict`/`overflow.strict` tighten to `error`. | `warn` | enum |
 | `SCITEX_WRITER_PAPER_SYMLINK` | Severity for the `paper -> .scitex/writer` symlink check (`off`/`warn`/`error`/`repair`). Private convention — default `warn`. | `warn` | enum |
 | `SCITEX_WRITER_MEDIA_PROVENANCE` | Severity for the media-symlink/provenance check on `caption_and_media/` (`off`/`warn`/`error`). Private convention — default `off`. | `off` | enum |
 

--- a/src/scitex_writer/_skills/scitex-writer/20_env-vars.md
+++ b/src/scitex_writer/_skills/scitex-writer/20_env-vars.md
@@ -41,6 +41,9 @@ exits non-zero.
 | `SCITEX_WRITER_OVERFLOW` | Severity for the off-page overflow check (`off`/`warn`/`error`). Default `warn`; `--strict`/`overflow.strict` tighten to `error`. | `warn` | enum |
 | `SCITEX_WRITER_PAPER_SYMLINK` | Severity for the `paper -> .scitex/writer` symlink check (`off`/`warn`/`error`/`repair`). Private convention — default `warn`. | `warn` | enum |
 | `SCITEX_WRITER_MEDIA_PROVENANCE` | Severity for the media-symlink/provenance check on `caption_and_media/` (`off`/`warn`/`error`). Private convention — default `off`. | `off` | enum |
+| `SCITEX_WRITER_REFERENCES` | Severity for the cross-reference/citation/label check (`off`/`warn`/`error`). Default `error` (a broken `\ref`/`\cite` is a real defect); `warn` reports but exits 0; `off` disables. | `error` | enum |
+| `SCITEX_WRITER_CAPTION_FOOTNOTE` | Severity for the `\footnote`-in-`\caption{}` lint (`off`/`warn`/`error`). Default `error`. | `error` | enum |
+| `SCITEX_WRITER_REF_INTEGRITY` | Severity for the pre-compile reference-integrity gate (`off`/`warn`/`error`). Default `error`. | `error` | enum |
 
 ## Branding & naming
 

--- a/src/scitex_writer/_skills/scitex-writer/20_env-vars.md
+++ b/src/scitex_writer/_skills/scitex-writer/20_env-vars.md
@@ -42,8 +42,15 @@ exits non-zero.
 | `SCITEX_WRITER_PAPER_SYMLINK` | Severity for the `paper -> .scitex/writer` symlink check (`off`/`warn`/`error`/`repair`). Private convention — default `warn`. | `warn` | enum |
 | `SCITEX_WRITER_MEDIA_PROVENANCE` | Severity for the media-symlink/provenance check on `caption_and_media/` (`off`/`warn`/`error`). Private convention — default `off`. | `off` | enum |
 | `SCITEX_WRITER_REFERENCES` | Severity for the cross-reference/citation/label check (`off`/`warn`/`error`). Default `error` (a broken `\ref`/`\cite` is a real defect); `warn` reports but exits 0; `off` disables. | `error` | enum |
+| `SCITEX_WRITER_FLOAT_ORDER` | Severity for the figure/table reference-order check (`off`/`warn`/`error`). Default `error`. `--level` governs only the gating exit; `--fix`/`--dry-run` always run regardless of level. | `error` | enum |
 | `SCITEX_WRITER_CAPTION_FOOTNOTE` | Severity for the `\footnote`-in-`\caption{}` lint (`off`/`warn`/`error`). Default `error`. | `error` | enum |
 | `SCITEX_WRITER_REF_INTEGRITY` | Severity for the pre-compile reference-integrity gate (`off`/`warn`/`error`). Default `error`. | `error` | enum |
+
+> **`references` vs `ref_integrity` are separate knobs.** `references` is the
+> advisory cross-reference/citation/label *report*; `ref_integrity` is the
+> *pre-compile integrity gate*. Downgrading `references` (e.g. to `off`) does
+> **not** disable `ref_integrity`, so a broken `\ref` can still block a compile
+> via the gate — defense in depth by design.
 
 ## Branding & naming
 

--- a/src/scitex_writer/checks.py
+++ b/src/scitex_writer/checks.py
@@ -29,6 +29,7 @@ from typing import Callable as _Callable
 from typing import Literal as _Literal
 from typing import Optional as _Optional
 
+from ._mcp.handlers import check_caption_footnote as _check_caption_footnote
 from ._mcp.handlers import check_float_order as _check_float_order
 from ._mcp.handlers import check_limits as _check_limits
 from ._mcp.handlers import check_media_provenance as _check_media_provenance
@@ -231,6 +232,52 @@ def media_provenance(
     return handler(project_dir, doc_type, level, require_under_scripts)
 
 
+def caption_footnote(
+    project_dir: str,
+    doc_type: _Literal["manuscript", "supplementary", "revision", "all"] = "all",
+    level: _Optional[_Literal["off", "warn", "error"]] = None,
+    handler: _Optional[_Callable[..., dict]] = None,
+) -> dict:
+    """Lint: flag ``\\footnote``/``\\footnotetext`` inside a ``\\caption{}``.
+
+    ``\\footnote`` in a caption is a fatal LaTeX pattern — the caption argument
+    is reprocessed (list-of-figures + heading), yielding
+    ``\\caption@ydblarg`` "extra }" and a runaway ``\\@xfootnote``, fatal in
+    ``figure*``/``table*`` spanning floats. The blessed pattern is
+    ``\\caption[short]{long\\protect\\footnotemark}`` with ``\\footnotetext``
+    **after** the float, so ``\\footnotemark`` in a caption is allowed and is
+    **not** flagged.
+
+    Scans the source ``.tex`` under ``<doc>/contents/`` — every
+    ``caption_and_media/*.tex`` whole-file (the engine wraps it in
+    ``\\caption{}``) plus brace-matched ``\\caption{}`` arguments in other
+    source files. The generated assembled doc is not scanned (it duplicates the
+    sources), keeping this a pre-compile lint.
+
+    Severity:
+
+    * ``error`` — report as an error (``exit_code`` 1). **The default**, because
+      the pattern is always a fatal compile bug; a clean manuscript never fires.
+    * ``warn`` — report as a warning (``exit_code`` 0).
+    * ``off`` — check disabled.
+
+    Severity precedence (highest → lowest): the ``level`` argument, env
+    ``SCITEX_WRITER_CAPTION_FOOTNOTE``, project ``./config.yaml``
+    (``caption_footnote.level``), user ``~/.scitex/writer/config.yaml``, then
+    the ``error`` default.
+
+    Returns a dict with ``success``, ``exit_code``, ``stdout``, ``stderr``,
+    and ``summary={passed, warnings, errors}``.
+
+    ``handler`` is the underlying check implementation; it defaults to
+    :func:`scitex_writer._mcp.handlers.check_caption_footnote`. Exposed so
+    callers (and tests) can supply an alternate implementation without patching
+    internals.
+    """
+    handler = handler or _check_caption_footnote
+    return handler(project_dir, doc_type, level)
+
+
 __all__ = [
     "references",
     "float_order",
@@ -238,6 +285,7 @@ __all__ = [
     "overflow",
     "paper_symlink",
     "media_provenance",
+    "caption_footnote",
 ]
 
 # EOF

--- a/src/scitex_writer/checks.py
+++ b/src/scitex_writer/checks.py
@@ -31,6 +31,7 @@ from typing import Optional as _Optional
 
 from ._mcp.handlers import check_caption_footnote as _check_caption_footnote
 from ._mcp.handlers import check_float_order as _check_float_order
+from ._mcp.handlers import check_ref_integrity as _check_ref_integrity
 from ._mcp.handlers import check_limits as _check_limits
 from ._mcp.handlers import check_media_provenance as _check_media_provenance
 from ._mcp.handlers import check_overflow as _check_overflow
@@ -278,6 +279,53 @@ def caption_footnote(
     return handler(project_dir, doc_type, level)
 
 
+def ref_integrity(
+    project_dir: str,
+    doc_type: _Literal["manuscript", "supplementary", "revision", "all"] = "all",
+    level: _Optional[_Literal["off", "warn", "error"]] = None,
+    handler: _Optional[_Callable[..., dict]] = None,
+) -> dict:
+    """Pre-compile reference-integrity gate over all four reference classes.
+
+    Validates, reporting **all** problems at once (file:line):
+
+    * **figure** ``\\ref`` resolves to a figure label / auto-label,
+    * **table** ``\\ref`` resolves to a table label / auto-label,
+    * every ``\\cite`` key exists in the merged bibliography,
+    * every ``supple-`` cross-document xref resolves against the supplement's
+      ``.aux`` — and if the supplement has not been compiled (its ``.aux`` is
+      missing) that is reported explicitly as "not compiled", not as a pile of
+      undefined refs.
+
+    Designed to run FIRST, fail-fast: at ``error`` it exits non-zero so the
+    compile stage blocks (proceeding only on an explicit ``--yes``); ``warn``
+    reports without blocking; ``off`` skips. Reuses the ``check_references``
+    extractors.
+
+    Severity:
+
+    * ``error`` — report and exit 1. **The default** (a broken ref ships a
+      ?-mark / wrong PDF).
+    * ``warn`` — report, exit 0 (does not block).
+    * ``off`` — gate disabled.
+
+    Severity precedence (highest → lowest): the ``level`` argument, env
+    ``SCITEX_WRITER_REF_INTEGRITY``, project ``./config.yaml``
+    (``ref_integrity.level``), user ``~/.scitex/writer/config.yaml``, then the
+    ``error`` default.
+
+    Returns a dict with ``success``, ``exit_code``, ``stdout``, ``stderr``,
+    and ``summary={passed, warnings, errors}``.
+
+    ``handler`` is the underlying check implementation; it defaults to
+    :func:`scitex_writer._mcp.handlers.check_ref_integrity`. Exposed so callers
+    (and tests) can supply an alternate implementation without patching
+    internals.
+    """
+    handler = handler or _check_ref_integrity
+    return handler(project_dir, doc_type, level)
+
+
 __all__ = [
     "references",
     "float_order",
@@ -286,6 +334,7 @@ __all__ = [
     "paper_symlink",
     "media_provenance",
     "caption_footnote",
+    "ref_integrity",
 ]
 
 # EOF

--- a/tests/scitex_writer/test_checks.py
+++ b/tests/scitex_writer/test_checks.py
@@ -36,7 +36,31 @@ def test_module_exports_references_float_order_limits_and_overflow():
         "paper_symlink",
         "media_provenance",
         "caption_footnote",
+        "ref_integrity",
     ]
+
+
+def test_ref_integrity_forwards_all_arguments_to_handler():
+    # Arrange
+    handler = _RecordingHandler({"success": True})
+    # Act
+    checks.ref_integrity(
+        "/path",
+        doc_type="supplementary",
+        level="error",
+        handler=handler,
+    )
+    # Assert
+    assert handler.calls == [("/path", "supplementary", "error")]
+
+
+def test_ref_integrity_defaults_are_all_doctype_none_level():
+    # Arrange
+    handler = _RecordingHandler({"success": True})
+    # Act
+    checks.ref_integrity("/path", handler=handler)
+    # Assert
+    assert handler.calls == [("/path", "all", None)]
 
 
 def test_caption_footnote_forwards_all_arguments_to_handler():

--- a/tests/scitex_writer/test_checks.py
+++ b/tests/scitex_writer/test_checks.py
@@ -35,7 +35,31 @@ def test_module_exports_references_float_order_limits_and_overflow():
         "overflow",
         "paper_symlink",
         "media_provenance",
+        "caption_footnote",
     ]
+
+
+def test_caption_footnote_forwards_all_arguments_to_handler():
+    # Arrange
+    handler = _RecordingHandler({"success": True})
+    # Act
+    checks.caption_footnote(
+        "/path",
+        doc_type="supplementary",
+        level="error",
+        handler=handler,
+    )
+    # Assert
+    assert handler.calls == [("/path", "supplementary", "error")]
+
+
+def test_caption_footnote_defaults_are_all_doctype_none_level():
+    # Arrange
+    handler = _RecordingHandler({"success": True})
+    # Act
+    checks.caption_footnote("/path", handler=handler)
+    # Assert
+    assert handler.calls == [("/path", "all", None)]
 
 
 def test_media_provenance_forwards_all_arguments_to_handler():

--- a/tests/scripts/python/test__severity.py
+++ b/tests/scripts/python/test__severity.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: _severity.py (shared severity-model resolver, Part D §9)
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from _severity import (  # noqa: E402
+    LEVELS,
+    LINT_STRICT_ENV,
+    env_truthy,
+    resolve_level,
+)
+
+# Every per-check env var the resolver may read, isolated per test.
+_ENV_KEYS = (
+    "SCITEX_WRITER_LIMITS",
+    "SCITEX_WRITER_OVERFLOW",
+    "SCITEX_WRITER_PAPER_SYMLINK",
+    "SCITEX_WRITER_REFERENCES",
+    "SCITEX_WRITER_LINT_STRICT",
+)
+
+
+# ============================================================================
+# helpers / fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def clean_env():
+    """Isolate the severity env vars + HOME so config/env never leak in."""
+    saved = {k: os.environ.get(k) for k in (*_ENV_KEYS, "HOME")}
+    for key in _ENV_KEYS:
+        os.environ.pop(key, None)
+    with tempfile.TemporaryDirectory() as home:
+        os.environ["HOME"] = home
+        yield home
+    for key, val in saved.items():
+        if val is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = val
+
+
+def _write_yaml(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+# ============================================================================
+# precedence ladder
+# ============================================================================
+
+
+def test_default_when_nothing_set(tmp_path, clean_env):
+    """With no CLI/env/config, the per-check default is returned."""
+    # Arrange
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "warn"
+
+
+def test_cli_overrides_default(tmp_path, clean_env):
+    """An explicit --level wins over the default."""
+    # Arrange
+    # Act
+    level = resolve_level(
+        "limits", "error", tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "error"
+
+
+def test_cli_overrides_env(tmp_path, clean_env):
+    """CLI --level beats the per-check env var."""
+    # Arrange
+    os.environ["SCITEX_WRITER_LIMITS"] = "off"
+    # Act
+    level = resolve_level(
+        "limits", "error", tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "error"
+
+
+def test_env_overrides_project_config(tmp_path, clean_env):
+    """The per-check env var beats project ./config.yaml."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write_yaml(tmp_path / "config.yaml", "limits:\n  level: error\n")
+    os.environ["SCITEX_WRITER_LIMITS"] = "off"
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "off"
+
+
+def test_project_config_level_honored(tmp_path, clean_env):
+    """`<check>.level` in project ./config.yaml is used when no CLI/env."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write_yaml(tmp_path / "config.yaml", "limits:\n  level: error\n")
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "error"
+
+
+def test_project_config_overrides_user_config(tmp_path, clean_env):
+    """Project ./config.yaml wins over user ~/.scitex/writer/config.yaml."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write_yaml(tmp_path / "config.yaml", "limits:\n  level: error\n")
+    _write_yaml(
+        Path(clean_env) / ".scitex" / "writer" / "config.yaml",
+        "limits:\n  level: off\n",
+    )
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "error"
+
+
+def test_user_config_honored_when_no_project_config(tmp_path, clean_env):
+    """User-wide config supplies the level when the project has none."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write_yaml(
+        Path(clean_env) / ".scitex" / "writer" / "config.yaml",
+        "limits:\n  level: error\n",
+    )
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "error"
+
+
+def test_invalid_env_value_falls_through(tmp_path, clean_env):
+    """A bogus env value is ignored and the default applies."""
+    # Arrange
+    os.environ["SCITEX_WRITER_LIMITS"] = "nonsense"
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "warn"
+
+
+# ============================================================================
+# legacy_strict tightening (the --strict / <check>.strict alias)
+# ============================================================================
+
+
+def test_legacy_strict_tightens_warn_to_error(tmp_path, clean_env):
+    """legacy_strict promotes a resolved warn to error."""
+    # Arrange
+    # Act
+    level = resolve_level(
+        "limits",
+        None,
+        tmp_path,
+        default="warn",
+        env_var="SCITEX_WRITER_LIMITS",
+        legacy_strict=True,
+    )
+    # Assert
+    assert level == "error"
+
+
+def test_legacy_strict_does_not_touch_off(tmp_path, clean_env):
+    """legacy_strict never tightens an explicit off."""
+    # Arrange
+    # Act
+    level = resolve_level(
+        "limits",
+        "off",
+        tmp_path,
+        default="warn",
+        env_var="SCITEX_WRITER_LIMITS",
+        legacy_strict=True,
+    )
+    # Assert
+    assert level == "off"
+
+
+# ============================================================================
+# SCITEX_WRITER_LINT_STRICT — scoped to limits + overflow only
+# ============================================================================
+
+
+def test_lint_strict_tightens_limits(tmp_path, clean_env):
+    """LINT_STRICT promotes limits warn -> error (in scope)."""
+    # Arrange
+    os.environ[LINT_STRICT_ENV] = "1"
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "error"
+
+
+def test_lint_strict_tightens_overflow(tmp_path, clean_env):
+    """LINT_STRICT promotes overflow warn -> error (in scope)."""
+    # Arrange
+    os.environ[LINT_STRICT_ENV] = "1"
+    # Act
+    level = resolve_level(
+        "overflow", None, tmp_path, default="warn", env_var="SCITEX_WRITER_OVERFLOW"
+    )
+    # Assert
+    assert level == "error"
+
+
+def test_lint_strict_does_not_affect_unscoped_check(tmp_path, clean_env):
+    """LINT_STRICT leaves a non-scoped check (references) at warn."""
+    # Arrange
+    os.environ[LINT_STRICT_ENV] = "1"
+    # Act
+    level = resolve_level(
+        "references",
+        None,
+        tmp_path,
+        default="warn",
+        env_var="SCITEX_WRITER_REFERENCES",
+    )
+    # Assert
+    assert level == "warn"
+
+
+# ============================================================================
+# repair level — only for self-fixing checks (paper_symlink)
+# ============================================================================
+
+
+def test_repair_honored_for_paper_symlink(tmp_path, clean_env):
+    """paper_symlink accepts the repair level."""
+    # Arrange
+    # Act
+    level = resolve_level(
+        "paper_symlink",
+        "repair",
+        tmp_path,
+        default="warn",
+        env_var="SCITEX_WRITER_PAPER_SYMLINK",
+    )
+    # Assert
+    assert level == "repair"
+
+
+def test_repair_ignored_for_non_repair_check(tmp_path, clean_env):
+    """A repair value for a non-self-fixing check falls through to default."""
+    # Arrange
+    # Act
+    level = resolve_level(
+        "limits", "repair", tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "warn"
+
+
+# ============================================================================
+# env_truthy + module constants
+# ============================================================================
+
+
+def test_env_truthy_true_for_yes(clean_env):
+    """env_truthy recognizes a truthy token."""
+    # Arrange
+    os.environ["SCITEX_WRITER_LINT_STRICT"] = "yes"
+    # Act
+    result = env_truthy("SCITEX_WRITER_LINT_STRICT")
+    # Assert
+    assert result is True
+
+
+def test_env_truthy_false_for_zero(clean_env):
+    """env_truthy treats 0 as not truthy."""
+    # Arrange
+    os.environ["SCITEX_WRITER_LINT_STRICT"] = "0"
+    # Act
+    result = env_truthy("SCITEX_WRITER_LINT_STRICT")
+    # Assert
+    assert result is False
+
+
+def test_levels_tuple_is_canonical_order(clean_env):
+    """LEVELS exposes the canonical off<warn<error<repair order."""
+    # Arrange
+    # Act
+    levels = LEVELS
+    # Assert
+    assert levels == ("off", "warn", "error", "repair")
+
+
+# EOF

--- a/tests/scripts/python/test__severity.py
+++ b/tests/scripts/python/test__severity.py
@@ -19,12 +19,18 @@ from _severity import (  # noqa: E402
     resolve_level,
 )
 
-# Every per-check env var the resolver may read, isolated per test.
+# Every per-check env var the resolver may read, isolated per test. The shared
+# self-hosted runners export many SCITEX_* vars in-profile, so a per-check leak
+# would make a test pass/fail by host -- list them all (cheap insurance).
 _ENV_KEYS = (
     "SCITEX_WRITER_LIMITS",
     "SCITEX_WRITER_OVERFLOW",
     "SCITEX_WRITER_PAPER_SYMLINK",
+    "SCITEX_WRITER_MEDIA_PROVENANCE",
     "SCITEX_WRITER_REFERENCES",
+    "SCITEX_WRITER_FLOAT_ORDER",
+    "SCITEX_WRITER_CAPTION_FOOTNOTE",
+    "SCITEX_WRITER_REF_INTEGRITY",
     "SCITEX_WRITER_LINT_STRICT",
 )
 
@@ -158,6 +164,50 @@ def test_invalid_env_value_falls_through(tmp_path, clean_env):
     """A bogus env value is ignored and the default applies."""
     # Arrange
     os.environ["SCITEX_WRITER_LIMITS"] = "nonsense"
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "warn"
+
+
+# ============================================================================
+# config `level` YAML-bool coercion (§2 ruling: `level: off` must disable)
+# ============================================================================
+
+
+def test_config_level_off_yaml_bool_disables(tmp_path, clean_env):
+    """`level: off` (YAML 1.1 -> bool False) still disables the check."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write_yaml(tmp_path / "config.yaml", "limits:\n  level: off\n")
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "off"
+
+
+def test_config_level_on_yaml_bool_falls_through(tmp_path, clean_env):
+    """`level: on` (YAML -> bool True) is invalid and falls through to default."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write_yaml(tmp_path / "config.yaml", "limits:\n  level: on\n")
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "warn"
+
+
+def test_config_level_typo_falls_through(tmp_path, clean_env):
+    """A typo'd config level is ignored (treated as unset), not a crash."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write_yaml(tmp_path / "config.yaml", "limits:\n  level: bogus\n")
     # Act
     level = resolve_level(
         "limits", None, tmp_path, default="warn", env_var="SCITEX_WRITER_LIMITS"

--- a/tests/scripts/python/test__severity.py
+++ b/tests/scripts/python/test__severity.py
@@ -279,6 +279,17 @@ def test_repair_ignored_for_non_repair_check(tmp_path, clean_env):
     assert level == "warn"
 
 
+def test_repair_default_gated_for_non_repair_check(tmp_path, clean_env):
+    """Even a repair *default* cannot smuggle repair into a non-repair check."""
+    # Arrange
+    # Act
+    level = resolve_level(
+        "limits", None, tmp_path, default="repair", env_var="SCITEX_WRITER_LIMITS"
+    )
+    # Assert
+    assert level == "error"
+
+
 # ============================================================================
 # env_truthy + module constants
 # ============================================================================

--- a/tests/scripts/python/test_check_caption_footnote.py
+++ b/tests/scripts/python/test_check_caption_footnote.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: check_caption_footnote.py
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Add scripts/python to path for imports
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from check_caption_footnote import (  # noqa: E402
+    _caption_arg_spans,
+    _strip_comments,
+    resolve_level,
+)
+
+_SCRIPT = ROOT_DIR / "scripts" / "python" / "check_caption_footnote.py"
+
+_CAPTION_MEDIA = "01_manuscript/contents/figures/caption_and_media"
+
+
+# ============================================================================
+# helpers / fixtures
+# ============================================================================
+
+
+def _write(tmp_path, rel, content):
+    p = tmp_path / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _run(project, *extra):
+    env = dict(os.environ)
+    env.pop("SCITEX_WRITER_CAPTION_FOOTNOTE", None)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), str(project), *extra],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+@pytest.fixture
+def clean_env():
+    """Isolate env + HOME so no stray SCITEX_WRITER_CAPTION_FOOTNOTE or user
+    config.yaml leaks into severity resolution."""
+    saved = {
+        k: os.environ.get(k)
+        for k in ("SCITEX_WRITER_CAPTION_FOOTNOTE", "HOME")
+    }
+    os.environ.pop("SCITEX_WRITER_CAPTION_FOOTNOTE", None)
+    with tempfile.TemporaryDirectory() as home:
+        os.environ["HOME"] = home
+        yield home
+    for key, val in saved.items():
+        if val is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = val
+
+
+# ============================================================================
+# resolve_level — default severity
+# ============================================================================
+
+
+def test_resolve_level_defaults_to_error(clean_env):
+    """With no --level, no env, no config, the default level is error."""
+    # Arrange
+    # Act
+    level = resolve_level(None, {}, {})
+    # Assert
+    assert level == "error"
+
+
+def test_resolve_level_cli_overrides(clean_env):
+    """An explicit --level wins over everything else."""
+    # Arrange
+    # Act
+    level = resolve_level("warn", {"level": "error"}, {})
+    # Assert
+    assert level == "warn"
+
+
+# ============================================================================
+# _strip_comments
+# ============================================================================
+
+
+def test_strip_comments_blanks_commented_footnote():
+    """A \\footnote after an unescaped % is removed from the scanned text."""
+    # Arrange
+    text = "good % \\footnote{ignored}\n"
+    # Act
+    stripped = _strip_comments(text)
+    # Assert
+    assert "\\footnote" not in stripped
+
+
+def test_strip_comments_keeps_escaped_percent():
+    """An escaped \\% is not treated as a comment start."""
+    # Arrange
+    text = "50\\% yield \\footnote{kept}\n"
+    # Act
+    stripped = _strip_comments(text)
+    # Assert
+    assert "\\footnote{kept}" in stripped
+
+
+# ============================================================================
+# _caption_arg_spans — brace matching
+# ============================================================================
+
+
+def test_caption_arg_spans_matches_nested_braces():
+    """The span covers a caption arg containing nested braces."""
+    # Arrange
+    text = r"\caption{outer {inner} end}"
+    # Act
+    spans = list(_caption_arg_spans(text))
+    # Assert
+    assert [text[s:e] for s, e in spans] == ["outer {inner} end"]
+
+
+def test_caption_arg_spans_skips_optional_short_arg():
+    """An optional [short] arg before {...} is skipped, span is the long arg."""
+    # Arrange
+    text = r"\caption[short]{long body}"
+    # Act
+    spans = list(_caption_arg_spans(text))
+    # Assert
+    assert [text[s:e] for s, e in spans] == ["long body"]
+
+
+# ============================================================================
+# End-to-end script behaviour (no LaTeX toolchain needed)
+# ============================================================================
+
+
+def test_footnote_in_caption_media_file_errors(tmp_path, clean_env):
+    """\\footnote in a caption_and_media/*.tex (whole-file caption body) errors."""
+    # Arrange
+    _write(tmp_path, f"{_CAPTION_MEDIA}/01.tex", "Cohort.\\footnote{disclosure}\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_footnote_in_inline_caption_errors(tmp_path, clean_env):
+    """\\footnote inside an inline \\caption{} in a content .tex errors."""
+    # Arrange
+    _write(
+        tmp_path,
+        "01_manuscript/contents/results.tex",
+        "\\begin{figure}\\caption{Cap \\footnote{bad}}\\end{figure}\n",
+    )
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_footnotemark_in_caption_is_allowed(tmp_path, clean_env):
+    """\\footnotemark (the blessed pattern) in a caption body does NOT error."""
+    # Arrange
+    _write(tmp_path, f"{_CAPTION_MEDIA}/01.tex", "Cohort.\\footnotemark\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_footnotetext_in_caption_media_errors(tmp_path, clean_env):
+    """\\footnotetext used as an in-caption workaround is flagged too."""
+    # Arrange
+    _write(tmp_path, f"{_CAPTION_MEDIA}/01.tex", "Cohort.\\footnotetext{x}\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_commented_footnote_is_ignored(tmp_path, clean_env):
+    """A \\footnote inside a LaTeX comment does not trigger the lint."""
+    # Arrange
+    _write(tmp_path, f"{_CAPTION_MEDIA}/01.tex", "Cohort. % \\footnote{ignored}\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_off_level_exits_zero_with_violation(tmp_path, clean_env):
+    """--level off disables the check even when a violation is present."""
+    # Arrange
+    _write(tmp_path, f"{_CAPTION_MEDIA}/01.tex", "Cohort.\\footnote{bad}\n")
+    # Act
+    proc = _run(tmp_path, "--level", "off")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_warn_level_does_not_block(tmp_path, clean_env):
+    """--level warn reports the violation but exits 0 (does not block compile)."""
+    # Arrange
+    _write(tmp_path, f"{_CAPTION_MEDIA}/01.tex", "Cohort.\\footnote{bad}\n")
+    # Act
+    proc = _run(tmp_path, "--level", "warn")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_clean_manuscript_passes(tmp_path, clean_env):
+    """A caption with no footnote passes (exit 0)."""
+    # Arrange
+    _write(tmp_path, f"{_CAPTION_MEDIA}/01.tex", "Cohort design overview.\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 0

--- a/tests/scripts/python/test_check_caption_footnote.py
+++ b/tests/scripts/python/test_check_caption_footnote.py
@@ -72,20 +72,34 @@ def clean_env():
 # ============================================================================
 
 
-def test_resolve_level_defaults_to_error(clean_env):
+def test_resolve_level_defaults_to_error(tmp_path, clean_env):
     """With no --level, no env, no config, the default level is error."""
     # Arrange
     # Act
-    level = resolve_level(None, {}, {})
+    level = resolve_level(
+        "caption_footnote",
+        None,
+        tmp_path,
+        default="error",
+        env_var="SCITEX_WRITER_CAPTION_FOOTNOTE",
+    )
     # Assert
     assert level == "error"
 
 
-def test_resolve_level_cli_overrides(clean_env):
-    """An explicit --level wins over everything else."""
+def test_resolve_level_cli_overrides(tmp_path, clean_env):
+    """An explicit --level wins over a config-set level."""
     # Arrange
+    pytest.importorskip("yaml")
+    _write(tmp_path, "config.yaml", "caption_footnote:\n  level: error\n")
     # Act
-    level = resolve_level("warn", {"level": "error"}, {})
+    level = resolve_level(
+        "caption_footnote",
+        "warn",
+        tmp_path,
+        default="error",
+        env_var="SCITEX_WRITER_CAPTION_FOOTNOTE",
+    )
     # Assert
     assert level == "warn"
 

--- a/tests/scripts/python/test_check_float_order.py
+++ b/tests/scripts/python/test_check_float_order.py
@@ -3,8 +3,12 @@
 # Test file for: check_float_order.py
 
 import os
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
+
+import pytest
 
 # Add scripts/python to path for imports
 ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
@@ -16,6 +20,8 @@ from check_float_order import (  # noqa: E402
     find_labels,
     find_references,
 )
+
+_SCRIPT = ROOT_DIR / "scripts" / "python" / "check_float_order.py"
 
 # ====================================================================
 # Tests for extract_number_and_name
@@ -424,3 +430,95 @@ if __name__ == "__main__":
 # --------------------------------------------------------------------------------
 # End of Source Code from: /home/ywatanabe/proj/scitex-writer/scripts/python/check_float_order.py
 # --------------------------------------------------------------------------------
+
+
+# ============================================================================
+# Severity level (off / warn / error) + --fix×level — D3c adoption
+# ============================================================================
+
+
+@pytest.fixture
+def clean_env():
+    """Isolate SCITEX_WRITER_FLOAT_ORDER + HOME so no stray env/user config
+    leaks into severity resolution."""
+    saved = {k: os.environ.get(k) for k in ("SCITEX_WRITER_FLOAT_ORDER", "HOME")}
+    os.environ.pop("SCITEX_WRITER_FLOAT_ORDER", None)
+    with tempfile.TemporaryDirectory() as home:
+        os.environ["HOME"] = home
+        yield home
+    for key, val in saved.items():
+        if val is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = val
+
+
+def _project_with_out_of_order_floats(tmp_path):
+    """A manuscript referencing fig:02 before fig:01 (out of order)."""
+    contents = tmp_path / "01_manuscript" / "contents"
+    contents.mkdir(parents=True)
+    (contents / "results.tex").write_text(
+        "See \\ref{fig:02} then \\ref{fig:01}.\n", encoding="utf-8"
+    )
+    return tmp_path
+
+
+def _run(project, *extra):
+    env = dict(os.environ)
+    env.pop("SCITEX_WRITER_FLOAT_ORDER", None)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), str(project), "--doc-type", "manuscript", *extra],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_default_level_errors_on_out_of_order(tmp_path, clean_env):
+    """With the default level (error), out-of-order floats exit non-zero."""
+    # Arrange
+    _project_with_out_of_order_floats(tmp_path)
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_warn_level_demotes_out_of_order(tmp_path, clean_env):
+    """At --level warn, out-of-order floats are reported but exit zero."""
+    # Arrange
+    _project_with_out_of_order_floats(tmp_path)
+    # Act
+    proc = _run(tmp_path, "--level", "warn")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_off_level_disables_check(tmp_path, clean_env):
+    """At --level off (no fix), the check is disabled with a loud note."""
+    # Arrange
+    _project_with_out_of_order_floats(tmp_path)
+    # Act
+    proc = _run(tmp_path, "--level", "off")
+    # Assert
+    assert "disabled (level=off)" in proc.stdout
+
+
+def test_off_level_still_runs_dry_run_fix(tmp_path, clean_env):
+    """--dry-run runs regardless of level: off does NOT disable the fixer."""
+    # Arrange
+    _project_with_out_of_order_floats(tmp_path)
+    # Act
+    proc = _run(tmp_path, "--level", "off", "--dry-run")
+    # Assert
+    assert "DRY RUN" in proc.stdout
+
+
+def test_emits_summary_line(tmp_path, clean_env):
+    """check_float_order now emits the contract Summary line."""
+    # Arrange
+    _project_with_out_of_order_floats(tmp_path)
+    # Act
+    proc = _run(tmp_path, "--level", "warn")
+    # Assert
+    assert "Summary:" in proc.stdout

--- a/tests/scripts/python/test_check_paper_symlink.py
+++ b/tests/scripts/python/test_check_paper_symlink.py
@@ -73,7 +73,13 @@ def test_resolve_level_defaults_to_warn(tmp_path, clean_paper_env):
     # Arrange
     project_dir = str(tmp_path)
     # Act
-    level = resolve_level(None, project_dir)
+    level = resolve_level(
+        "paper_symlink",
+        None,
+        project_dir,
+        default="warn",
+        env_var="SCITEX_WRITER_PAPER_SYMLINK",
+    )
     # Assert
     assert level == "warn"
 

--- a/tests/scripts/python/test_check_ref_integrity.py
+++ b/tests/scripts/python/test_check_ref_integrity.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: check_ref_integrity.py
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from check_ref_integrity import resolve_level  # noqa: E402
+
+_SCRIPT = ROOT_DIR / "scripts" / "python" / "check_ref_integrity.py"
+
+_FIG_MEDIA = "01_manuscript/contents/figures/caption_and_media"
+_TAB_MEDIA = "01_manuscript/contents/tables/caption_and_media"
+
+
+# ============================================================================
+# helpers / fixtures
+# ============================================================================
+
+
+def _write(tmp_path, rel, content):
+    p = tmp_path / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _base_project(tmp_path, body):
+    """A minimal project: fig:01 + tab:01 auto-labels, one bib key, and a
+    results.tex whose body the caller supplies."""
+    _write(tmp_path, f"{_FIG_MEDIA}/01.tex", "Figure one.\n")
+    _write(tmp_path, f"{_TAB_MEDIA}/01.tex", "Table one.\n")
+    _write(tmp_path, "00_shared/bib_files/bibliography.bib", "@article{Known2020, title={x}}\n")
+    _write(tmp_path, "01_manuscript/contents/results.tex", body)
+    return tmp_path
+
+
+def _run(project, *extra):
+    env = dict(os.environ)
+    env.pop("SCITEX_WRITER_REF_INTEGRITY", None)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), str(project), *extra],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+@pytest.fixture
+def clean_env():
+    saved = {k: os.environ.get(k) for k in ("SCITEX_WRITER_REF_INTEGRITY", "HOME")}
+    os.environ.pop("SCITEX_WRITER_REF_INTEGRITY", None)
+    with tempfile.TemporaryDirectory() as home:
+        os.environ["HOME"] = home
+        yield home
+    for key, val in saved.items():
+        if val is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = val
+
+
+# ============================================================================
+# resolve_level
+# ============================================================================
+
+
+def test_resolve_level_defaults_to_error(tmp_path, clean_env):
+    """With no --level, no env, no config, the default level is error."""
+    # Arrange
+    # Act
+    level = resolve_level(None, str(tmp_path))
+    # Assert
+    assert level == "error"
+
+
+# ============================================================================
+# End-to-end (no LaTeX toolchain needed)
+# ============================================================================
+
+
+def test_undefined_figure_ref_errors(tmp_path, clean_env):
+    """A \\ref to a non-existent figure label blocks (exit 1)."""
+    # Arrange
+    _base_project(tmp_path, "See \\ref{fig:99}.\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_resolved_figure_and_table_refs_pass(tmp_path, clean_env):
+    """\\ref to existing fig:/tab: auto-labels resolves (exit 0)."""
+    # Arrange
+    _base_project(tmp_path, "See \\ref{fig:01} and \\ref{tab:01}.\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_undefined_citation_errors(tmp_path, clean_env):
+    """A \\cite key absent from the bib blocks (exit 1)."""
+    # Arrange
+    _base_project(tmp_path, "Cite \\cite{Missing2021}.\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_known_citation_passes(tmp_path, clean_env):
+    """A \\cite key present in the bib resolves (exit 0)."""
+    # Arrange
+    _base_project(tmp_path, "Cite \\cite{Known2020}.\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_supple_ref_without_aux_errors(tmp_path, clean_env):
+    """A supple- xref with no supplement .aux blocks (exit 1)."""
+    # Arrange
+    _base_project(tmp_path, "See \\ref{supple-fig:S01}.\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_supple_ref_without_aux_says_not_compiled(tmp_path, clean_env):
+    """The missing-supplement message is explicit, not a generic undefined ref."""
+    # Arrange
+    _base_project(tmp_path, "See \\ref{supple-fig:S01}.\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert "supplement not compiled" in proc.stdout
+
+
+def test_supple_ref_resolved_by_aux_passes(tmp_path, clean_env):
+    """A supple- xref resolves against the supplement .aux \\newlabel (exit 0)."""
+    # Arrange
+    _base_project(tmp_path, "See \\ref{supple-fig:S01}.\n")
+    _write(tmp_path, "02_supplementary/supplementary.aux", "\\newlabel{fig:S01}{{S1}{1}}\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_reports_all_classes_at_once(tmp_path, clean_env):
+    """One run surfaces every broken class together (3 errors), not one-at-a-time."""
+    # Arrange
+    _base_project(
+        tmp_path,
+        "See \\ref{fig:99}. Cite \\cite{Missing2021}. See \\ref{supple-fig:S01}.\n",
+    )
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert "3 errors" in proc.stdout
+
+
+def test_off_level_skips(tmp_path, clean_env):
+    """--level off disables the gate even with violations (exit 0)."""
+    # Arrange
+    _base_project(tmp_path, "See \\ref{fig:99}.\n")
+    # Act
+    proc = _run(tmp_path, "--level", "off")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_warn_level_does_not_block(tmp_path, clean_env):
+    """--level warn reports but exits 0 (does not block the compile)."""
+    # Arrange
+    _base_project(tmp_path, "See \\ref{fig:99}.\n")
+    # Act
+    proc = _run(tmp_path, "--level", "warn")
+    # Assert
+    assert proc.returncode == 0

--- a/tests/scripts/python/test_check_ref_integrity.py
+++ b/tests/scripts/python/test_check_ref_integrity.py
@@ -77,7 +77,13 @@ def test_resolve_level_defaults_to_error(tmp_path, clean_env):
     """With no --level, no env, no config, the default level is error."""
     # Arrange
     # Act
-    level = resolve_level(None, str(tmp_path))
+    level = resolve_level(
+        "ref_integrity",
+        None,
+        str(tmp_path),
+        default="error",
+        env_var="SCITEX_WRITER_REF_INTEGRITY",
+    )
     # Assert
     assert level == "error"
 

--- a/tests/scripts/python/test_check_references.py
+++ b/tests/scripts/python/test_check_references.py
@@ -3,12 +3,18 @@
 # Test file for: check_references.py
 
 import os
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
+
+import pytest
 
 # Add scripts/python to path for imports
 ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+_SCRIPT = ROOT_DIR / "scripts" / "python" / "check_references.py"
 
 from check_references import (  # noqa: E402
     collect_tex_files,
@@ -519,7 +525,78 @@ def test_auto_labels_vs_explicit(tmp_path):
     )
 
 
-if __name__ == "__main__":
-    import pytest
+# ============================================================================
+# Severity level (off / warn / error) — D3b adoption of the shared resolver
+# ============================================================================
 
+
+@pytest.fixture
+def clean_env():
+    """Isolate SCITEX_WRITER_REFERENCES + HOME so no stray env/user config
+    leaks into severity resolution."""
+    saved = {k: os.environ.get(k) for k in ("SCITEX_WRITER_REFERENCES", "HOME")}
+    os.environ.pop("SCITEX_WRITER_REFERENCES", None)
+    with tempfile.TemporaryDirectory() as home:
+        os.environ["HOME"] = home
+        yield home
+    for key, val in saved.items():
+        if val is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = val
+
+
+def _project_with_broken_ref(tmp_path):
+    """A minimal manuscript with one \\ref to a non-existent label."""
+    contents = tmp_path / "01_manuscript" / "contents"
+    contents.mkdir(parents=True)
+    (contents / "results.tex").write_text("See \\ref{fig:missing}.\n", encoding="utf-8")
+    bib = tmp_path / "00_shared" / "bib_files"
+    bib.mkdir(parents=True)
+    (bib / "bibliography.bib").write_text("", encoding="utf-8")
+    return tmp_path
+
+
+def _run(project, *extra):
+    env = dict(os.environ)
+    env.pop("SCITEX_WRITER_REFERENCES", None)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), str(project), "--doc-type", "manuscript", *extra],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_default_level_errors_on_broken_ref(tmp_path, clean_env):
+    """With the default level (error), a broken \\ref exits non-zero."""
+    # Arrange
+    _project_with_broken_ref(tmp_path)
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_warn_level_demotes_broken_ref(tmp_path, clean_env):
+    """At --level warn, a broken \\ref is reported but exits zero."""
+    # Arrange
+    _project_with_broken_ref(tmp_path)
+    # Act
+    proc = _run(tmp_path, "--level", "warn")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_off_level_disables_check(tmp_path, clean_env):
+    """At --level off, the check is disabled and exits zero with a loud note."""
+    # Arrange
+    _project_with_broken_ref(tmp_path)
+    # Act
+    proc = _run(tmp_path, "--level", "off")
+    # Assert
+    assert "disabled (level=off)" in proc.stdout
+
+
+if __name__ == "__main__":
     pytest.main([os.path.abspath(__file__), "-v"])

--- a/tests/scripts/python/test_csv_to_latex.py
+++ b/tests/scripts/python/test_csv_to_latex.py
@@ -495,6 +495,19 @@ class TestCsvToLatex:
         # Assert
         assert "$p<0.001$" in content
 
+    def test_csv_to_latex_zebra_stripe_uses_dark_aware_color(self, tmp_path):
+        """Zebra stripe uses the dark-aware `lightgray` theme color, not a
+        literal gray!10 (which stays light and hides text in dark mode)."""
+        # Arrange
+        csv_file = tmp_path / "test.csv"
+        csv_file.write_text("Name,Age\nAlice,30\nBob,25\nCarol,40")
+        output_file = tmp_path / "output.tex"
+        csv_to_latex(csv_file, output_file)
+        # Act
+        content = output_file.read_text()
+        # Assert
+        assert ("\\rowcolor{lightgray}" in content) and ("gray!10" not in content)
+
 
 if __name__ == "__main__":
     pytest.main([os.path.abspath(__file__), "-v"])


### PR DESCRIPTION
## Release 2.23.0

Promotes develop → main for the 2.23.0 tag. Contents (since 2.22.0):
- Unified 8-check severity framework on the shared `resolve_level` resolver (§9 contract ratified).
- New checks: reference-integrity pre-compile gate (#174), `\footnote`-in-`\caption{}` lint (#173).
- Shared-metadata SSoT: title/authors/journal/keywords from `00_shared` across manuscript/supplementary/revision (#181).
- Compile fixes: lineno↔siunitx order (#170), bibtex stale-`.bbl` (#171), supplement `.aux` at doc-root (#172), dark-mode zebra-stripe legibility (#180).

All commits already CI-green on develop. After merge: tag `v2.23.0` → release workflow publishes to PyPI.