### PR TITLE
fix(preamble): microtype + emergencystretch, justified full-width captions; CSV-header doc

### DIFF
--- a/00_shared/latex_styles/dark_mode.tex
+++ b/00_shared/latex_styles/dark_mode.tex
@@ -38,11 +38,13 @@
 \titleformat{\subsubsection}
   {\normalfont\normalsize\bfseries\color{MonacoFg}}{\thesubsubsection}{1em}{}
 
-% Caption labels: same as body text, left-aligned
+% Caption labels: same as body text. Full-width justified (matches the
+% light-mode default in packages.tex) — was raggedright, which left dark-mode
+% captions ragged instead of spanning the figure/column width.
 \captionsetup{
   labelfont={bf,color=MonacoFg},
   textfont={color=MonacoFg},
-  justification=raggedright,
+  justification=justified,
   singlelinecheck=false
 }
 

--- a/00_shared/latex_styles/packages.tex
+++ b/00_shared/latex_styles/packages.tex
@@ -45,11 +45,15 @@
 \usepackage{titlesec}  % For custom section formatting
 
 %% Captions and references
-\usepackage[margin=10pt,font=small,labelfont=bf,labelsep=endash]{caption}
+%% justification=justified + singlelinecheck=false: captions span the full
+%% figure/column width (both edges flush), incl. single-line captions.
+\usepackage[margin=10pt,font=small,labelfont=bf,labelsep=endash,justification=justified,singlelinecheck=false]{caption}
 \usepackage[numbers]{natbib}  % numbers: numeric citations [1], [2]
 \setcitestyle{sort=false}     % Preserve citation order as written
 \usepackage{hyperref}
 \usepackage{xurl}  % break long URLs / DOIs at any character so they wrap instead of overflowing the margin
+\usepackage{microtype}  % subtle protrusion/expansion: fewer overfull \hbox
+\setlength{\emergencystretch}{2em}  % last-resort stretch for long unbreakable words (e.g. "Laplace-approximation")
 
 %% Document features (lineno loaded earlier, before siunitx)
 \usepackage{accsupp, bashful, lipsum}

--- a/src/scitex_writer/_skills/scitex-writer/12_figures-and-tables.md
+++ b/src/scitex_writer/_skills/scitex-writer/12_figures-and-tables.md
@@ -58,6 +58,22 @@ mv -f 01_manuscript/contents/tables/caption_and_media/*.csv \
 ```
 
 Reference tables as Supplementary Tables (S1, S2, ...) in the manuscript text.
+(Supplementary figures/tables are auto-numbered with the `S` prefix by the
+`02_supplementary` template.)
+
+## CSV table-header conventions
+
+Author CSV column headers as the FINAL rendered label — the csv→LaTeX converter
+passes them through faithfully (it no longer title-cases or strips them):
+
+- **Math** renders when written in `$...$`: `$n_{\mathrm{SZ}}$`, `$F_1$`,
+  `Sens$_{15}$`, `$R^2$` (a header containing `$` or `\` is emitted verbatim).
+- **Human labels** read as written: `SOP (min)`, `# of Patients`, `ROC-AUC` —
+  NOT raw underscore-derived `SOP min` / `n patients` / `n SZ`. Use real words
+  and spaces (or math) in the header, not `snake_case`.
+- Numeric **columns auto-align** to a consistent decimal precision (a column
+  with `0.333` and `0.35` renders `0.333` / `0.350`); all-integer count columns
+  stay bare.
 
 ## Archiving Figures and Tables
 


### PR DESCRIPTION
## Summary
Operator-requested durable template defaults (neurovista had local stopgaps; this bakes them in).

- **microtype + `\setlength{\emergencystretch}{2em}`** in `00_shared/latex_styles/packages.tex` — cut overfull `\hbox` from long unbreakable words (e.g. "Laplace-approximation").
- **Justified full-width captions**: added `justification=justified,singlelinecheck=false` to the `caption` package options, AND changed `dark_mode.tex`'s `\captionsetup` from `raggedright` → `justified`. *Dark-mode compiles were the ragged ones* (that override won), and neurovista compiles in dark mode — so the dark_mode change is the operative fix for them.
- **Docs**: `12_figures-and-tables.md` gains a "CSV table-header conventions" note (author headers as final labels — `$math$` via the verbatim-`$` path, human labels not `snake_case`; numeric columns auto-align) + an S-prefix mention.

## Note on the xurl item (no change here)
The template is **already correct** — `01_manuscript/contents/latex_styles` is a **symlink** to `00_shared/latex_styles`, which loads `xurl`, so the manuscript wraps URLs. A consumer seeing margin overflow has a **drifted workspace** (symlink replaced by a stale real copy lacking xurl) — re-vendor/relink fixes it. No template change needed.

## Test plan
- [ ] CI green.
- [ ] **Host-verify** (no LaTeX in the agent container): captions full-width justified in both light + dark mode; fewer overfull boxes. neurovista's working stopgaps already prove the microtype/caption behavior on the real manuscript.