### PR TITLE
fix(compile): fail loud (non-zero) when no PDF produced + microtype expansion=false [URGENT]

### DIFF
--- a/00_shared/latex_styles/packages.tex
+++ b/00_shared/latex_styles/packages.tex
@@ -52,7 +52,11 @@
 \setcitestyle{sort=false}     % Preserve citation order as written
 \usepackage{hyperref}
 \usepackage{xurl}  % break long URLs / DOIs at any character so they wrap instead of overflowing the margin
-\usepackage{microtype}  % subtle protrusion/expansion: fewer overfull \hbox
+%% expansion=false is REQUIRED: font expansion is FATAL on non-scalable fonts
+%% (e.g. elsarticle) -- "pdfTeX error (font expansion): auto expansion is only
+%% possible with scalable fonts" -> no output PDF. Protrusion alone is safe and
+%% gives most of the overfull-\hbox benefit.
+\usepackage[protrusion=true,expansion=false]{microtype}
 \setlength{\emergencystretch}{2em}  % last-resort stretch for long unbreakable words (e.g. "Laplace-approximation")
 
 %% Document features (lineno loaded earlier, before siunitx)

--- a/scripts/shell/compile_manuscript.sh
+++ b/scripts/shell/compile_manuscript.sh
@@ -376,9 +376,15 @@ main() {
     echo_info "$(get_engine_info "$SELECTED_ENGINE")"
     log_stage_end "Engine Selection"
 
-    # TeX to PDF
+    # TeX to PDF. FAIL LOUD: the module returns non-zero when manuscript.pdf was
+    # not (re)created (engine failure, or a pdfTeX Fatal error that produced no
+    # PDF). Propagate that — never exit 0 with only a printed ERRO, or callers
+    # (and humans) treat a stale/absent PDF as a fresh success.
     log_stage_start "PDF Generation"
-    "$PROJECT_ROOT/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh"
+    if ! "$PROJECT_ROOT/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh"; then
+        log_error "PDF generation failed — manuscript.pdf was not (re)created. Aborting."
+        exit 1
+    fi
     log_stage_end "PDF Generation"
 
     # Diff (skip if --no_diff specified)

--- a/scripts/shell/compile_revision.sh
+++ b/scripts/shell/compile_revision.sh
@@ -357,9 +357,12 @@ parse_arguments() {
     ./scripts/shell/modules/compilation_structure_tex_to_compiled_tex.sh
     log_stage_end "TeX Compilation (Structure)"
 
-    # Compile to PDF
+    # Compile to PDF. FAIL LOUD if the revision PDF was not (re)created.
     log_stage_start "PDF Generation"
-    ./scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
+    if ! ./scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh; then
+        echo_error "PDF generation failed — revision.pdf was not (re)created. Aborting."
+        exit 1
+    fi
     log_stage_end "PDF Generation"
 
     # Skip diff generation for revision (revision document already shows changes inline)

--- a/scripts/shell/compile_supplementary.sh
+++ b/scripts/shell/compile_supplementary.sh
@@ -314,9 +314,12 @@ main() {
     ./scripts/shell/modules/compilation_structure_tex_to_compiled_tex.sh
     log_stage_end "TeX Compilation (Structure)"
 
-    # TeX to PDF
+    # TeX to PDF. FAIL LOUD if the supplementary PDF was not (re)created.
     log_stage_start "PDF Generation"
-    ./scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
+    if ! ./scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh; then
+        echo_error "PDF generation failed — supplementary.pdf was not (re)created. Aborting."
+        exit 1
+    fi
     log_stage_end "PDF Generation"
 
     # Diff (skip if --no_diff specified)


### PR DESCRIPTION
## Summary
**URGENT** (operator deadline ~2026-06-30). Fixes a silent-success incident: a pdfTeX **Fatal error** produced no PDF, yet `compile_manuscript.sh` exited **0** (only printed `ERRO: ... was not created despite successful compilation`), so a wrapper treated it as success and sent a **stale** PDF for ~2 h.

1. **Exit non-zero when no PDF is produced.** The PDF-generation module already `return 1`s when the PDF isn't (re)created — but `compile_{manuscript,supplementary,revision}.sh` invoked it **without checking the result** and proceeded to Diff/Archive/Cleanup, exiting 0. Now each wraps the PDF-Generation stage in `if ! <module>; then <error>; exit 1; fi`. (Operator's #1 requirement: tools must not rely on a human noticing a printed warning.)
2. **`microtype` `expansion=false`** — *regression from #187*. Font expansion is **fatal** on non-scalable fonts (elsarticle): "auto expansion is only possible with scalable fonts" → no output PDF. Changed to `[protrusion=true,expansion=false]` (protrusion keeps most of the overfull-`\hbox` benefit, safe on all classes). This was the actual fatal behind the incident.

## Test plan
- [x] `bash -n` clean on all three compile scripts; uses each script's defined error fn (`log_error` / `echo_error`).
- [ ] CI green.
- [ ] **Host-verify** (no LaTeX in the agent container): (a) a deliberately-broken compile now exits non-zero with no PDF; (b) elsarticle compiles a PDF again with microtype. neurovista's `expansion=false` workaround already proves (2).

## Follow-up (carded)
Harden against a **stale** (present-but-not-re-created) PDF passing as success — pre-remove the target before compiling so presence ⇒ freshly generated.