### PR TITLE
fix(flatten): ignore \begin{document} inside comments when injecting metadata/dark-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Flattener no longer injects before a `\begin{document}` that appears inside
+  a comment.** The build-metadata (`_build_id.inject_build_metadata`) and
+  dark-mode injections targeted `\begin{document}` with a plain `str.replace`,
+  which also matched the literal inside a preamble *comment* (e.g.
+  `clew_presentation.tex`'s "overridable before `\begin{document}`"). With the
+  clew layer active this injected the dark-mode override block mid-preamble —
+  before the base `\newcommand`s (`\REDENDS`/`\hlref` undefined) — and
+  de-commented the comment tail (`\begin{document}) ---` emitted as code →
+  "Missing \begin{document}"), producing ~25 LaTeX errors + page-1 garbage on a
+  reflatten. Both injections now anchor to the real line-start `\begin{document}`
+  (first match only), so a `\begin{document}` inside any comment is ignored.
 - **Clew colophon/signature no longer crashes the compile when the icon asset
   is absent.** `\clewColophonIcon` guarded `\includegraphics{\clewSigIcon}` with
   `\IfFileExists{\clewSigIcon}{…}{}`, but the bare macro could reach the test

--- a/scripts/python/_build_id.py
+++ b/scripts/python/_build_id.py
@@ -154,8 +154,10 @@ def inject_build_metadata(content: str, build_id: str) -> str:
         + "-" * 76
         + "\n"
     )
+    # End with a newline (not a space) so the marker stays at LINE START — a
+    # later line-anchored injection (dark mode) must still be able to find it.
     return marker_re.sub(
-        lambda m: r"\makeatletter " + block + r"\makeatother " + m.group(0),
+        lambda m: "\\makeatletter " + block + "\\makeatother\n" + m.group(0),
         content,
         count=1,
     )

--- a/scripts/python/_build_id.py
+++ b/scripts/python/_build_id.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
@@ -126,8 +127,13 @@ def inject_build_metadata(content: str, build_id: str) -> str:
     ``\scitexBuildIDFootnote`` macros so document templates can opt into
     a tiny footer, colophon, or watermark without further changes here.
     """
-    marker = r"\begin{document}"
-    if marker not in content:
+    # Match the REAL document-body marker at line start, not a \begin{document}
+    # appearing inside a comment (e.g. clew_presentation.tex's "overridable
+    # before \begin{document})"). A plain str.replace(..., 1) hit that earlier
+    # comment occurrence first, injecting the build block mid-preamble and
+    # de-commenting the tail.
+    marker_re = re.compile(r"(?m)^[ \t]*\\begin\{document\}")
+    if marker_re.search(content) is None:
         return content
 
     block = (
@@ -148,8 +154,10 @@ def inject_build_metadata(content: str, build_id: str) -> str:
         + "-" * 76
         + "\n"
     )
-    return content.replace(
-        marker, r"\makeatletter " + block + r"\makeatother " + marker, 1
+    return marker_re.sub(
+        lambda m: r"\makeatletter " + block + r"\makeatother " + m.group(0),
+        content,
+        count=1,
     )
 
 

--- a/scripts/python/compile_tex_structure.py
+++ b/scripts/python/compile_tex_structure.py
@@ -349,11 +349,18 @@ def compile_tex_structure(
             dark_mode_injection = ""
 
         if dark_mode_injection:
-            # Inject dark mode styling before \begin{document}
-            # Leave hyperref/link colors untouched (use document defaults)
-            expanded_content = expanded_content.replace(
-                r"\begin{document}",
-                dark_mode_injection + r"\begin{document}",
+            # Inject dark mode styling before the REAL \begin{document}.
+            # Anchor to a line-start match, first occurrence only: a plain
+            # str.replace() also matched \begin{document} inside COMMENTS (e.g.
+            # clew_presentation.tex's "overridable before \begin{document})"),
+            # injecting the dark-mode block mid-preamble (before base defs ->
+            # "\REDENDS undefined") and de-commenting the tail. A function
+            # replacement keeps backslashes in the injection literal.
+            expanded_content = re.sub(
+                r"(?m)^([ \t]*)\\begin\{document\}",
+                lambda m: dark_mode_injection + m.group(0),
+                expanded_content,
+                count=1,
             )
 
     # Write output

--- a/tests/scripts/python/test_build_id.py
+++ b/tests/scripts/python/test_build_id.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: _build_id.py (inject_build_metadata \begin{document} anchoring)
+
+import sys
+from pathlib import Path
+
+# Add scripts/python to path for imports
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from _build_id import inject_build_metadata  # noqa: E402
+
+# A preamble comment whose text contains \begin{document} (e.g. clew's
+# "overridable before \begin{document})"), appearing BEFORE the real marker.
+_CONTENT = (
+    "\\documentclass{article}\n"
+    "%% --- signature config (overridable before \\begin{document}) ---\n"
+    "\\newcommand{\\foo}{bar}\n"
+    "\\begin{document}\n"
+    "Hello\n"
+    "\\end{document}\n"
+)
+
+
+def test_comment_with_begin_document_is_untouched():
+    # Arrange
+    original_comment = "%% --- signature config (overridable before \\begin{document}) ---"
+    # Act
+    out = inject_build_metadata(_CONTENT, "abc123")
+    # Assert
+    assert original_comment in out.splitlines()
+
+
+def test_metadata_injected_only_once():
+    # Arrange
+    # Act
+    out = inject_build_metadata(_CONTENT, "abc123")
+    # Assert
+    assert out.count("scitex-writer build identifier") == 1
+
+
+def test_metadata_injected_before_real_begin_not_in_comment():
+    # Arrange
+    out = inject_build_metadata(_CONTENT, "abc123")
+    # Act
+    block_pos = out.index("scitex-writer build identifier")
+    comment_pos = out.index("overridable before")
+    # Assert
+    assert block_pos > comment_pos
+
+
+def test_noop_when_only_commented_begin_document():
+    # Arrange
+    only_comment = "\\documentclass{article}\n% see \\begin{document} note\nno real marker\n"
+    # Act
+    out = inject_build_metadata(only_comment, "abc123")
+    # Assert
+    assert out == only_comment


### PR DESCRIPTION
## Summary
Reported by neurovista (dogfood, clew layer active): a reflatten produces ~25 LaTeX errors + page-1 garbage. Root cause: the flattener injects the build-metadata block (`_build_id.inject_build_metadata`) and the dark-mode block by matching `\begin{document}` with a plain `str.replace`, which **also matches the literal inside a preamble comment** — `clew_presentation.tex`'s `%% --- signature config (overridable before \begin{document}) ---`.

Because that comment occurrence is *earlier* than the real marker:
- build-metadata `replace(..., 1)` injected at the **comment** (mid-preamble), de-commenting the tail → `\begin{document}) ---` emitted as code → "Missing \begin{document}".
- dark-mode `replace` (no count) injected the override block (`\renewcommand{\REDENDS}`/`\hlref`) **before** the base `\newcommand`s → "\REDENDS undefined", and duplicated it.

Compile **without** clew is clean (no such comment), which is why this only bit the clew-active path.

## Fix
Both injections now anchor to the **real, line-start** `\begin{document}` (first match only) via `re.sub(r"(?m)^[ \t]*\\begin\{document\}", …, count=1)` with a function replacement (keeps backslashes literal). A `\begin{document}` inside any comment is ignored.

## Test plan
- [x] New `tests/scripts/python/test_build_id.py` (4 cases): comment-with-`\begin{document}` left untouched; metadata injected exactly once; injected before the real marker (not into the comment); no-op when only a commented marker exists. Verified green locally.
- [x] Existing flattener tests unaffected (logic change is the anchor only).
- [ ] CI (test matrix + quality-audit).
- [ ] **Host end-to-end (neurovista):** reflatten with clew active → confirm clean compile (no \REDENDS-undefined, no stray `\begin{document})`), pg1 garbage gone.

Unblocks the live-paper reflatten. Card: `writer-clew-flatten-begin-document-decomment`.