### PR TITLE
chore(release): 2.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.23.1] - 2026-06-29
+
+### Fixed
+- **Compile now FAILS LOUD when no PDF is produced.** `compile_{manuscript,
+  supplementary,revision}.sh` invoked the PDF-generation stage without checking
+  its exit code, so a pdfTeX Fatal error that produced no PDF still exited 0
+  (only printing an `ERRO:` line). Each now propagates the non-zero result and
+  aborts, so a missing/failed PDF can never be mistaken for success (#188).
+- **`microtype` no longer breaks elsarticle.** Font expansion is fatal on
+  non-scalable fonts ("auto expansion is only possible with scalable fonts" →
+  no output PDF); loaded now as `[protrusion=true,expansion=false]` (#188,
+  regression from #187).
+- **png→jpg figure conversion: Pillow fallback + fail-loud.** When ImageMagick
+  is absent the converter now falls back to Pillow, and fails loud if neither
+  backend exists, instead of emitting a `.txt` placeholder that broke
+  `\includegraphics` (#184).
+- **Per-column table decimal alignment.** csv→LaTeX aligns each numeric column
+  to a consistent precision (`0.35` → `0.350` alongside `0.333`; integer-valued
+  cells pad in a fractional column; all-integer columns stay bare). Default
+  caption no longer title-cases the name (acronyms survive) (#185).
+- **Supplementary `S`-prefixed numbering by default** (Figure S1, Table S1) via
+  the `02_supplementary` template (#186).
+
+### Added / Changed
+- **Preamble defaults**: `microtype` (protrusion) + `\emergencystretch` and
+  full-width **justified captions** (light + dark mode) in the shared styles;
+  CSV table-header convention documented (#187).
+
 ## [2.23.0] - 2026-06-29
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.23.0"
+version = "2.23.1"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary
Patch release 2.23.1 — bundles the 5 fixes merged to develop since 2.23.0, for a clean pinned version (neurovista re-vendors to drop local stopgaps).

- **#188** compile fails loud (non-zero) when no PDF is produced; `microtype expansion=false` (elsarticle fatal-fix, regression from #187).
- **#187** preamble defaults: microtype protrusion + `\emergencystretch`, justified full-width captions (light+dark); CSV-header doc.
- **#186** supplementary `S`-prefixed figure/table numbering by default.
- **#185** per-column table decimal alignment + default-caption acronym casing.
- **#184** png→jpg Pillow fallback + fail-loud (no silent `.txt`).

Version bump + CHANGELOG only; all code already reviewed/merged + CI-green on develop.

## Test plan
- [ ] CI green on the release branch → merge → PR develop→main → tag v2.23.1 → PyPI publish.