### PR TITLE
fix(figures): assembler preserves user-placed jpgs in jpg_for_compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Figure assembler no longer destroys user-placed jpgs.** `init_figures`
+  previously ran a blanket `rm -rf jpg_for_compilation/*` at the start of every
+  figure run, silently deleting real figures materialized directly in
+  `jpg_for_compilation/` that have no `caption_and_media/` source to regenerate
+  from (they became 9KB "Missing Figure" placeholders → PDF embedded 0 images).
+  The clean step now removes only derived **symlinks** (re-created from
+  `caption_and_media/` each run) and preserves real files, warning about any
+  orphan jpg so it can be moved to `caption_and_media/` as a tracked source.
+
 ## [2.24.0] - 2026-06-30
 
 ### Added

--- a/scripts/shell/modules/process_figures_modules/00_common.src
+++ b/scripts/shell/modules/process_figures_modules/00_common.src
@@ -45,10 +45,23 @@ init_figures() {
         rm -f "$SCITEX_WRITER_FIGURE_COMPILED_DIR"/*.tex
     fi
 
-    # Clean jpg_for_compilation directory
+    # Clean jpg_for_compilation: remove only DERIVED artifacts (symlinks, which
+    # are re-created from caption_and_media each run) and PRESERVE real files.
+    # A blanket `rm -rf` here silently destroyed figures materialized directly
+    # in jpg_for_compilation that have no caption_and_media source to regenerate
+    # from. Surface any such orphan (warn, don't silently keep or delete) so the
+    # user can move it to caption_and_media/ as a tracked source.
     if [ -d "$SCITEX_WRITER_FIGURE_JPG_DIR" ]; then
-        echo_info "Cleaning jpg_for_compilation directory..."
-        rm -rf "${SCITEX_WRITER_FIGURE_JPG_DIR:?}"/*
+        echo_info "Cleaning jpg_for_compilation directory (symlinks; real files preserved)..."
+        find "${SCITEX_WRITER_FIGURE_JPG_DIR:?}" -maxdepth 1 -type l -delete 2>/dev/null
+        for _orphan in "$SCITEX_WRITER_FIGURE_JPG_DIR"/*.jpg; do
+            [ -f "$_orphan" ] || continue
+            local _stem
+            _stem=$(basename "$_orphan" .jpg)
+            if ! ls "$SCITEX_WRITER_FIGURE_CAPTION_MEDIA_DIR/${_stem}".{png,tif,tiff,pptx,mmd,pdf,jpg} >/dev/null 2>&1; then
+                echo_warning "Preserving user-placed $(basename "$_orphan") (no caption_and_media source); move it to caption_and_media/ to track it as a source."
+            fi
+        done
     fi
 }
 

--- a/tests/scripts/shell/modules/test_init_figures_preserve.py
+++ b/tests/scripts/shell/modules/test_init_figures_preserve.py
@@ -1,0 +1,71 @@
+"""init_figures must preserve real user-placed jpgs and only clear derived symlinks."""
+
+import os
+import subprocess
+from pathlib import Path
+
+_COMMON_SRC = (
+    Path(__file__).resolve().parents[4]
+    / "scripts/shell/modules/process_figures_modules/00_common.src"
+)
+
+
+def _run_init_figures(caption_dir, jpg_dir, compiled_dir):
+    env = dict(os.environ)
+    env["SCITEX_WRITER_FIGURE_CAPTION_MEDIA_DIR"] = str(caption_dir)
+    env["SCITEX_WRITER_FIGURE_JPG_DIR"] = str(jpg_dir)
+    env["SCITEX_WRITER_FIGURE_COMPILED_DIR"] = str(compiled_dir)
+    return subprocess.run(
+        ["bash", "-c", f"source '{_COMMON_SRC}'; init_figures"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def test_preserves_user_jpg_without_source(tmp_path):
+    # Arrange
+    caption_dir = tmp_path / "caption_and_media"
+    jpg_dir = caption_dir / "jpg_for_compilation"
+    compiled_dir = tmp_path / "compiled"
+    jpg_dir.mkdir(parents=True)
+    caption_dir.mkdir(exist_ok=True)
+    compiled_dir.mkdir()
+    user_jpg = jpg_dir / "01.jpg"
+    user_jpg.write_bytes(b"\xff\xd8\xff\xe0real-image-bytes")
+    # Act
+    _run_init_figures(caption_dir, jpg_dir, compiled_dir)
+    # Assert
+    assert user_jpg.is_file()
+
+
+def test_removes_derived_symlink(tmp_path):
+    # Arrange
+    caption_dir = tmp_path / "caption_and_media"
+    jpg_dir = caption_dir / "jpg_for_compilation"
+    compiled_dir = tmp_path / "compiled"
+    jpg_dir.mkdir(parents=True)
+    compiled_dir.mkdir()
+    source_jpg = caption_dir / "02.jpg"
+    source_jpg.write_bytes(b"\xff\xd8\xff\xe0source")
+    link = jpg_dir / "02.jpg"
+    link.symlink_to(source_jpg)
+    # Act
+    _run_init_figures(caption_dir, jpg_dir, compiled_dir)
+    # Assert
+    assert not os.path.lexists(link)
+
+
+def test_warns_on_preserved_orphan(tmp_path):
+    # Arrange
+    caption_dir = tmp_path / "caption_and_media"
+    jpg_dir = caption_dir / "jpg_for_compilation"
+    compiled_dir = tmp_path / "compiled"
+    jpg_dir.mkdir(parents=True)
+    compiled_dir.mkdir()
+    (jpg_dir / "03.jpg").write_bytes(b"\xff\xd8\xff\xe0orphan")
+    # Act
+    result = _run_init_figures(caption_dir, jpg_dir, compiled_dir)
+    # Assert
+    assert "Preserving user-placed 03.jpg" in result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- `init_figures` ran a blanket `rm -rf jpg_for_compilation/*` at the start of every figure run, **silently destroying real figures** materialized directly in `jpg_for_compilation/` that have no `caption_and_media/` source to regenerate from. They became 9KB "Missing Figure" placeholders and the PDF embedded **0 images** (repro from neurovista).
- The clean step now removes **only derived symlinks** (which are re-created from `caption_and_media/` each run) and **preserves real files**, emitting a WARN for any orphan jpg (no `caption_and_media/` source) so the user can move it to `caption_and_media/` as a tracked source — no more silent data loss.

## Design
`caption_and_media/0N.{png,tif,jpg,...}` is the figure **source**; `jpg_for_compilation/` is the **derived** dir (symlinks/copies of converted jpgs). Symlinks are safe to clear (re-derived); real regular files are not (may be the only copy). Re-derivation still overwrites preserved files that *do* have a source, so canonical sources continue to win.

## Test plan
- [x] Manual bash validation: orphan jpg preserved + warned, derived symlink removed, source intact.
- [x] Added `tests/scripts/shell/modules/test_init_figures_preserve.py` (drives `init_figures` via subprocess; CI `pytest tests/` covers it — local container has no pytest).
- [ ] CI green on the PR.

Complements #194 (post-compile gate that catches the imgs=0 end-result). Card: `writer-figure-assembler-wipes-jpgs`.