### PR TITLE
fix(supplementary): S-prefixed figure/table numbering by default (Figure S1, Table S1)

### DIFF
--- a/02_supplementary/base.tex
+++ b/02_supplementary/base.tex
@@ -10,6 +10,16 @@
 \input{./02_supplementary/contents/latex_styles/formatting}
 
 %% ----------------------------------------
+%% SUPPLEMENTARY FIGURE/TABLE NUMBERING
+%% ----------------------------------------
+%% Standard supplementary numbering: Figure S1, S2, ... / Table S1, S2, ...
+%% This lives in the SUPPLEMENTARY base only (NOT 00_shared/latex_styles, which
+%% is shared with the manuscript and must keep plain 1, 2, ...). The supplement
+%% compiles as its own document, so counters already start at 0 -> first is S1.
+\renewcommand{\thefigure}{S\arabic{figure}}
+\renewcommand{\thetable}{S\arabic{table}}
+
+%% ----------------------------------------
 %% JOURNAL NAME
 %% ----------------------------------------
 \input{./00_shared/journal_name}


### PR DESCRIPTION
## Summary
The `02_supplementary` template never set the S-prefix counter format, so supplements rendered plain "Figure 1 / Table 1" instead of the standard supplementary "S1, S2, ..." (reported by neurovista). Added to the **supplementary `base.tex` preamble**:

```latex
\renewcommand{\thefigure}{S\arabic{figure}}
\renewcommand{\thetable}{S\arabic{table}}
```

so it's the default supplementary behavior — no per-project hand-setting.

## Why it's placed here (not in shared styles)
It lives in `02_supplementary/base.tex` **only**, not `00_shared/latex_styles` (which is shared with the manuscript and must keep plain `1, 2, ...`). The supplement compiles as its own document, so counters start at 0 → first float is `S1`; no `\setcounter` reset needed.

## Test plan
- [ ] **Host-verify** (no LaTeX in the agent container): the compiled supplementary shows "Figure S1 / Table S1 ..." and the manuscript still shows plain "1, 2 ...". `base.tex` is engine-vendored (`LEGACY_ENGINE_PATHS`), so consumers pick it up on re-vendor.