### PR TITLE
Release 2.24.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.24.3] - 2026-07-01
+
+### Fixed
+- **`claims_rendered.tex` is regenerated fresh on every compile (no stale
+  `\vclaim` values).** The shell compile path (`compile_{manuscript,
+  supplementary,revision}.sh`) never regenerated `00_shared/claims_rendered.tex`
+  from `00_shared/claims.json` (the `\vclaim` value SSoT), so a stale or
+  hand-edited file — e.g. a legacy "CLEW PROTOTYPE" block — could ship outdated
+  values into the PDF. A new "Claims Render" pre-flight stage (`render_claims.sh`
+  / `render_claims.py`) now regenerates it before flattening: a no-op when
+  `claims.json` is absent, and **fail-loud** (non-zero) when it exists but
+  rendering errors. The MCP compile path's `_auto_render_claims` no longer
+  swallows render failures silently — it raises, so a broken `claims.json` can
+  never silently produce a stale `claims_rendered.tex` (#205).
+
 ## [2.24.2] - 2026-06-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.24.2"
+version = "2.24.3"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/scripts/python/render_claims.py
+++ b/scripts/python/render_claims.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/render_claims.py
+# Purpose: Pre-compile generation step -- regenerate 00_shared/claims_rendered.tex
+#          from 00_shared/claims.json (the \vclaim value SSoT) before the
+#          manuscript is flattened. The shell compile path (compile_*.sh) did
+#          NOT regenerate this file, so a stale/hand-edited claims_rendered.tex
+#          could ship outdated \vclaim values (or a legacy prototype block)
+#          into the PDF. render_claims() fully overwrites the file, so running
+#          it here guarantees freshness.
+#
+#          FAIL LOUD: if claims.json exists but rendering fails, exit non-zero
+#          so the compile aborts instead of shipping a stale file. No severity
+#          knob -- a render failure when claims.json is present is always a
+#          defect (malformed JSON / broken claim), unlike the style/policy
+#          checks which a team may legitimately set to warn/off.
+#
+#          No-op (exit 0) when claims.json is absent: claims are optional.
+
+import sys
+from pathlib import Path
+
+
+def main(argv) -> int:
+    project_dir = argv[1] if len(argv) > 1 else "."
+    project_path = Path(project_dir).resolve()
+    claims_json = project_path / "00_shared" / "claims.json"
+
+    if not claims_json.exists():
+        return 0
+
+    try:
+        from scitex_writer._mcp.handlers._claim import render_claims
+    except Exception as exc:  # ImportError or a broken install -- surface it
+        print(
+            f"ERRO:     Cannot import render_claims to regenerate "
+            f"claims_rendered.tex: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    result = render_claims(str(project_path))
+    if not result.get("success"):
+        print(
+            f"ERRO:     Failed to render claims_rendered.tex from {claims_json}: "
+            f"{result.get('error', 'unknown error')}. Fix claims.json or the "
+            f"claim definitions; compiling now would ship a stale "
+            f"claims_rendered.tex.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"INFO:     Rendered claims_rendered.tex "
+        f"({result.get('claims_count', 0)} claims) from claims.json"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))
+
+# EOF

--- a/scripts/shell/compile_manuscript.sh
+++ b/scripts/shell/compile_manuscript.sh
@@ -267,6 +267,15 @@ main() {
     fi
     log_stage_end "Provenance Checks"
 
+    # Regenerate claims_rendered.tex from claims.json (\vclaim SSoT) so a stale
+    # file can never ship outdated values; fails loud if rendering errors.
+    log_stage_start "Claims Render"
+    if ! "$PROJECT_ROOT/scripts/shell/modules/render_claims.sh"; then
+        log_error "Claims render failed (claims.json present but rendering errored) -- fix claims.json; compiling would ship a stale claims_rendered.tex"
+        exit 1
+    fi
+    log_stage_end "Claims Render"
+
     # Merge bibliography files if multiple exist
     log_stage_start "Bibliography Merge"
     "$PROJECT_ROOT/scripts/shell/modules/merge_bibliographies.sh"

--- a/scripts/shell/compile_revision.sh
+++ b/scripts/shell/compile_revision.sh
@@ -227,6 +227,15 @@ parse_arguments() {
     fi
     log_stage_end "Provenance Checks"
 
+    # Regenerate claims_rendered.tex from claims.json (\vclaim SSoT) so a stale
+    # file can never ship outdated values; fails loud if rendering errors.
+    log_stage_start "Claims Render"
+    if ! ./scripts/shell/modules/render_claims.sh; then
+        echo -e "${RED}ERRO: Claims render failed (claims.json present but rendering errored) -- fix claims.json; compiling would ship a stale claims_rendered.tex${NC}"
+        exit 1
+    fi
+    log_stage_end "Claims Render"
+
     # 2. Merge bibliography files if multiple exist
     log_stage_start "Bibliography Merge"
     ./scripts/shell/modules/merge_bibliographies.sh

--- a/scripts/shell/compile_supplementary.sh
+++ b/scripts/shell/compile_supplementary.sh
@@ -234,6 +234,15 @@ main() {
     fi
     log_stage_end "Provenance Checks"
 
+    # Regenerate claims_rendered.tex from claims.json (\vclaim SSoT) so a stale
+    # file can never ship outdated values; fails loud if rendering errors.
+    log_stage_start "Claims Render"
+    if ! ./scripts/shell/modules/render_claims.sh; then
+        log_error "Claims render failed (claims.json present but rendering errored) -- fix claims.json; compiling would ship a stale claims_rendered.tex"
+        exit 1
+    fi
+    log_stage_end "Claims Render"
+
     # Merge bibliography files if multiple exist
     log_stage_start "Bibliography Merge"
     ./scripts/shell/modules/merge_bibliographies.sh

--- a/scripts/shell/modules/render_claims.sh
+++ b/scripts/shell/modules/render_claims.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# File: scripts/shell/modules/render_claims.sh
+#
+# Regenerate 00_shared/claims_rendered.tex from 00_shared/claims.json (the
+# \vclaim value SSoT) before the manuscript is flattened, so the shell compile
+# path can never ship a stale/hand-edited claims_rendered.tex. No-op when
+# claims.json is absent; FAILS LOUD (non-zero) when claims.json exists but
+# rendering errors. Delegates to scripts/python/render_claims.py.
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Honor the PROJECT_ROOT the caller (compile_*.sh) already resolved + exported;
+# fall back to the install-relative root when run standalone.
+PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$THIS_DIR/../../.." && pwd)}"
+PY="${SCITEX_WRITER_PYTHON:-python3}"
+
+exec "$PY" "$PROJECT_ROOT/scripts/python/render_claims.py" "$PROJECT_ROOT"

--- a/src/scitex_writer/_mcp/handlers/_compile.py
+++ b/src/scitex_writer/_mcp/handlers/_compile.py
@@ -8,15 +8,27 @@ from ..utils import resolve_project_path, run_compile_script
 
 
 def _auto_render_claims(project_path) -> None:
-    """Render claims_rendered.tex if claims.json exists (silent, best-effort)."""
-    claims_json = project_path / "00_shared" / "claims.json"
-    if claims_json.exists():
-        try:
-            from ._claim import render_claims
+    """Regenerate claims_rendered.tex from claims.json (\\vclaim SSoT), fail loud.
 
-            render_claims(str(project_path))
-        except Exception:
-            pass  # Never block compilation due to claims rendering
+    claims.json is the source of truth for \\vclaim values; a stale
+    claims_rendered.tex would ship outdated values into the PDF. If claims.json
+    is absent there is nothing to render. If rendering fails, raise rather than
+    compile with a stale file — a render failure when claims.json is present is
+    always a defect (malformed JSON / broken claim definition).
+    """
+    claims_json = project_path / "00_shared" / "claims.json"
+    if not claims_json.exists():
+        return
+    from ._claim import render_claims
+
+    result = render_claims(str(project_path))
+    if not result.get("success"):
+        raise RuntimeError(
+            f"Failed to render claims_rendered.tex from {claims_json}: "
+            f"{result.get('error', 'unknown error')}. Fix claims.json or the "
+            f"claim definitions; compiling now would ship a stale "
+            f"claims_rendered.tex."
+        )
 
 
 def _inject_version_stamp(project_path) -> None:

--- a/tests/scripts/python/test_render_claims.py
+++ b/tests/scripts/python/test_render_claims.py
@@ -1,0 +1,57 @@
+"""render_claims.py pre-compile step regenerates claims_rendered.tex from claims.json."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[3] / "scripts/python/render_claims.py"
+)
+
+
+def _make_project(tmp_path, claims=None):
+    shared = tmp_path / "00_shared"
+    shared.mkdir(parents=True)
+    if claims is not None:
+        (shared / "claims.json").write_text(
+            json.dumps({"version": "1.0", "claims": claims}), encoding="utf-8"
+        )
+    return tmp_path
+
+
+def _run(project_dir):
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), str(project_dir)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_noop_when_no_claims_json(tmp_path):
+    # Arrange
+    project = _make_project(tmp_path, claims=None)
+    # Act
+    result = _run(project)
+    # Assert
+    assert result.returncode == 0 and not (project / "00_shared/claims_rendered.tex").exists()
+
+
+def test_renders_when_claims_json_present(tmp_path):
+    # Arrange
+    project = _make_project(tmp_path, claims={"foo": {"type": "value", "value": {"value": 42, "unit": "ms"}}})
+    # Act
+    _run(project)
+    # Assert
+    assert "\\vclaim" in (project / "00_shared/claims_rendered.tex").read_text(encoding="utf-8")
+
+
+def test_regenerates_stale_file(tmp_path):
+    # Arrange
+    project = _make_project(tmp_path, claims={"foo": {"type": "value", "value": {"value": 1}}})
+    stale = project / "00_shared/claims_rendered.tex"
+    stale.write_text("%% STALE CLEW PROTOTYPE BLOCK\n", encoding="utf-8")
+    # Act
+    _run(project)
+    # Assert
+    assert "STALE CLEW PROTOTYPE" not in stale.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
Promote **2.24.3** to main.

### Fixed
- `claims_rendered.tex` regenerated fresh on every compile (shell + MCP paths), fail-loud on render errors — no stale `\vclaim` values in the PDF (#205).

Tag `v2.24.3` follows merge → PyPI publish on Spartan.