### PR TITLE
Release 2.23.1

### DIFF
--- a/00_shared/latex_styles/dark_mode.tex
+++ b/00_shared/latex_styles/dark_mode.tex
@@ -38,11 +38,13 @@
 \titleformat{\subsubsection}
   {\normalfont\normalsize\bfseries\color{MonacoFg}}{\thesubsubsection}{1em}{}
 
-% Caption labels: same as body text, left-aligned
+% Caption labels: same as body text. Full-width justified (matches the
+% light-mode default in packages.tex) — was raggedright, which left dark-mode
+% captions ragged instead of spanning the figure/column width.
 \captionsetup{
   labelfont={bf,color=MonacoFg},
   textfont={color=MonacoFg},
-  justification=raggedright,
+  justification=justified,
   singlelinecheck=false
 }
 

--- a/00_shared/latex_styles/packages.tex
+++ b/00_shared/latex_styles/packages.tex
@@ -52,7 +52,11 @@
 \setcitestyle{sort=false}     % Preserve citation order as written
 \usepackage{hyperref}
 \usepackage{xurl}  % break long URLs / DOIs at any character so they wrap instead of overflowing the margin
-\usepackage{microtype}  % subtle protrusion/expansion: fewer overfull \hbox
+%% expansion=false is REQUIRED: font expansion is FATAL on non-scalable fonts
+%% (e.g. elsarticle) -- "pdfTeX error (font expansion): auto expansion is only
+%% possible with scalable fonts" -> no output PDF. Protrusion alone is safe and
+%% gives most of the overfull-\hbox benefit.
+\usepackage[protrusion=true,expansion=false]{microtype}
 \setlength{\emergencystretch}{2em}  % last-resort stretch for long unbreakable words (e.g. "Laplace-approximation")
 
 %% Document features (lineno loaded earlier, before siunitx)

--- a/00_shared/latex_styles/packages.tex
+++ b/00_shared/latex_styles/packages.tex
@@ -45,11 +45,15 @@
 \usepackage{titlesec}  % For custom section formatting
 
 %% Captions and references
-\usepackage[margin=10pt,font=small,labelfont=bf,labelsep=endash]{caption}
+%% justification=justified + singlelinecheck=false: captions span the full
+%% figure/column width (both edges flush), incl. single-line captions.
+\usepackage[margin=10pt,font=small,labelfont=bf,labelsep=endash,justification=justified,singlelinecheck=false]{caption}
 \usepackage[numbers]{natbib}  % numbers: numeric citations [1], [2]
 \setcitestyle{sort=false}     % Preserve citation order as written
 \usepackage{hyperref}
 \usepackage{xurl}  % break long URLs / DOIs at any character so they wrap instead of overflowing the margin
+\usepackage{microtype}  % subtle protrusion/expansion: fewer overfull \hbox
+\setlength{\emergencystretch}{2em}  % last-resort stretch for long unbreakable words (e.g. "Laplace-approximation")
 
 %% Document features (lineno loaded earlier, before siunitx)
 \usepackage{accsupp, bashful, lipsum}

--- a/02_supplementary/base.tex
+++ b/02_supplementary/base.tex
@@ -10,6 +10,16 @@
 \input{./02_supplementary/contents/latex_styles/formatting}
 
 %% ----------------------------------------
+%% SUPPLEMENTARY FIGURE/TABLE NUMBERING
+%% ----------------------------------------
+%% Standard supplementary numbering: Figure S1, S2, ... / Table S1, S2, ...
+%% This lives in the SUPPLEMENTARY base only (NOT 00_shared/latex_styles, which
+%% is shared with the manuscript and must keep plain 1, 2, ...). The supplement
+%% compiles as its own document, so counters already start at 0 -> first is S1.
+\renewcommand{\thefigure}{S\arabic{figure}}
+\renewcommand{\thetable}{S\arabic{table}}
+
+%% ----------------------------------------
 %% JOURNAL NAME
 %% ----------------------------------------
 \input{./00_shared/journal_name}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.23.1] - 2026-06-29
+
+### Fixed
+- **Compile now FAILS LOUD when no PDF is produced.** `compile_{manuscript,
+  supplementary,revision}.sh` invoked the PDF-generation stage without checking
+  its exit code, so a pdfTeX Fatal error that produced no PDF still exited 0
+  (only printing an `ERRO:` line). Each now propagates the non-zero result and
+  aborts, so a missing/failed PDF can never be mistaken for success (#188).
+- **`microtype` no longer breaks elsarticle.** Font expansion is fatal on
+  non-scalable fonts ("auto expansion is only possible with scalable fonts" →
+  no output PDF); loaded now as `[protrusion=true,expansion=false]` (#188,
+  regression from #187).
+- **png→jpg figure conversion: Pillow fallback + fail-loud.** When ImageMagick
+  is absent the converter now falls back to Pillow, and fails loud if neither
+  backend exists, instead of emitting a `.txt` placeholder that broke
+  `\includegraphics` (#184).
+- **Per-column table decimal alignment.** csv→LaTeX aligns each numeric column
+  to a consistent precision (`0.35` → `0.350` alongside `0.333`; integer-valued
+  cells pad in a fractional column; all-integer columns stay bare). Default
+  caption no longer title-cases the name (acronyms survive) (#185).
+- **Supplementary `S`-prefixed numbering by default** (Figure S1, Table S1) via
+  the `02_supplementary` template (#186).
+
+### Added / Changed
+- **Preamble defaults**: `microtype` (protrusion) + `\emergencystretch` and
+  full-width **justified captions** (light + dark mode) in the shared styles;
+  CSV table-header convention documented (#187).
+
 ## [2.23.0] - 2026-06-29
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.23.0"
+version = "2.23.1"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/scripts/python/csv_to_latex.py
+++ b/scripts/python/csv_to_latex.py
@@ -87,6 +87,51 @@ def format_number(val):
         return val
 
 
+def _value_decimals(val):
+    """Decimal places a numeric value needs to display, or None if not numeric.
+
+    Integer-valued numbers (incl. ``5.0``) need 0. The ``.6f`` cap strips
+    float-repr noise (e.g. ``0.1+0.2``) before counting.
+    """
+    try:
+        num = float(val)
+    except (ValueError, TypeError):
+        return None
+    if num != num:  # NaN
+        return None
+    if num.is_integer():
+        return 0
+    trimmed = f"{num:.6f}".rstrip("0")
+    return len(trimmed.split(".")[1]) if "." in trimmed else 0
+
+
+def column_precision(values):
+    """Target decimal precision for a column so its numbers align.
+
+    The max decimal places among the column's numeric cells, but only when the
+    column actually has a fractional value. Returns ``None`` for an all-integer
+    or non-numeric column (leave those untouched: counts like ``288`` stay
+    ``288``, never ``288.000``).
+    """
+    decimals = [d for d in (_value_decimals(v) for v in values) if d is not None]
+    if not decimals:
+        return None
+    target = max(decimals)
+    return target if target > 0 else None
+
+
+def _format_aligned(val, precision):
+    """Format ``val`` to a fixed ``precision`` (padding trailing zeros) so a
+    column's numbers line up; fall back to ``format_number`` when ``precision``
+    is None or ``val`` is not a plain number (``--`` / ``...`` / text)."""
+    if precision is None:
+        return format_number(val)
+    try:
+        return f"{float(val):.{precision}f}"
+    except (ValueError, TypeError):
+        return format_number(val)
+
+
 def csv_to_latex(csv_file, output_file, caption=None, label=None, max_rows=30):
     """Convert CSV to LaTeX table with proper formatting.
 
@@ -189,7 +234,9 @@ def csv_to_latex(csv_file, output_file, caption=None, label=None, max_rows=30):
     lines.append(" & ".join(headers) + " \\\\")
     lines.append("\\midrule")
 
-    # Data rows
+    # Data rows. Pre-compute each column's decimal precision so its numbers
+    # align (e.g. 0.333 / 0.35 -> 0.333 / 0.350); all-integer columns stay bare.
+    col_prec = {col: column_precision(df[col]) for col in df.columns}
     for idx, row in df.iterrows():
         values = []
         is_separator = False
@@ -208,7 +255,7 @@ def csv_to_latex(csv_file, output_file, caption=None, label=None, max_rows=30):
                     if _is_verbatim(val):
                         val = str(val)
                     else:
-                        val = format_number(val)
+                        val = _format_aligned(val, col_prec[col])
                         val = escape_latex(val)
             else:
                 val = "--"  # Display for missing values
@@ -250,13 +297,15 @@ def csv_to_latex(csv_file, output_file, caption=None, label=None, max_rows=30):
             caption += "}"
         lines.append(caption)
     else:
-        # Generate default caption
+        # Generate default caption. Do NOT .title() the name — preserve the
+        # CSV-derived casing so acronyms survive (ROC-AUC, PR-AUC), matching the
+        # header handling.
         if table_number:
             lines.append(
-                f"\\caption{{\\textbf{{Table {table_number}: {table_name.title()}}}"
+                f"\\caption{{\\textbf{{Table {table_number}: {table_name}}}"
             )
         else:
-            lines.append(f"\\caption{{\\textbf{{{table_name.title()}}}")
+            lines.append(f"\\caption{{\\textbf{{{table_name}}}")
         lines.append("\\\\")
         if truncated:
             lines.append(

--- a/scripts/python/csv_to_latex.py
+++ b/scripts/python/csv_to_latex.py
@@ -88,10 +88,11 @@ def format_number(val):
 
 
 def _value_decimals(val):
-    """Decimal places a numeric value needs to display, or None if not numeric.
-
-    Integer-valued numbers (incl. ``5.0``) need 0. The ``.6f`` cap strips
-    float-repr noise (e.g. ``0.1+0.2``) before counting.
+    """Decimal places ``val`` shows under :func:`format_number`, or None for a
+    non-number / NaN (or a scientific-notation tiny value, which is left
+    unaligned). Using format_number's own output keeps the column precision in
+    lockstep with the per-cell display (e.g. the 3-dp cap), so alignment never
+    *uncaps* precision — it only pads shorter values to the column max.
     """
     try:
         num = float(val)
@@ -99,10 +100,10 @@ def _value_decimals(val):
         return None
     if num != num:  # NaN
         return None
-    if num.is_integer():
-        return 0
-    trimmed = f"{num:.6f}".rstrip("0")
-    return len(trimmed.split(".")[1]) if "." in trimmed else 0
+    disp = format_number(val)
+    if "e" in disp or "E" in disp:  # scientific notation (very small): unaligned
+        return None
+    return len(disp.split(".")[1]) if "." in disp else 0
 
 
 def column_precision(values):
@@ -121,15 +122,12 @@ def column_precision(values):
 
 
 def _format_aligned(val, precision):
-    """Format ``val`` to a fixed ``precision`` (padding trailing zeros) so a
-    column's numbers line up; fall back to ``format_number`` when ``precision``
-    is None or ``val`` is not a plain number (``--`` / ``...`` / text)."""
-    if precision is None:
+    """Pad ``val`` to a fixed ``precision`` (trailing zeros) so a column's
+    numbers line up. Falls back to ``format_number`` when there's no target
+    precision, or for non-numbers / scientific-notation cells (left as-is)."""
+    if precision is None or _value_decimals(val) is None:
         return format_number(val)
-    try:
-        return f"{float(val):.{precision}f}"
-    except (ValueError, TypeError):
-        return format_number(val)
+    return f"{float(val):.{precision}f}"
 
 
 def csv_to_latex(csv_file, output_file, caption=None, label=None, max_rows=30):

--- a/scripts/python/png_to_jpg.py
+++ b/scripts/python/png_to_jpg.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/png_to_jpg.py
+# Purpose: Pillow-based PNG->JPG fallback for the figure pipeline, used when
+#          ImageMagick (magick/convert) is absent. Flattens alpha onto a white
+#          background and saves JPEG quality 95 (matching the ImageMagick
+#          `-background white -flatten -quality 95` behavior). Also generates a
+#          plain placeholder JPG (so a missing figure never leaves a broken
+#          `.txt` where the compile expects a `.jpg`).
+#
+# Usage:
+#   python3 png_to_jpg.py OUT.jpg --src IN.png
+#   python3 png_to_jpg.py OUT.jpg --placeholder "Missing figure: NN"
+#
+# Exit 0 on success; non-zero (with a loud stderr hint) if Pillow is missing or
+# conversion fails — the caller treats that as fail-loud, never a silent no-op.
+
+import argparse
+import sys
+
+
+def _flatten_to_white(img):
+    """Composite an image (any mode) onto an opaque white background, RGB."""
+    from PIL import Image
+
+    rgba = img.convert("RGBA")
+    bg = Image.new("RGBA", rgba.size, (255, 255, 255, 255))
+    return Image.alpha_composite(bg, rgba).convert("RGB")
+
+
+def convert_png_to_jpg(src, dst, quality=95):
+    """Convert a PNG (alpha flattened onto white) to JPEG at ``dst``."""
+    from PIL import Image
+
+    with Image.open(src) as img:
+        _flatten_to_white(img).save(dst, "JPEG", quality=quality)
+
+
+def write_placeholder_jpg(text, dst, size=(800, 600)):
+    """Write a light-gray placeholder JPEG bearing ``text``."""
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGB", size, (211, 211, 211))
+    draw = ImageDraw.Draw(img)
+    draw.text((20, size[1] // 2), text, fill=(64, 64, 64))
+    img.save(dst, "JPEG", quality=95)
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        description="PNG->JPG (Pillow fallback) + placeholder JPG generator."
+    )
+    parser.add_argument("dst", help="output .jpg path")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--src", help="input .png to convert")
+    group.add_argument("--placeholder", help="text for a placeholder JPG")
+    args = parser.parse_args(argv[1:])
+
+    try:
+        if args.src is not None:
+            convert_png_to_jpg(args.src, args.dst)
+        else:
+            write_placeholder_jpg(args.placeholder, args.dst)
+    except ImportError:
+        sys.stderr.write(
+            "ERROR: Pillow not installed and ImageMagick unavailable — cannot "
+            "render figures. Fix: install ImageMagick (magick/convert) or "
+            "`pip install pillow`.\n"
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001 - surface any conversion failure loudly
+        sys.stderr.write(f"ERROR: PNG->JPG conversion failed for {args.dst}: {exc}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))
+
+# EOF

--- a/scripts/shell/compile_manuscript.sh
+++ b/scripts/shell/compile_manuscript.sh
@@ -376,9 +376,15 @@ main() {
     echo_info "$(get_engine_info "$SELECTED_ENGINE")"
     log_stage_end "Engine Selection"
 
-    # TeX to PDF
+    # TeX to PDF. FAIL LOUD: the module returns non-zero when manuscript.pdf was
+    # not (re)created (engine failure, or a pdfTeX Fatal error that produced no
+    # PDF). Propagate that — never exit 0 with only a printed ERRO, or callers
+    # (and humans) treat a stale/absent PDF as a fresh success.
     log_stage_start "PDF Generation"
-    "$PROJECT_ROOT/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh"
+    if ! "$PROJECT_ROOT/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh"; then
+        log_error "PDF generation failed — manuscript.pdf was not (re)created. Aborting."
+        exit 1
+    fi
     log_stage_end "PDF Generation"
 
     # Diff (skip if --no_diff specified)

--- a/scripts/shell/compile_revision.sh
+++ b/scripts/shell/compile_revision.sh
@@ -357,9 +357,12 @@ parse_arguments() {
     ./scripts/shell/modules/compilation_structure_tex_to_compiled_tex.sh
     log_stage_end "TeX Compilation (Structure)"
 
-    # Compile to PDF
+    # Compile to PDF. FAIL LOUD if the revision PDF was not (re)created.
     log_stage_start "PDF Generation"
-    ./scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
+    if ! ./scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh; then
+        echo_error "PDF generation failed — revision.pdf was not (re)created. Aborting."
+        exit 1
+    fi
     log_stage_end "PDF Generation"
 
     # Skip diff generation for revision (revision document already shows changes inline)

--- a/scripts/shell/compile_supplementary.sh
+++ b/scripts/shell/compile_supplementary.sh
@@ -314,9 +314,12 @@ main() {
     ./scripts/shell/modules/compilation_structure_tex_to_compiled_tex.sh
     log_stage_end "TeX Compilation (Structure)"
 
-    # TeX to PDF
+    # TeX to PDF. FAIL LOUD if the supplementary PDF was not (re)created.
     log_stage_start "PDF Generation"
-    ./scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
+    if ! ./scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh; then
+        echo_error "PDF generation failed — supplementary.pdf was not (re)created. Aborting."
+        exit 1
+    fi
     log_stage_end "PDF Generation"
 
     # Diff (skip if --no_diff specified)

--- a/scripts/shell/modules/process_figures_modules/02_format_conversion.src
+++ b/scripts/shell/modules/process_figures_modules/02_format_conversion.src
@@ -86,11 +86,15 @@ png2jpg() {
                 temp_copy_needed=true
             fi
 
-            # Convert to JPG (flatten alpha onto white background)
+            # Convert to JPG (flatten alpha onto white). Prefer ImageMagick;
+            # fall back to Pillow; FAIL LOUD if neither exists — never leave the
+            # .jpg missing (which silently breaks the figure's \includegraphics).
             if command -v magick >/dev/null 2>&1; then
                 magick "$work_png_file" -background white -flatten -quality 95 "$jpg_file"
-            else
+            elif command -v convert >/dev/null 2>&1; then
                 convert "$work_png_file" -background white -flatten -quality 95 "$jpg_file"
+            elif ! python3 ./scripts/python/png_to_jpg.py "$jpg_file" --src "$work_png_file"; then
+                echo_error "Failed to convert ${base_name}.png to JPG: no ImageMagick (magick/convert) and the Pillow fallback failed. Install ImageMagick or run 'pip install pillow'."
             fi
 
             # Clean up temp file if created

--- a/scripts/shell/modules/process_figures_modules/04_compilation.src
+++ b/scripts/shell/modules/process_figures_modules/04_compilation.src
@@ -162,16 +162,22 @@ create_placeholder_jpg() {
     local output_file="$1"
     local figure_name="$2"
 
-    # Use ImageMagick to create a placeholder
-    if command -v convert >/dev/null 2>&1; then
+    # Create a placeholder JPG. Prefer ImageMagick; fall back to Pillow; FAIL
+    # LOUD if neither exists. NEVER emit a `.txt` — \includegraphics expects a
+    # `.jpg`, and a stray `.txt` silently breaks the compile.
+    if command -v magick >/dev/null 2>&1; then
+        magick -size 800x600 xc:lightgray \
+            -gravity center -pointsize 48 \
+            -annotate +0+0 "Missing Figure\n$figure_name" \
+            "$output_file"
+    elif command -v convert >/dev/null 2>&1; then
         convert -size 800x600 xc:lightgray \
             -gravity center \
             -pointsize 48 \
             -annotate +0+0 "Missing Figure\n$figure_name" \
             "$output_file"
-    else
-        # Create a minimal placeholder
-        echo "Missing figure: $figure_name" >"${output_file%.jpg}.txt"
+    elif ! python3 ./scripts/python/png_to_jpg.py "$output_file" --placeholder "Missing figure: $figure_name"; then
+        echo_error "Cannot create placeholder for missing figure '$figure_name': no ImageMagick (magick/convert) and the Pillow fallback failed. Install ImageMagick or run 'pip install pillow'."
     fi
 }
 

--- a/src/scitex_writer/_skills/scitex-writer/12_figures-and-tables.md
+++ b/src/scitex_writer/_skills/scitex-writer/12_figures-and-tables.md
@@ -58,6 +58,22 @@ mv -f 01_manuscript/contents/tables/caption_and_media/*.csv \
 ```
 
 Reference tables as Supplementary Tables (S1, S2, ...) in the manuscript text.
+(Supplementary figures/tables are auto-numbered with the `S` prefix by the
+`02_supplementary` template.)
+
+## CSV table-header conventions
+
+Author CSV column headers as the FINAL rendered label — the csv→LaTeX converter
+passes them through faithfully (it no longer title-cases or strips them):
+
+- **Math** renders when written in `$...$`: `$n_{\mathrm{SZ}}$`, `$F_1$`,
+  `Sens$_{15}$`, `$R^2$` (a header containing `$` or `\` is emitted verbatim).
+- **Human labels** read as written: `SOP (min)`, `# of Patients`, `ROC-AUC` —
+  NOT raw underscore-derived `SOP min` / `n patients` / `n SZ`. Use real words
+  and spaces (or math) in the header, not `snake_case`.
+- Numeric **columns auto-align** to a consistent decimal precision (a column
+  with `0.333` and `0.35` renders `0.333` / `0.350`); all-integer count columns
+  stay bare.
 
 ## Archiving Figures and Tables
 

--- a/tests/scripts/python/test_csv_to_latex.py
+++ b/tests/scripts/python/test_csv_to_latex.py
@@ -403,7 +403,8 @@ class TestCsvToLatex:
         assert ('\\toprule' in content) and ('\\midrule' in content) and ('\\bottomrule' in content)
 
     def test_csv_to_latex_number_formatting(self, tmp_path):
-        """Should format numbers appropriately."""
+        """Numbers format to the column precision (3.14159->3.142; the
+        integer-valued 42.0 pads to 42.000 to align with the fractional cell)."""
         # Arrange
         csv_file = tmp_path / "test.csv"
         csv_file.write_text("Value\n3.14159\n42.0")
@@ -413,9 +414,8 @@ class TestCsvToLatex:
 
         # Act
         content = output_file.read_text()
-        # Float should be formatted
         # Assert
-        assert ('3.142' in content) and ('42 ' in content or '42\\\\' in content)
+        assert ('3.142' in content) and ('42.000' in content)
 
     def test_csv_to_latex_column_alignment(self, tmp_path):
         """Should align numeric columns right."""

--- a/tests/scripts/python/test_csv_to_latex.py
+++ b/tests/scripts/python/test_csv_to_latex.py
@@ -17,7 +17,12 @@ pytest.importorskip("pandas")
 # Try to import pandas and the functions
 try:
     import pandas as pd  # noqa: F401
-    from csv_to_latex import csv_to_latex, escape_latex, format_number
+    from csv_to_latex import (
+        column_precision,
+        csv_to_latex,
+        escape_latex,
+        format_number,
+    )
 
     HAS_DEPS = True
 except ImportError:
@@ -507,6 +512,74 @@ class TestCsvToLatex:
         content = output_file.read_text()
         # Assert
         assert ("\\rowcolor{lightgray}" in content) and ("gray!10" not in content)
+
+
+class TestColumnPrecision:
+    """Per-column decimal precision (drives alignment)."""
+
+    def test_picks_max_decimals_of_fractional_column(self):
+        """A fractional column's precision is its max decimal places."""
+        # Arrange
+        # Act
+        prec = column_precision([0.333, 0.35])
+        # Assert
+        assert prec == 3
+
+    def test_all_integer_column_returns_none(self):
+        """An all-integer column gets no precision (stays bare)."""
+        # Arrange
+        # Act
+        prec = column_precision([288, 100])
+        # Assert
+        assert prec is None
+
+    def test_skips_non_numeric_cells(self):
+        """Non-numeric markers (--/...) are ignored when sizing precision."""
+        # Arrange
+        # Act
+        prec = column_precision(["--", 0.35, "..."])
+        # Assert
+        assert prec == 2
+
+
+class TestDecimalAlignment:
+    """End-to-end: csv_to_latex aligns a column's decimals."""
+
+    def test_pads_shorter_value_to_column_precision(self, tmp_path):
+        """0.35 renders as 0.350 when the column also has 0.333."""
+        # Arrange
+        csv_file = tmp_path / "auc.csv"
+        csv_file.write_text("AUC\n0.333\n0.35")
+        output_file = tmp_path / "out.tex"
+        csv_to_latex(csv_file, output_file)
+        # Act
+        content = output_file.read_text()
+        # Assert
+        assert "0.350" in content
+
+    def test_all_integer_column_not_padded(self, tmp_path):
+        """A pure count column keeps bare integers (no 288.000)."""
+        # Arrange
+        csv_file = tmp_path / "n.csv"
+        csv_file.write_text("n_SZ\n288\n100")
+        output_file = tmp_path / "out.tex"
+        csv_to_latex(csv_file, output_file)
+        # Act
+        content = output_file.read_text()
+        # Assert
+        assert "288.000" not in content
+
+    def test_default_caption_preserves_acronym_casing(self, tmp_path):
+        """The auto-caption is not title-cased (ROC-AUC, not Roc-Auc)."""
+        # Arrange
+        csv_file = tmp_path / "05_ROC_AUC.csv"
+        csv_file.write_text("AUC\n0.9")
+        output_file = tmp_path / "out.tex"
+        csv_to_latex(csv_file, output_file)
+        # Act
+        content = output_file.read_text()
+        # Assert
+        assert "Roc Auc" not in content
 
 
 if __name__ == "__main__":

--- a/tests/scripts/python/test_png_to_jpg.py
+++ b/tests/scripts/python/test_png_to_jpg.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: png_to_jpg.py (Pillow PNG->JPG fallback)
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+_SCRIPT = ROOT_DIR / "scripts" / "python" / "png_to_jpg.py"
+
+
+def _make_png(path, color=(255, 0, 0, 128), size=(40, 30)):
+    from PIL import Image
+
+    Image.new("RGBA", size, color).save(path)
+
+
+def _run(*args):
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_convert_produces_jpeg(tmp_path):
+    """--src converts a PNG into a real JPEG file."""
+    # Arrange
+    pytest.importorskip("PIL")
+    from PIL import Image
+
+    src = tmp_path / "in.png"
+    _make_png(src)
+    dst = tmp_path / "out.jpg"
+    # Act
+    _run(str(dst), "--src", str(src))
+    # Assert
+    assert Image.open(dst).format == "JPEG"
+
+
+def test_convert_flattens_alpha_onto_white(tmp_path):
+    """A fully transparent PNG flattens onto a white background."""
+    # Arrange
+    pytest.importorskip("PIL")
+    from PIL import Image
+
+    src = tmp_path / "clear.png"
+    _make_png(src, color=(0, 0, 0, 0))
+    dst = tmp_path / "clear.jpg"
+    # Act
+    _run(str(dst), "--src", str(src))
+    # Assert
+    assert Image.open(dst).convert("RGB").getpixel((0, 0)) == (255, 255, 255)
+
+
+def test_placeholder_produces_jpeg(tmp_path):
+    """--placeholder writes a JPEG placeholder (never a .txt)."""
+    # Arrange
+    pytest.importorskip("PIL")
+    from PIL import Image
+
+    dst = tmp_path / "ph.jpg"
+    # Act
+    _run(str(dst), "--placeholder", "Missing figure: 02")
+    # Assert
+    assert Image.open(dst).format == "JPEG"
+
+
+def test_requires_src_or_placeholder(tmp_path):
+    """With neither --src nor --placeholder, the CLI errors (no silent no-op)."""
+    # Arrange
+    dst = tmp_path / "out.jpg"
+    # Act
+    proc = _run(str(dst))
+    # Assert
+    assert proc.returncode != 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])
+
+# EOF


### PR DESCRIPTION
## Release 2.23.1
Promotes develop → main for the v2.23.1 tag. Patch bundle since 2.23.0:
- #188 compile fails loud on no-PDF + microtype expansion=false (elsarticle fatal fix)
- #187 microtype/justify/URL preamble defaults
- #186 supplementary S-prefix numbering
- #185 table per-column decimal alignment + caption casing
- #184 png→jpg Pillow fallback + fail-loud

All CI-green on develop. After merge: tag v2.23.1 → PyPI.