### PR TITLE
fix(figures): png→jpg Pillow fallback + fail-loud (no silent .txt placeholder)

### DIFF
--- a/scripts/python/png_to_jpg.py
+++ b/scripts/python/png_to_jpg.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/png_to_jpg.py
+# Purpose: Pillow-based PNG->JPG fallback for the figure pipeline, used when
+#          ImageMagick (magick/convert) is absent. Flattens alpha onto a white
+#          background and saves JPEG quality 95 (matching the ImageMagick
+#          `-background white -flatten -quality 95` behavior). Also generates a
+#          plain placeholder JPG (so a missing figure never leaves a broken
+#          `.txt` where the compile expects a `.jpg`).
+#
+# Usage:
+#   python3 png_to_jpg.py OUT.jpg --src IN.png
+#   python3 png_to_jpg.py OUT.jpg --placeholder "Missing figure: NN"
+#
+# Exit 0 on success; non-zero (with a loud stderr hint) if Pillow is missing or
+# conversion fails — the caller treats that as fail-loud, never a silent no-op.
+
+import argparse
+import sys
+
+
+def _flatten_to_white(img):
+    """Composite an image (any mode) onto an opaque white background, RGB."""
+    from PIL import Image
+
+    rgba = img.convert("RGBA")
+    bg = Image.new("RGBA", rgba.size, (255, 255, 255, 255))
+    return Image.alpha_composite(bg, rgba).convert("RGB")
+
+
+def convert_png_to_jpg(src, dst, quality=95):
+    """Convert a PNG (alpha flattened onto white) to JPEG at ``dst``."""
+    from PIL import Image
+
+    with Image.open(src) as img:
+        _flatten_to_white(img).save(dst, "JPEG", quality=quality)
+
+
+def write_placeholder_jpg(text, dst, size=(800, 600)):
+    """Write a light-gray placeholder JPEG bearing ``text``."""
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGB", size, (211, 211, 211))
+    draw = ImageDraw.Draw(img)
+    draw.text((20, size[1] // 2), text, fill=(64, 64, 64))
+    img.save(dst, "JPEG", quality=95)
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        description="PNG->JPG (Pillow fallback) + placeholder JPG generator."
+    )
+    parser.add_argument("dst", help="output .jpg path")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--src", help="input .png to convert")
+    group.add_argument("--placeholder", help="text for a placeholder JPG")
+    args = parser.parse_args(argv[1:])
+
+    try:
+        if args.src is not None:
+            convert_png_to_jpg(args.src, args.dst)
+        else:
+            write_placeholder_jpg(args.placeholder, args.dst)
+    except ImportError:
+        sys.stderr.write(
+            "ERROR: Pillow not installed and ImageMagick unavailable — cannot "
+            "render figures. Fix: install ImageMagick (magick/convert) or "
+            "`pip install pillow`.\n"
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001 - surface any conversion failure loudly
+        sys.stderr.write(f"ERROR: PNG->JPG conversion failed for {args.dst}: {exc}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))
+
+# EOF

--- a/scripts/shell/modules/process_figures_modules/02_format_conversion.src
+++ b/scripts/shell/modules/process_figures_modules/02_format_conversion.src
@@ -86,11 +86,15 @@ png2jpg() {
                 temp_copy_needed=true
             fi
 
-            # Convert to JPG (flatten alpha onto white background)
+            # Convert to JPG (flatten alpha onto white). Prefer ImageMagick;
+            # fall back to Pillow; FAIL LOUD if neither exists — never leave the
+            # .jpg missing (which silently breaks the figure's \includegraphics).
             if command -v magick >/dev/null 2>&1; then
                 magick "$work_png_file" -background white -flatten -quality 95 "$jpg_file"
-            else
+            elif command -v convert >/dev/null 2>&1; then
                 convert "$work_png_file" -background white -flatten -quality 95 "$jpg_file"
+            elif ! python3 ./scripts/python/png_to_jpg.py "$jpg_file" --src "$work_png_file"; then
+                echo_error "Failed to convert ${base_name}.png to JPG: no ImageMagick (magick/convert) and the Pillow fallback failed. Install ImageMagick or run 'pip install pillow'."
             fi
 
             # Clean up temp file if created

--- a/scripts/shell/modules/process_figures_modules/04_compilation.src
+++ b/scripts/shell/modules/process_figures_modules/04_compilation.src
@@ -162,16 +162,22 @@ create_placeholder_jpg() {
     local output_file="$1"
     local figure_name="$2"
 
-    # Use ImageMagick to create a placeholder
-    if command -v convert >/dev/null 2>&1; then
+    # Create a placeholder JPG. Prefer ImageMagick; fall back to Pillow; FAIL
+    # LOUD if neither exists. NEVER emit a `.txt` — \includegraphics expects a
+    # `.jpg`, and a stray `.txt` silently breaks the compile.
+    if command -v magick >/dev/null 2>&1; then
+        magick -size 800x600 xc:lightgray \
+            -gravity center -pointsize 48 \
+            -annotate +0+0 "Missing Figure\n$figure_name" \
+            "$output_file"
+    elif command -v convert >/dev/null 2>&1; then
         convert -size 800x600 xc:lightgray \
             -gravity center \
             -pointsize 48 \
             -annotate +0+0 "Missing Figure\n$figure_name" \
             "$output_file"
-    else
-        # Create a minimal placeholder
-        echo "Missing figure: $figure_name" >"${output_file%.jpg}.txt"
+    elif ! python3 ./scripts/python/png_to_jpg.py "$output_file" --placeholder "Missing figure: $figure_name"; then
+        echo_error "Cannot create placeholder for missing figure '$figure_name': no ImageMagick (magick/convert) and the Pillow fallback failed. Install ImageMagick or run 'pip install pillow'."
     fi
 }
 

--- a/tests/scripts/python/test_png_to_jpg.py
+++ b/tests/scripts/python/test_png_to_jpg.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: png_to_jpg.py (Pillow PNG->JPG fallback)
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+_SCRIPT = ROOT_DIR / "scripts" / "python" / "png_to_jpg.py"
+
+
+def _make_png(path, color=(255, 0, 0, 128), size=(40, 30)):
+    from PIL import Image
+
+    Image.new("RGBA", size, color).save(path)
+
+
+def _run(*args):
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_convert_produces_jpeg(tmp_path):
+    """--src converts a PNG into a real JPEG file."""
+    # Arrange
+    pytest.importorskip("PIL")
+    from PIL import Image
+
+    src = tmp_path / "in.png"
+    _make_png(src)
+    dst = tmp_path / "out.jpg"
+    # Act
+    _run(str(dst), "--src", str(src))
+    # Assert
+    assert Image.open(dst).format == "JPEG"
+
+
+def test_convert_flattens_alpha_onto_white(tmp_path):
+    """A fully transparent PNG flattens onto a white background."""
+    # Arrange
+    pytest.importorskip("PIL")
+    from PIL import Image
+
+    src = tmp_path / "clear.png"
+    _make_png(src, color=(0, 0, 0, 0))
+    dst = tmp_path / "clear.jpg"
+    # Act
+    _run(str(dst), "--src", str(src))
+    # Assert
+    assert Image.open(dst).convert("RGB").getpixel((0, 0)) == (255, 255, 255)
+
+
+def test_placeholder_produces_jpeg(tmp_path):
+    """--placeholder writes a JPEG placeholder (never a .txt)."""
+    # Arrange
+    pytest.importorskip("PIL")
+    from PIL import Image
+
+    dst = tmp_path / "ph.jpg"
+    # Act
+    _run(str(dst), "--placeholder", "Missing figure: 02")
+    # Assert
+    assert Image.open(dst).format == "JPEG"
+
+
+def test_requires_src_or_placeholder(tmp_path):
+    """With neither --src nor --placeholder, the CLI errors (no silent no-op)."""
+    # Arrange
+    dst = tmp_path / "out.jpg"
+    # Act
+    proc = _run(str(dst))
+    # Assert
+    assert proc.returncode != 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])
+
+# EOF


### PR DESCRIPTION
## Summary
When ImageMagick (`magick`/`convert`) is absent, the PNG→JPG figure conversion silently produced no `.jpg`, and `create_placeholder_jpg` wrote a `.txt` — so `\includegraphics{...jpg}` broke the compile (hit on neurovista's supplementary build; host had no ImageMagick).

- **New `scripts/python/png_to_jpg.py` (Pillow):** flattens alpha onto white, JPEG quality 95 (matching the ImageMagick path); also generates a placeholder JPG. **Fails loud** (non-zero + hint) if Pillow is missing — never a silent no-op.
- **`png2jpg()` and `create_placeholder_jpg()`** now cascade `magick` → `convert` → **Pillow** → **FAIL LOUD** (`echo_error` with a hint). `create_placeholder_jpg` no longer emits a `.txt` (which silently broke the include).

## Test plan
- [x] Helper tests: convert→JPEG, alpha-flatten-to-white, placeholder→JPEG, arg-required. Conversion tests `importorskip("PIL")` (run in CI's `.[dev]`, skip where Pillow absent).
- [x] Fail-loud branch verified in-container (Pillow absent → loud error + exit non-zero). `scitex-dev linter` clean.
- [ ] CI green.
- [ ] **Host-verify** on a no-ImageMagick host (neurovista): PNG figures convert via Pillow; a genuinely missing figure yields a loud error, not a stray `.txt`.

Pillow is already a dependency (thumbnails/_ports).