### PR TITLE
fix(clew): text-only colophon when icon asset is absent (no compile crash)

### DIFF
--- a/00_shared/latex_styles/clew_presentation.tex
+++ b/00_shared/latex_styles/clew_presentation.tex
@@ -168,9 +168,17 @@
 %% --- bottom-RIGHT colophon + attestation (both carry the snake icon) ---
 %% The snake icon (writer-repo for the colophon, clew-repo for the attestation
 %% per the operator -- same snake on both lines).
+%% Force-expand \clewSigIcon to a LITERAL path before \IfFileExists so the
+%% guard actually tests the file. Passing the bare macro (\IfFileExists{\clewSigIcon})
+%% can leave it unexpanded (texlive vintage / flatten context), so the false
+%% branch never fires and a MISSING icon crashes \includegraphics with
+%% "File `\clewSigIcon ' not found". With the icon absent this now degrades to a
+%% text-only colophon instead of a fatal error.
 \newcommand{\clewColophonIcon}{%
-  \IfFileExists{\clewSigIcon}{%
-    \raisebox{-0.25em}{\includegraphics[height=1em]{\clewSigIcon}}\,}{}}
+  \begingroup\edef\clew@sigiconpath{\clewSigIcon}%
+  \expandafter\IfFileExists\expandafter{\clew@sigiconpath}%
+    {\raisebox{-0.25em}{\includegraphics[height=1em]{\clew@sigiconpath}}\,}{}%
+  \endgroup}
 %% "Compiled by SciTeX Writer." -> writer repo, right-aligned.
 \newcommand{\clewSignature}{%
   \par\vspace{0.8em}%

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Clew colophon/signature no longer crashes the compile when the icon asset
+  is absent.** `\clewColophonIcon` guarded `\includegraphics{\clewSigIcon}` with
+  `\IfFileExists{\clewSigIcon}{…}{}`, but the bare macro could reach the test
+  unexpanded (texlive vintage / flattened context), so the false branch never
+  fired and a missing `\clewSigIcon` (default `docs/scitex-icon-navy-inverted.png`,
+  not vendored) hard-failed with `File \`\clewSigIcon ' not found` whenever the
+  signature/colophon was enabled (`\clewpressignaturetrue`). The path is now
+  force-expanded to a literal before `\IfFileExists`, so an absent icon degrades
+  to a text-only colophon instead of crashing.
+
 ## [2.24.4] - 2026-07-01
 
 ### Added


### PR DESCRIPTION
## Summary
Reported by neurovista (dogfood, 2.24.4): enabling the clew signature/colophon (`\clewpressignaturetrue`) **hard-crashes the compile** when the icon asset is missing — `File \`\clewSigIcon ' not found`.

Root cause: `\clewColophonIcon` guarded `\includegraphics{\clewSigIcon}` with `\IfFileExists{\clewSigIcon}{…}{}`, but the bare macro can reach the test **unexpanded** (texlive vintage / flattened context), so the false branch never fires and a missing `\clewSigIcon` (default `docs/scitex-icon-navy-inverted.png`, which `update-project` does not vendor) is fatal.

## Fix
Force-expand `\clewSigIcon` to a literal path before `\IfFileExists` (and `\includegraphics`):
```
\begingroup\edef\clew@sigiconpath{\clewSigIcon}%
\expandafter\IfFileExists\expandafter{\clew@sigiconpath}{…\includegraphics{\clew@sigiconpath}…}{}%
\endgroup
```
Absent icon → **text-only colophon** (no icon), never a crash. Icon present → renders as before. The badge already degrades safely (fontawesome fallback at line 46 defines `\faCheckCircle`→`[ok]`), so no badge change needed.

## Validation
- LaTeX-macro change — **cannot be exercised by the test CI** (no TeX there). **Needs host-validation by @neurovista** (who has the repro + a Spartan compute node): with `\clewpressignaturetrue` and no icon on disk, confirm the colophon renders text-only and the compile succeeds; with the icon present, confirm it still renders.

Follow-up option (separate): ship the icon asset via `update-project` so the default colophon shows the snake icon — operator's call. This PR only stops the crash.