### PR TITLE
feat(compile): fail loud on Spartan login-node compile + point to srun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Fail-loud guard against compiling on a Spartan HPC login node.** Running
+  the TeX toolchain (pdflatex/bibtex/latexmk) on a Spartan login node is
+  prohibited heavy compute (admins kill it; the account can be sanctioned).
+  `compile_{manuscript,supplementary,revision}.sh` now abort early
+  (`check_spartan_login.sh`) when on a `spartan-login*` host with no
+  `SLURM_JOB_ID`, printing the `srun … bash scripts/shell/compile_manuscript.sh`
+  pattern (and the `spartan-tex` helper) instead of a misleading "pdflatex
+  missing"/`127`. The check is hostname-based, so it catches absolute-path
+  `pdflatex` invocations that slip past command-name guards; it is a no-op
+  everywhere else and adds no SLURM coupling to the portable engine (HPC
+  incident 2026-07-01, coordinated with scitex-hpc).
+
 ## [2.24.3] - 2026-07-01
 
 ### Fixed

--- a/scripts/shell/compile_manuscript.sh
+++ b/scripts/shell/compile_manuscript.sh
@@ -252,6 +252,11 @@ main() {
     # Dark mode (black background, white text)
     export SCITEX_WRITER_DARK_MODE=$dark_mode
 
+    # Refuse to compile on a Spartan login node (prohibited heavy compute) —
+    # fail loud with the srun hint BEFORE the toolchain probe, which would
+    # otherwise mis-report the login-node guard's [BLOCKED] as "pdflatex broken".
+    "$PROJECT_ROOT/scripts/shell/modules/check_spartan_login.sh" || exit 1
+
     # Check dependencies
     log_stage_start "Dependency Check"
     "$PROJECT_ROOT/scripts/shell/modules/check_dependancy_commands.sh"

--- a/scripts/shell/compile_revision.sh
+++ b/scripts/shell/compile_revision.sh
@@ -211,6 +211,10 @@ parse_arguments() {
     # Dark mode (black background, white text)
     export SCITEX_WRITER_DARK_MODE=$dark_mode
 
+    # Refuse to compile on a Spartan login node (prohibited heavy compute) —
+    # fail loud with the srun hint before the toolchain probe.
+    ./scripts/shell/modules/check_spartan_login.sh || exit 1
+
     # 1. Check dependencies
     log_stage_start "Dependency Check"
     if ! ./scripts/shell/modules/check_dependancy_commands.sh; then

--- a/scripts/shell/compile_supplementary.sh
+++ b/scripts/shell/compile_supplementary.sh
@@ -221,6 +221,10 @@ main() {
     # Dark mode (black background, white text)
     export SCITEX_WRITER_DARK_MODE=$dark_mode
 
+    # Refuse to compile on a Spartan login node (prohibited heavy compute) —
+    # fail loud with the srun hint before the toolchain probe.
+    ./scripts/shell/modules/check_spartan_login.sh || exit 1
+
     # Check dependencies
     log_stage_start "Dependency Check"
     ./scripts/shell/modules/check_dependancy_commands.sh

--- a/scripts/shell/modules/check_spartan_login.sh
+++ b/scripts/shell/modules/check_spartan_login.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# File: scripts/shell/modules/check_spartan_login.sh
+#
+# Refuse to run the TeX toolchain on a Spartan HPC LOGIN node. Compiling
+# (pdflatex/bibtex/latexmk) on a login node is prohibited heavy compute — admins
+# kill the process and can sanction the account (HPC incident 2026-07-01,
+# scitex-hpc). The login node now also runs a guard that REFUSES the toolchain
+# with exit 100 + "[BLOCKED]" on stderr unless inside a SLURM job.
+#
+# This guard is PORTABLE: it is a no-op everywhere except a Spartan login node
+# with no active SLURM job, and it does NOT bake SLURM into the compile engine —
+# it only DETECTS the prohibited node and aborts with an actionable hint
+# (route the build through srun on a compute node). The SLURM wrapper itself is
+# owned by scitex-hpc's `spartan-tex` helper, not by scitex-writer.
+#
+# Detection (per scitex-hpc, in priority order):
+#   1. hostname matches spartan-login*  (robust, independent of the guard)
+#   2. AND no SLURM_JOB_ID  (bad state = login host outside a job)
+# The guard's own contract (exit 100 / "[BLOCKED]") is the secondary signal if
+# a real compile call is reached without this early check firing.
+
+# Pure predicate: true (0) iff host is a Spartan login node AND not in a SLURM
+# job. Args: $1=hostname, $2=SLURM_JOB_ID. Kept arg-driven so it is testable
+# without spoofing uname/the environment.
+_scitex_on_spartan_login_no_job() {
+    local host="$1"
+    local job="$2"
+    case "$host" in
+        spartan-login*)
+            [ -z "$job" ] && return 0
+            ;;
+    esac
+    return 1
+}
+
+# Guard: abort with an actionable hint when on a Spartan login node outside a
+# SLURM job. Returns 0 (proceed) otherwise. Callers: `scitex_guard_spartan_login || exit 1`.
+scitex_guard_spartan_login() {
+    if _scitex_on_spartan_login_no_job "$(uname -n)" "${SLURM_JOB_ID:-}"; then
+        cat >&2 <<'EOF'
+ERRO:     Refusing to compile on a Spartan LOGIN node — running pdflatex/latexmk
+ERRO:     here is prohibited heavy compute (admins kill it; the account can be
+ERRO:     sanctioned). Re-run the build inside a SLURM job on a COMPUTE node:
+ERRO:
+ERRO:       srun --partition=cascade --qos=publiccpu --time=0:30:00 \
+ERRO:            --cpus-per-task=2 --mem=4G bash scripts/shell/compile_manuscript.sh
+ERRO:
+ERRO:     Run it from the repo on SHARED storage ($HOME or /data, NOT /tmp —
+ERRO:     login and compute nodes do not share /tmp). Quick ad-hoc alternative:
+ERRO:     `spartan-tex <file.tex>` (scitex-hpc helper that wraps a compile in srun).
+EOF
+        return 1
+    fi
+    return 0
+}
+
+# When executed directly (not sourced), run the guard and exit with its code so
+# callers can `"$PROJECT_ROOT/scripts/shell/modules/check_spartan_login.sh" || exit 1`.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    scitex_guard_spartan_login || exit 1
+fi

--- a/tests/scripts/shell/modules/test_check_spartan_login.py
+++ b/tests/scripts/shell/modules/test_check_spartan_login.py
@@ -1,0 +1,53 @@
+"""check_spartan_login.sh refuses TeX on a Spartan login node but is a no-op elsewhere."""
+
+import subprocess
+from pathlib import Path
+
+_MODULE = (
+    Path(__file__).resolve().parents[4]
+    / "scripts/shell/modules/check_spartan_login.sh"
+)
+
+
+def _predicate_rc(host, job):
+    # Source the module and run the pure predicate with controlled args.
+    return subprocess.run(
+        ["bash", "-c", f"source '{_MODULE}'; _scitex_on_spartan_login_no_job '{host}' '{job}'"],
+    ).returncode
+
+
+def test_detects_login_node_without_job():
+    # Arrange
+    host, job = "spartan-login1.hpc.unimelb.edu.au", ""
+    # Act
+    rc = _predicate_rc(host, job)
+    # Assert
+    assert rc == 0
+
+
+def test_allows_login_node_inside_job():
+    # Arrange
+    host, job = "spartan-login1.hpc.unimelb.edu.au", "123456"
+    # Act
+    rc = _predicate_rc(host, job)
+    # Assert
+    assert rc == 1
+
+
+def test_allows_non_spartan_host():
+    # Arrange
+    host, job = "my-laptop", ""
+    # Act
+    rc = _predicate_rc(host, job)
+    # Assert
+    assert rc == 1
+
+
+def test_standalone_guard_is_noop_off_spartan():
+    # Arrange
+    # The CI/test host is not a spartan-login node, so the standalone guard exits 0.
+    cmd = ["bash", str(_MODULE)]
+    # Act
+    result = subprocess.run(cmd)
+    # Assert
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
Running the TeX toolchain on a Spartan HPC **login node** is prohibited heavy compute (admins kill it; the account can be sanctioned — HPC incident 2026-07-01). Today such a run fails confusingly (`latexmk`→127 / a login-node guard's `[BLOCKED]` mis-read as "pdflatex missing"). This adds an early **fail-loud** guard.

## Changes
- New `scripts/shell/modules/check_spartan_login.sh`: aborts when on a `spartan-login*` host with no `SLURM_JOB_ID`, printing the actionable `srun … bash scripts/shell/compile_manuscript.sh` pattern (+ the `spartan-tex` helper). Pure predicate `_scitex_on_spartan_login_no_job host job` for testability.
- Wired as the first stage (before the dependency probe) into `compile_{manuscript,supplementary,revision}.sh`.
- Test `tests/scripts/shell/modules/test_check_spartan_login.py`.

## Design (coordinated with scitex-hpc)
- **Portable**: no-op everywhere except a Spartan login node; **no SLURM baked into the engine** — it only detects + points. The `srun` wrapper stays owned by scitex-hpc's `spartan-tex`.
- **Hostname-based** detection (`uname -n` + `SLURM_JOB_ID`) is invocation-agnostic, so it catches **absolute-path** `pdflatex` calls (`/apps/.../texlive/.../pdflatex`) that slip past command-name guards — the exact vector that bit a consumer.
- Recognizes scitex-hpc's fixed guard contract (exit 100 / `[BLOCKED]`) as the secondary signal.

## Test plan
- [x] Validated locally: predicate (login+no-job→detect; login+in-job→ok; non-spartan→ok); full srun hint prints on a simulated login node; standalone is a no-op off Spartan.
- [ ] CI green (test matrix + quality-audit).

cc @scitex-hpc for review. Card: `writer-spartan-login-node-failloud-srun`.