### PR TITLE
chore(release): 2.24.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.24.5] - 2026-07-01
+
 ### Fixed
 - **Flattener no longer injects before a `\begin{document}` that appears inside
   a comment.** The build-metadata (`_build_id.inject_build_metadata`) and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.24.4"
+version = "2.24.5"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Patch 2.24.5: clew colophon icon-guard (#211) + flattener \begin{document}-in-comment fix (#212). Both unit-tested; clew layer opt-in.