### PR TITLE
Release 2.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.24.2] - 2026-06-30
+
 ### Fixed
 - **Figure assembler no longer destroys user-placed jpgs.** `init_figures`
   previously ran a blanket `rm -rf jpg_for_compilation/*` at the start of every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Figure assembler no longer destroys user-placed jpgs.** `init_figures`
+  previously ran a blanket `rm -rf jpg_for_compilation/*` at the start of every
+  figure run, silently deleting real figures materialized directly in
+  `jpg_for_compilation/` that have no `caption_and_media/` source to regenerate
+  from (they became 9KB "Missing Figure" placeholders → PDF embedded 0 images).
+  The clean step now removes only derived **symlinks** (re-created from
+  `caption_and_media/` each run) and preserves real files, warning about any
+  orphan jpg so it can be moved to `caption_and_media/` as a tracked source.
+
 ## [2.24.0] - 2026-06-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.24.1"
+version = "2.24.2"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/scripts/shell/modules/process_figures_modules/00_common.src
+++ b/scripts/shell/modules/process_figures_modules/00_common.src
@@ -45,10 +45,23 @@ init_figures() {
         rm -f "$SCITEX_WRITER_FIGURE_COMPILED_DIR"/*.tex
     fi
 
-    # Clean jpg_for_compilation directory
+    # Clean jpg_for_compilation: remove only DERIVED artifacts (symlinks, which
+    # are re-created from caption_and_media each run) and PRESERVE real files.
+    # A blanket `rm -rf` here silently destroyed figures materialized directly
+    # in jpg_for_compilation that have no caption_and_media source to regenerate
+    # from. Surface any such orphan (warn, don't silently keep or delete) so the
+    # user can move it to caption_and_media/ as a tracked source.
     if [ -d "$SCITEX_WRITER_FIGURE_JPG_DIR" ]; then
-        echo_info "Cleaning jpg_for_compilation directory..."
-        rm -rf "${SCITEX_WRITER_FIGURE_JPG_DIR:?}"/*
+        echo_info "Cleaning jpg_for_compilation directory (symlinks; real files preserved)..."
+        find "${SCITEX_WRITER_FIGURE_JPG_DIR:?}" -maxdepth 1 -type l -delete 2>/dev/null
+        for _orphan in "$SCITEX_WRITER_FIGURE_JPG_DIR"/*.jpg; do
+            [ -f "$_orphan" ] || continue
+            local _stem
+            _stem=$(basename "$_orphan" .jpg)
+            if ! ls "$SCITEX_WRITER_FIGURE_CAPTION_MEDIA_DIR/${_stem}".{png,tif,tiff,pptx,mmd,pdf,jpg} >/dev/null 2>&1; then
+                echo_warning "Preserving user-placed $(basename "$_orphan") (no caption_and_media source); move it to caption_and_media/ to track it as a source."
+            fi
+        done
     fi
 }
 

--- a/tests/scripts/shell/modules/test_init_figures_preserve.py
+++ b/tests/scripts/shell/modules/test_init_figures_preserve.py
@@ -1,0 +1,71 @@
+"""init_figures must preserve real user-placed jpgs and only clear derived symlinks."""
+
+import os
+import subprocess
+from pathlib import Path
+
+_COMMON_SRC = (
+    Path(__file__).resolve().parents[4]
+    / "scripts/shell/modules/process_figures_modules/00_common.src"
+)
+
+
+def _run_init_figures(caption_dir, jpg_dir, compiled_dir):
+    env = dict(os.environ)
+    env["SCITEX_WRITER_FIGURE_CAPTION_MEDIA_DIR"] = str(caption_dir)
+    env["SCITEX_WRITER_FIGURE_JPG_DIR"] = str(jpg_dir)
+    env["SCITEX_WRITER_FIGURE_COMPILED_DIR"] = str(compiled_dir)
+    return subprocess.run(
+        ["bash", "-c", f"source '{_COMMON_SRC}'; init_figures"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def test_preserves_user_jpg_without_source(tmp_path):
+    # Arrange
+    caption_dir = tmp_path / "caption_and_media"
+    jpg_dir = caption_dir / "jpg_for_compilation"
+    compiled_dir = tmp_path / "compiled"
+    jpg_dir.mkdir(parents=True)
+    caption_dir.mkdir(exist_ok=True)
+    compiled_dir.mkdir()
+    user_jpg = jpg_dir / "01.jpg"
+    user_jpg.write_bytes(b"\xff\xd8\xff\xe0real-image-bytes")
+    # Act
+    _run_init_figures(caption_dir, jpg_dir, compiled_dir)
+    # Assert
+    assert user_jpg.is_file()
+
+
+def test_removes_derived_symlink(tmp_path):
+    # Arrange
+    caption_dir = tmp_path / "caption_and_media"
+    jpg_dir = caption_dir / "jpg_for_compilation"
+    compiled_dir = tmp_path / "compiled"
+    jpg_dir.mkdir(parents=True)
+    compiled_dir.mkdir()
+    source_jpg = caption_dir / "02.jpg"
+    source_jpg.write_bytes(b"\xff\xd8\xff\xe0source")
+    link = jpg_dir / "02.jpg"
+    link.symlink_to(source_jpg)
+    # Act
+    _run_init_figures(caption_dir, jpg_dir, compiled_dir)
+    # Assert
+    assert not os.path.lexists(link)
+
+
+def test_warns_on_preserved_orphan(tmp_path):
+    # Arrange
+    caption_dir = tmp_path / "caption_and_media"
+    jpg_dir = caption_dir / "jpg_for_compilation"
+    compiled_dir = tmp_path / "compiled"
+    jpg_dir.mkdir(parents=True)
+    compiled_dir.mkdir()
+    (jpg_dir / "03.jpg").write_bytes(b"\xff\xd8\xff\xe0orphan")
+    # Act
+    result = _run_init_figures(caption_dir, jpg_dir, compiled_dir)
+    # Assert
+    assert "Preserving user-placed 03.jpg" in result.stdout + result.stderr


### PR DESCRIPTION
## Summary
Promote **2.24.2** to main.

### Fixed
- Figure assembler preserves user-placed jpgs in `jpg_for_compilation/` (clears only derived symlinks, warns on orphans) instead of a blanket `rm -rf` that produced "Missing Figure" placeholders / 0-image PDFs (#202).

Tag `v2.24.2` follows merge → PyPI publish on Spartan.