### PR TITLE
fix(compile): flattener 00_shared/latex_styles fallback + fail-loud on missing preamble

### DIFF
--- a/scripts/python/_tex_signature.py
+++ b/scripts/python/_tex_signature.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/_tex_signature.py
+# Purpose: Build the compilation signature comment block prepended to the
+#          flattened TeX by compile_tex_structure.py. Extracted from that
+#          module to keep it under the line limit; pure helper, no public API
+#          change.
+
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+
+def generate_signature(source_file: Path = None, build_id: Optional[str] = None) -> str:
+    """Generate the compilation signature comment block.
+
+    Args:
+        source_file: Original source file path (optional).
+        build_id: Per-compilation build id (optional).
+
+    Returns:
+        Formatted signature as a LaTeX comment block.
+    """
+    # Read version from pyproject.toml (single source of truth). This module
+    # lives in scripts/python/, so parent.parent.parent is the repo root.
+    version = "unknown"
+    pyproject_path = Path(__file__).parent.parent.parent / "pyproject.toml"
+    try:
+        with open(pyproject_path, "r") as f:
+            for line in f:
+                if line.startswith("version"):
+                    version = line.split("=")[1].strip().strip('"')
+                    break
+    except Exception:
+        pass
+
+    engine = (
+        os.getenv("SCITEX_WRITER_SELECTED_ENGINE", "")
+        or os.getenv("SCITEX_WRITER_ENGINE", "")
+        or "auto"
+    )
+
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    signature = f"""% {"=" * 78}
+% SciTeX Writer {version} (https://scitex.ai)
+% LaTeX compilation engine: {engine}
+% Compiled: {timestamp}
+"""
+
+    if build_id:
+        signature += f"% Build ID: build:{build_id}\n"
+
+    if source_file:
+        signature += f"% Source: {source_file}\n"
+
+    signature += f"""% {"=" * 78}
+
+"""
+    return signature
+
+
+__all__ = ["generate_signature"]
+
+# EOF

--- a/scripts/python/compile_tex_structure.py
+++ b/scripts/python/compile_tex_structure.py
@@ -13,7 +13,6 @@ import argparse
 import os
 import re
 import sys
-from datetime import datetime
 from pathlib import Path
 from typing import Optional, Set
 
@@ -23,57 +22,27 @@ from _build_id import (  # noqa: E402
     inject_build_metadata,
     register_build,
 )
+from _tex_signature import generate_signature  # noqa: E402
 
 
-def generate_signature(source_file: Path = None, build_id: Optional[str] = None) -> str:
+def _is_style_input(input_file: str) -> bool:
+    r"""True if an \input target is a preamble style file (latex_styles/)."""
+    return "latex_styles" in Path(input_file).parts
+
+
+def _style_fallback(input_path: Path) -> Optional[Path]:
+    r"""Resolve a latex_styles \input against 00_shared/latex_styles by basename.
+
+    Preamble styles are \input via contents/latex_styles/ -- a dev-only,
+    UNCOMMITTED symlink to 00_shared/latex_styles that a fresh clone/CI/worktree
+    lacks. Resolved from cwd (= project root), like ./-prefixed inputs. Returns
+    None if not a style input or the fallback is absent.
     """
-    Generate compilation signature comment block.
-
-    Args:
-        source_file: Original source file path (optional)
-
-    Returns:
-        Formatted signature as comment block
-    """
-    # Read version from pyproject.toml (single source of truth)
-    version = "unknown"
-    pyproject_path = Path(__file__).parent.parent.parent / "pyproject.toml"
-    try:
-        with open(pyproject_path, "r") as f:
-            for line in f:
-                if line.startswith("version"):
-                    version = line.split("=")[1].strip().strip('"')
-                    break
-    except Exception:
-        pass
-
-    # Get engine
-    engine = (
-        os.getenv("SCITEX_WRITER_SELECTED_ENGINE", "")
-        or os.getenv("SCITEX_WRITER_ENGINE", "")
-        or "auto"
-    )
-
-    # Get timestamp
-    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-
-    # Format signature
-    signature = f"""% {"=" * 78}
-% SciTeX Writer {version} (https://scitex.ai)
-% LaTeX compilation engine: {engine}
-% Compiled: {timestamp}
-"""
-
-    if build_id:
-        signature += f"% Build ID: build:{build_id}\n"
-
-    if source_file:
-        signature += f"% Source: {source_file}\n"
-
-    signature += f"""% {"=" * 78}
-
-"""
-    return signature
+    if "latex_styles" in input_path.parts:
+        candidate = Path("00_shared") / "latex_styles" / input_path.name
+        if candidate.exists():
+            return candidate
+    return None
 
 
 def expand_inputs(
@@ -81,6 +50,7 @@ def expand_inputs(
     processed: Set[Path] = None,
     depth: int = 0,
     max_depth: int = 10,
+    errors: Optional[list] = None,
 ) -> str:
     r"""
     Recursively expand \input{} commands.
@@ -90,12 +60,17 @@ def expand_inputs(
         processed: Set of already processed files (prevents infinite loops)
         depth: Current recursion depth
         max_depth: Maximum recursion depth
+        errors: Accumulator for FATAL preamble-style misses (fail-loud). The
+            top-level caller passes a list and aborts the compile if it is
+            non-empty after expansion.
 
     Returns:
         Expanded content as string
     """
     if processed is None:
         processed = set()
+    if errors is None:
+        errors = []
 
     if depth > max_depth:
         return f"% ERROR: Max recursion depth ({max_depth}) exceeded\n"
@@ -149,21 +124,42 @@ def expand_inputs(
                     # Path like contents/... is relative to current file
                     input_path = file_path.parent / input_path
 
+            # Fresh-checkout robustness: a latex_styles \input missing in
+            # contents/ falls back to 00_shared/latex_styles (uncommitted dev
+            # symlink -- see _style_fallback).
+            if not input_path.exists():
+                fb = _style_fallback(input_path)
+                if fb is not None:
+                    input_path = fb
+
             # Add header comment
             result_lines.append("")
             result_lines.append("% " + "=" * 70)
             result_lines.append(f"% File: {input_file}")
             result_lines.append("% " + "=" * 70)
 
-            # Recursively expand
-            expanded = expand_inputs(
-                input_path,
-                processed=processed,
-                depth=depth + 1,
-                max_depth=max_depth,
-            )
-
-            result_lines.append(expanded)
+            if input_path.exists():
+                expanded = expand_inputs(
+                    input_path,
+                    processed=processed,
+                    depth=depth + 1,
+                    max_depth=max_depth,
+                    errors=errors,
+                )
+                result_lines.append(expanded)
+            elif _is_style_input(input_file):
+                # FAIL LOUD: a missing PREAMBLE STYLE input silently yields a
+                # broken PDF (undefined \linenumbers etc.) on exit 0.
+                msg = (
+                    f"preamble style input not found: \\input{{{input_file}}} "
+                    f"(searched contents/ and 00_shared/latex_styles/)"
+                )
+                errors.append(msg)
+                result_lines.append(f"% FATAL: {msg}")
+            else:
+                result_lines.append(
+                    f"% SKIPPED: \\input{{{input_file}}} (file not found)"
+                )
             result_lines.append("")
 
         else:
@@ -210,8 +206,24 @@ def compile_tex_structure(
     if verbose:
         print(f"Build ID: build:{build_id}")
 
-    # Expand all inputs recursively
-    expanded_content = expand_inputs(base_tex)
+    # Expand all inputs recursively. A missing PREAMBLE STYLE \input is FATAL
+    # (would silently yield a broken PDF); collect any and abort below.
+    style_errors: list = []
+    expanded_content = expand_inputs(base_tex, errors=style_errors)
+    if style_errors:
+        print(
+            "ERROR: missing preamble style input(s) -- aborting (would produce "
+            "a broken PDF on exit 0):",
+            file=sys.stderr,
+        )
+        for e in style_errors:
+            print(f"  - {e}", file=sys.stderr)
+        print(
+            "  Fix: ensure 00_shared/latex_styles/ holds the style files, or "
+            "that contents/latex_styles resolves to them.",
+            file=sys.stderr,
+        )
+        return False
 
     # Inject PDF metadata + \scitexBuildID macro before \begin{document}
     expanded_content = inject_build_metadata(expanded_content, build_id)

--- a/tests/scripts/python/test_compile_tex_structure.py
+++ b/tests/scripts/python/test_compile_tex_structure.py
@@ -14,8 +14,10 @@ ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
 
 from compile_tex_structure import (  # noqa: E402
+    _is_style_input,
     _read_config_theme,
     _resolve_dark_mode,
+    _style_fallback,
     compile_tex_structure,
     expand_inputs,
     generate_signature,
@@ -536,6 +538,113 @@ class TestThemeResolution:
         result = _read_config_theme(base)
         # Assert
         assert result == "light"
+
+
+@pytest.fixture
+def chdir_tmp(tmp_path):
+    """Run the test with cwd = tmp_path (real chdir, restored on teardown).
+
+    _style_fallback resolves 00_shared/latex_styles relative to cwd (= project
+    root in the real pipeline, like ./-prefixed inputs). No monkeypatch: we set
+    the real cwd and restore it.
+    """
+    prev = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        os.chdir(prev)
+
+
+class TestStyleFallbackAndFailLoud:
+    """latex_styles \\input falls back to 00_shared/latex_styles; a still-missing
+    preamble style input fails loud (no silent broken-PDF on exit 0)."""
+
+    def test_is_style_input_true_for_latex_styles_path(self):
+        # Arrange
+        path = "contents/latex_styles/packages.tex"
+        # Act
+        result = _is_style_input(path)
+        # Assert
+        assert result is True
+
+    def test_is_style_input_false_for_content_path(self):
+        # Arrange
+        path = "contents/methods.tex"
+        # Act
+        result = _is_style_input(path)
+        # Assert
+        assert result is False
+
+    def test_style_fallback_resolves_from_00shared(self, chdir_tmp):
+        """A latex_styles input missing in contents/ resolves to 00_shared."""
+        # Arrange
+        (chdir_tmp / "00_shared" / "latex_styles").mkdir(parents=True)
+        (chdir_tmp / "00_shared" / "latex_styles" / "packages.tex").write_text("PKG")
+        # Act
+        resolved = _style_fallback(
+            Path("01_manuscript/contents/latex_styles/packages.tex")
+        )
+        # Assert
+        assert resolved == Path("00_shared") / "latex_styles" / "packages.tex"
+
+    def test_style_fallback_none_for_non_style(self, chdir_tmp):
+        # Arrange
+        target = Path("01_manuscript/contents/methods.tex")
+        # Act
+        resolved = _style_fallback(target)
+        # Assert
+        assert resolved is None
+
+    def test_expand_resolves_style_via_00shared_fallback(self, chdir_tmp):
+        """A \\input of a contents/latex_styles file inlines the 00_shared copy."""
+        # Arrange
+        (chdir_tmp / "00_shared" / "latex_styles").mkdir(parents=True)
+        (chdir_tmp / "00_shared" / "latex_styles" / "packages.tex").write_text("PKGMARK")
+        (chdir_tmp / "01_manuscript").mkdir(parents=True)
+        base = chdir_tmp / "01_manuscript" / "base.tex"
+        base.write_text("\\input{contents/latex_styles/packages}")
+        errors = []
+        # Act
+        out = expand_inputs(base, errors=errors)
+        # Assert
+        assert ("PKGMARK" in out) and (errors == [])
+
+    def test_missing_style_input_records_fatal_error(self, chdir_tmp):
+        """A style input absent in BOTH contents/ and 00_shared is fail-loud."""
+        # Arrange
+        (chdir_tmp / "01_manuscript").mkdir(parents=True)
+        base = chdir_tmp / "01_manuscript" / "base.tex"
+        base.write_text("\\input{contents/latex_styles/packages}")
+        errors = []
+        # Act
+        out = expand_inputs(base, errors=errors)
+        # Assert
+        assert (len(errors) == 1) and ("FATAL" in out) and ("PKGMARK" not in out)
+
+    def test_missing_non_style_input_is_skipped_not_fatal(self, chdir_tmp):
+        """A missing NON-style \\input keeps the historical skip (not fatal)."""
+        # Arrange
+        (chdir_tmp / "01_manuscript").mkdir(parents=True)
+        base = chdir_tmp / "01_manuscript" / "base.tex"
+        base.write_text("\\input{contents/optional_section}")
+        errors = []
+        # Act
+        out = expand_inputs(base, errors=errors)
+        # Assert
+        assert (errors == []) and ("SKIPPED" in out)
+
+    def test_compile_aborts_on_missing_style_input(self, chdir_tmp):
+        """compile_tex_structure returns False when a preamble style is missing."""
+        # Arrange
+        (chdir_tmp / "01_manuscript").mkdir(parents=True)
+        base = chdir_tmp / "01_manuscript" / "base.tex"
+        base.write_text("\\input{contents/latex_styles/packages}")
+        output = chdir_tmp / "01_manuscript" / "out.tex"
+        # Act
+        success = compile_tex_structure(base_tex=base, output_tex=output, verbose=False)
+        # Assert
+        assert success is False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Closes a reproducibility hole found while compiling a real manuscript from a fresh checkout (neurovista dogfood; reproduces on full TeXLive, not a TeXLive issue).

`base.tex` `\input`s `./01_manuscript/contents/latex_styles/{packages,columns,linker}`, but those files live in `00_shared/latex_styles/`. The main dev checkout only compiles because `contents/latex_styles` is a **local, uncommitted symlink** → `00_shared/latex_styles` (git: "beyond a symbolic link"). So a fresh clone / CI / worktree has only `formatting.tex` there → the flattener emitted `% SKIPPED: \input{...} (file not found)` and **continued** → `\linenumbers` undefined → ~300 cascading errors → a broken 3-page PDF, **with exit 0**.

## Fix (the robust pair)
- **(a) fallback**: a `latex_styles` `\input` missing in `contents/` falls back to `00_shared/latex_styles` by basename (`_style_fallback`), so fresh checkouts resolve the preamble **without** the symlink.
- **(c) fail loud**: a preamble style `\input` still missing after fallback is collected; `compile_tex_structure` returns `False` (non-zero) with a clear message — never a silent SKIPPED → broken PDF. Non-style / optional content `\input`s keep the historical skip-with-comment so optional sections don't break.

Matches the engine's standing fail-loud doctrine (never ship a broken PDF on exit 0).

Also: extracted `generate_signature` → `scripts/python/_tex_signature.py` (re-exported, no API change) to keep the module under the 512-line limit.

## Test plan
- [x] New tests in `test_compile_tex_structure.py`: `_is_style_input`, `_style_fallback` resolution, expand-via-fallback, missing-style → fatal, missing-optional → skip (not fatal), `compile_tex_structure` aborts on missing style. (No `monkeypatch` — a real `chdir` yield-fixture.)
- [x] Local smoke across both branches; scitex-dev linter clean on changed files.
- [ ] CI green.
- [ ] neurovista adopts on next vendor (also makes the eventual clew-marker showcase compile robustly from a clean checkout).

Independent of the clew presentation work (#192).