### PR TITLE
chore(release): 2.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.24.0] - 2026-06-30
+
+### Added
+- **Clew provenance layer (opt-in rendering).** `00_shared/latex_styles/clew_presentation.tex`
+  renders clew-registered claims inline: `\clewval{id}` substitutes the
+  registered value (SSoT) with a verdict-colored wavy underline, `\clewmark{id}{text}`
+  marks prose, plus a "Clew Verified" badge, a "Compiled by SciTeX Writer."
+  colophon (snake icon), and a self-demonstrating legend. 4-state palette
+  (verified / suspect / unverified / exception); writer owns the *rendering*,
+  scitex-clew emits the *data* (`00_shared/clew_rendered.tex`). All four
+  features are independent opt-in toggles, default off (#192).
+- **Pre-compile clew provenance gate.** `check_clew_verify.py` re-verifies every
+  clew-registered claim against its bound source before compiling; default
+  `error` for research projects, with a `require_claims` tightening knob
+  (`SCITEX_WRITER_CLEW_VERIFY`) (#191).
+- **Post-compile verification gate (fail loud on a deficient PDF).** A new
+  "Compile Verification" stage fails the compile non-zero when the compiled
+  `.tex` references `\includegraphics` (N>0) but the PDF embeds 0 images — a
+  silent figure-miss that a clean log would not catch — plus secondary log
+  deficiency signals (`SCITEX_WRITER_COMPILE_ARTIFACTS`, default error) (#194).
+
+### Fixed
+- **Fresh-checkout compiles no longer silently break.** The flattener now
+  resolves preamble style `\input`s against `00_shared/latex_styles` when
+  absent from `contents/` (the dev symlink is not committed), and FAILS LOUD if
+  a preamble style is still missing — instead of emitting `% SKIPPED` and
+  producing a broken PDF on exit 0 (#193).
+
 ## [2.23.1] - 2026-06-29
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.23.1"
+version = "2.24.0"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Release 2.24.0: clew verify gate (#191), clew presentation layer (#192), flattener fallback+fail-loud (#193), post-compile verification gate (#194). develop validated green (tests+audit) via workflow_dispatch — note: GitHub Actions auto-triggers are down repo-wide today, so CI was run manually.