### PR TITLE
chore(release): 2.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.24.2] - 2026-06-30
+
 ### Fixed
 - **Figure assembler no longer destroys user-placed jpgs.** `init_figures`
   previously ran a blanket `rm -rf jpg_for_compilation/*` at the start of every

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.24.1"
+version = "2.24.2"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary
Patch release **2.24.2**.

### Fixed
- Figure assembler no longer destroys user-placed jpgs: `init_figures` now clears only derived symlinks in `jpg_for_compilation/` and preserves real files (warning on orphans), instead of a blanket `rm -rf` that turned directly-materialized figures into "Missing Figure" placeholders (PDF embedded 0 images). (#202)

## Test plan
- [x] pytest-matrix (3.11/3.12/3.13) + quality-audit green on #202.
- [ ] develop→main, tag v2.24.2 → PyPI publish on Spartan runner.