### PR TITLE
fix(update): re-stamp scitex_writer_version.tex on re-vendor

### DIFF
--- a/src/scitex_writer/_mcp/handlers/_update/_handler.py
+++ b/src/scitex_writer/_mcp/handlers/_update/_handler.py
@@ -41,6 +41,28 @@ def _write_vendor_stamp(project_path: Path, pkg_version: str) -> None:
         pass
 
 
+def _restamp_version_tex(project_path: Path, pkg_version: str) -> None:
+    """Re-stamp 00_shared/scitex_writer_version.tex to the vendored version.
+
+    The compile (_compile.py) rewrites this from the installed __version__ for
+    PDF metadata, but only AT compile time -- so after a re-vendor the visible
+    "Compiled by SciTeX Writer vX" colophon + PDF Creator would still show the
+    OLD version until the next compile. Re-stamp it here so it is correct
+    immediately (mirrors _compile.py's format). Best-effort.
+    """
+    try:
+        version_tex = project_path / "00_shared" / "scitex_writer_version.tex"
+        if not version_tex.parent.exists():
+            return
+        version_tex.write_text(
+            f"\\def\\ScitexWriterVersion{{{pkg_version}}}\n"
+            f"\\hypersetup{{pdfcreator={{Compiled by scitex-writer v{pkg_version}}}}}\n",
+            encoding="utf-8",
+        )
+    except OSError:
+        pass
+
+
 def update_project(
     project_dir: str,
     branch: Optional[str] = None,
@@ -123,6 +145,9 @@ def update_project(
         # update-project vendored from. Absent => a pre-feature vendor (stale).
         if not dry_run:
             _write_vendor_stamp(project_path, pkg_version)
+            # Also refresh the visible colophon / PDF-Creator stamp so it shows
+            # the vendored version immediately (without waiting for a recompile).
+            _restamp_version_tex(project_path, pkg_version)
 
         return {
             "success": True,

--- a/tests/scitex_writer/_mcp/handlers/_update/test__handler.py
+++ b/tests/scitex_writer/_mcp/handlers/_update/test__handler.py
@@ -2,6 +2,11 @@
 
 import importlib
 
+from scitex_writer._mcp.handlers._update._handler import (
+    _restamp_version_tex,
+    _write_vendor_stamp,
+)
+
 
 def test_module_exposes_collect_sync_files():
     # Arrange
@@ -9,3 +14,32 @@ def test_module_exposes_collect_sync_files():
     module = importlib.import_module("scitex_writer._mcp.handlers._update._handler")
     # Assert
     assert hasattr(module, "collect_sync_files")
+
+
+def test_write_vendor_stamp_first_line_is_version(tmp_path):
+    # Arrange
+    (tmp_path / "00_shared").mkdir()
+    # Act
+    _write_vendor_stamp(tmp_path, "2.24.0")
+    # Assert
+    stamp = tmp_path / "00_shared" / ".scitex-writer-vendored-version"
+    assert stamp.read_text().splitlines()[0] == "2.24.0"
+
+
+def test_restamp_version_tex_sets_colophon_version(tmp_path):
+    # Arrange
+    (tmp_path / "00_shared").mkdir()
+    # Act
+    _restamp_version_tex(tmp_path, "2.24.0")
+    # Assert
+    text = (tmp_path / "00_shared" / "scitex_writer_version.tex").read_text()
+    assert "\\def\\ScitexWriterVersion{2.24.0}" in text
+
+
+def test_restamp_version_tex_noop_without_00shared(tmp_path):
+    # Arrange
+    target = tmp_path / "00_shared" / "scitex_writer_version.tex"
+    # Act
+    _restamp_version_tex(tmp_path, "2.24.0")
+    # Assert
+    assert not target.exists()


### PR DESCRIPTION
## Summary
Flagged by paper-scitex-clew during the 2.24.0 re-vendor: `update-project` preserved `00_shared/scitex_writer_version.tex`, so the visible "Compiled by SciTeX Writer vX" colophon + PDF Creator metadata still read the OLD version until the next compile re-stamped them. Now `update-project` re-stamps it to the vendored-from version right after vendoring (beside the vendor-version stamp from the freshness gate), so it's correct immediately — no recompile needed. Best-effort, mirrors `_compile.py`'s format.

## Test plan
- [x] Tests for `_restamp_version_tex` (sets the colophon version; no-op without `00_shared/`) + `_write_vendor_stamp`. Smoke + linter clean.
- [ ] CI green.

One of the 2.24.x batch follow-ups. Independent.