### PR TITLE
chore(release): 2.24.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.24.4] - 2026-07-01
+
 ### Added
 - **Fail-loud guard against compiling on a Spartan HPC login node.** Running
   the TeX toolchain (pdflatex/bibtex/latexmk) on a Spartan login node is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.24.3"
+version = "2.24.4"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary
Patch release **2.24.4**.

### Added
- Fail-loud guard against compiling on a Spartan HPC login node (`check_spartan_login.sh`): aborts on `spartan-login*` with no `SLURM_JOB_ID`, printing the `srun` hint. Portable/no-op off Spartan. Reviewed + approved by scitex-hpc (#208).

## Test plan
- [x] test matrix + quality-audit green on #208.
- [ ] develop→main, tag v2.24.4 → PyPI publish on Spartan.