### PR TITLE
fix(compile): promote valid PDF on non-fatal engine exit + dedupe bib by cite key

### DIFF
--- a/scripts/python/merge_bibliographies.py
+++ b/scripts/python/merge_bibliographies.py
@@ -67,12 +67,13 @@ def merge_entries(existing: dict, duplicate: dict) -> dict:
 
 def deduplicate_entries(entries: List[dict]) -> tuple[List[dict], dict]:
     """
-    Deduplicate BibTeX entries by DOI and title.
+    Deduplicate BibTeX entries by cite key, DOI, and title.
 
     Returns:
         (unique_entries, stats)
     """
     unique = []
+    id_index = {}  # cite key (entry ID) -> index in unique list
     doi_index = {}  # DOI -> index in unique list
     title_index = {}  # (normalized_title, year) -> index in unique list
     duplicates_found = 0
@@ -83,12 +84,23 @@ def deduplicate_entries(entries: List[dict]) -> tuple[List[dict], dict]:
         title = entry.get("title", "")
         year = entry.get("year", "")
         title_norm = normalize_title(title)
+        cite_key = str(entry.get("ID", "")).strip()
 
         is_duplicate = False
         merge_with_idx = None
 
-        # Check by DOI first (most reliable)
-        if doi and doi in doi_index:
+        # Check by cite key (entry ID) FIRST. A repeated cite key is exactly
+        # what makes bibtex emit "repeated entry" / "I'm skipping whatever
+        # remains of this entry" and drop a whole reference -- so it must never
+        # reach the merged output, regardless of DOI/title. Common with
+        # auto-generated stub entries duplicated across input .bib files.
+        if cite_key and cite_key in id_index:
+            is_duplicate = True
+            merge_with_idx = id_index[cite_key]
+            duplicates_found += 1
+
+        # Check by DOI (most reliable content match)
+        elif doi and doi in doi_index:
             is_duplicate = True
             merge_with_idx = doi_index[doi]
             duplicates_found += 1
@@ -119,6 +131,8 @@ def deduplicate_entries(entries: List[dict]) -> tuple[List[dict], dict]:
             unique.append(entry)
 
             # Index it by position
+            if cite_key:
+                id_index[cite_key] = new_idx
             if doi:
                 doi_index[doi] = new_idx
             if title_norm and year:

--- a/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
+++ b/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
@@ -87,6 +87,24 @@ compiled_tex_to_pdf() {
     return $ret
 }
 
+# Ground-truth page count of the PDF just produced by the engine. pdfTeX writes
+# "Output written on <path> (N pages, ...)" to the .log ONLY when it finalized a
+# PDF this run, so that line is the per-run source of truth (immune to a stale
+# PDF left by a previous successful compile). Falls back to pdfinfo. Prints the
+# page count, or 0 if it cannot be established.
+pdf_produced_pagecount() {
+    local pdf_path="$1"
+    local log_file="${LOG_DIR}/$(basename "${pdf_path%.pdf}").log"
+    local pages=""
+    if [ -f "$log_file" ]; then
+        pages=$(grep -oE "Output written on [^(]*\([0-9]+ page" "$log_file" 2>/dev/null | grep -oE "[0-9]+ page" | grep -oE "^[0-9]+" | tail -1)
+    fi
+    if [ -z "$pages" ] && command -v pdfinfo >/dev/null 2>&1; then
+        pages=$(pdfinfo "$pdf_path" 2>/dev/null | awk '/^Pages:/ {print $2}')
+    fi
+    echo "${pages:-0}"
+}
+
 cleanup() {
     local compile_result=${1:-1}
 
@@ -101,17 +119,40 @@ cleanup() {
     pdf_basename=$(basename "$pdf_file")
     local pdf_in_logs="${LOG_DIR}/${pdf_basename}"
 
+    # Track whether a PDF was produced by THIS run (present in logs/). A stale
+    # PDF from a previous compile is NOT fresh, so it can never be mistaken for
+    # a valid new output below.
+    local fresh_pdf=false
     if [ -f "$pdf_in_logs" ]; then
         # Move PDF from logs/ to final location
         mv "$pdf_in_logs" "$pdf_file"
+        fresh_pdf=true
         log_info "    Moved PDF: $pdf_in_logs -> $pdf_file"
     fi
 
     if [ "$compile_result" -ne 0 ]; then
-        echo_error "    PDF compilation failed (exit code: $compile_result)"
-        # Remove stale PDF from previous compilation to avoid false positive
-        [ -f "$pdf_file" ] && rm -f "$pdf_file"
-        return 1
+        # A non-zero engine exit is NOT always fatal: latexmk returns non-zero
+        # on a non-fatal bibtex warning (e.g. a malformed/stub .bib entry ->
+        # "repeated entry" / "skipping whatever remains" -> exit 12) even when
+        # pdfTeX finalized a complete PDF. Losing a valid multi-page PDF over
+        # one stub reference is worse than shipping it with a warning. So: if a
+        # PDF was freshly produced this run with pages>0, PROMOTE it and
+        # downgrade to WARN; otherwise fail loud (delete stale, return 1).
+        local produced_pages=0
+        if [ "$fresh_pdf" = true ] && [ -f "$pdf_file" ]; then
+            produced_pages=$(pdf_produced_pagecount "$pdf_file")
+        fi
+        if [ "$fresh_pdf" = true ] && [ "${produced_pages:-0}" -gt 0 ] 2>/dev/null; then
+            echo_warning "    Engine exited non-zero (code: $compile_result) but a valid PDF was produced (${produced_pages} pages)."
+            echo_warning "    Promoting $pdf_file anyway — this is usually a non-fatal bib/citation warning (e.g. a stub entry)."
+            echo_warning "    → Fix before submission: inspect ${LOG_DIR}/${pdf_basename%.pdf}.{log,blg} for the offending entry."
+            # Fall through to the promotion/symlink path below.
+        else
+            echo_error "    PDF compilation failed (exit code: $compile_result)"
+            # Remove stale PDF from previous compilation to avoid false positive
+            [ -f "$pdf_file" ] && rm -f "$pdf_file"
+            return 1
+        fi
     fi
 
     if [ -f "$pdf_file" ]; then
@@ -161,6 +202,10 @@ main() {
     cleanup "$compile_result"
 }
 
-main
+# Only auto-run when executed directly, not when sourced (so tests can source
+# the file and exercise pdf_produced_pagecount / cleanup in isolation).
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    main
+fi
 
 # EOF

--- a/tests/scripts/python/test_merge_bibliographies.py
+++ b/tests/scripts/python/test_merge_bibliographies.py
@@ -280,6 +280,50 @@ class TestDeduplicateEntries:
         # Assert
         assert (len(unique) == 1) and (stats['total_input'] == 2) and (stats['unique_output'] == 1) and (stats['duplicates_found'] == 1)
 
+    def test_deduplicate_by_cite_key(self):
+        """Should deduplicate a repeated cite key (bibtex 'repeated entry')."""
+        # Arrange: a stub entry duplicated across input files. No DOI, and the
+        # stub's title/year need not match -- the shared cite key alone is what
+        # breaks bibtex, so it must collapse to one entry.
+        entries = [
+            {"ID": "PintoOrellana2023StatisticalIFF", "title": "Statistical IFF", "year": "2023"},
+            {"ID": "PintoOrellana2023StatisticalIFF", "note": "Auto-generated stub; replace before submission"},
+        ]
+
+        # Act
+        unique, stats = deduplicate_entries(entries)
+
+        # Assert
+        assert (len(unique) == 1) and (stats["duplicates_found"] == 1) and (stats["duplicates_merged"] == 1)
+
+    def test_deduplicate_cite_key_takes_precedence_over_differing_content(self):
+        """A repeated cite key collapses even when DOI/title differ."""
+        # Arrange
+        entries = [
+            {"ID": "dupkey", "doi": "10.1/a", "title": "Title A", "year": "2023"},
+            {"ID": "dupkey", "doi": "10.2/b", "title": "Title B", "year": "2024"},
+        ]
+
+        # Act
+        unique, stats = deduplicate_entries(entries)
+
+        # Assert
+        assert len(unique) == 1
+
+    def test_deduplicate_distinct_cite_keys_kept(self):
+        """Distinct cite keys with no DOI/title overlap must both survive."""
+        # Arrange
+        entries = [
+            {"ID": "keyA", "author": "Alice"},
+            {"ID": "keyB", "author": "Bob"},
+        ]
+
+        # Act
+        unique, stats = deduplicate_entries(entries)
+
+        # Assert
+        assert (len(unique) == 2) and (stats["duplicates_found"] == 0)
+
     def test_deduplicate_by_title_year(self):
         """Should deduplicate by normalized title + year."""
         # Arrange

--- a/tests/scripts/shell/modules/test_compilation_compiled_tex_to_compiled_pdf.sh
+++ b/tests/scripts/shell/modules/test_compilation_compiled_tex_to_compiled_pdf.sh
@@ -3,7 +3,8 @@
 # Test file for: compilation_compiled_tex_to_compiled_pdf.sh
 
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(realpath "$THIS_DIR/../..")"
+ROOT_DIR="$(cd "$THIS_DIR/../../../.." && pwd)"
+MODULE="$ROOT_DIR/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh"
 
 # Test counter
 TESTS_RUN=0
@@ -15,34 +16,74 @@ GREEN='\033[0;32m'
 RED='\033[0;31m'
 NC='\033[0m'
 
-assert_success() {
-    local cmd="$1"
-    local desc="${2:-$cmd}"
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local desc="${3:-}"
     ((TESTS_RUN++))
-    if eval "$cmd" > /dev/null 2>&1; then
+    if [ "$expected" = "$actual" ]; then
         echo -e "${GREEN}✓${NC} $desc"
         ((TESTS_PASSED++))
     else
-        echo -e "${RED}✗${NC} $desc"
+        echo -e "${RED}✗${NC} $desc (expected '$expected', got '$actual')"
         ((TESTS_FAILED++))
     fi
 }
 
-assert_file_exists() {
-    local file="$1"
-    ((TESTS_RUN++))
-    if [ -f "$file" ]; then
-        echo -e "${GREEN}✓${NC} File exists: $file"
-        ((TESTS_PASSED++))
-    else
-        echo -e "${RED}✗${NC} File missing: $file"
-        ((TESTS_FAILED++))
-    fi
+# Source the module for its helper functions. The module guards main() behind a
+# "run only when executed directly" check, so sourcing here does NOT trigger a
+# compile. config/load_config.sh resolves from the repo root; its stderr is
+# irrelevant to the function under test. We override LOG_DIR afterwards.
+setup_module() {
+    export SCITEX_WRITER_DOC_TYPE="${SCITEX_WRITER_DOC_TYPE:-manuscript}"
+    cd "$ROOT_DIR" || return 1
+    # shellcheck source=/dev/null
+    source "$MODULE" >/dev/null 2>&1 || true
 }
 
-# Add your tests here
-test_placeholder() {
-    echo "TODO: Add tests for compilation_compiled_tex_to_compiled_pdf.sh"
+# pdf_produced_pagecount reads the engine .log "Output written on ... (N pages"
+# line, which is the per-run source of truth for whether a valid PDF exists.
+test_pagecount_from_log_multipage() {
+    local tmp
+    tmp="$(mktemp -d)"
+    export LOG_DIR="$tmp"
+    printf 'Output written on %s/manuscript.pdf (25 pages, 4602154 bytes).\n' "$tmp" >"$tmp/manuscript.log"
+    local n
+    n="$(pdf_produced_pagecount "$tmp/manuscript.pdf")"
+    assert_eq "25" "$n" "pdf_produced_pagecount reads 25 pages from log"
+    rm -rf "$tmp"
+}
+
+test_pagecount_from_log_single_page() {
+    local tmp
+    tmp="$(mktemp -d)"
+    export LOG_DIR="$tmp"
+    printf 'Output written on %s/manuscript.pdf (1 page, 1234 bytes).\n' "$tmp" >"$tmp/manuscript.log"
+    local n
+    n="$(pdf_produced_pagecount "$tmp/manuscript.pdf")"
+    assert_eq "1" "$n" "pdf_produced_pagecount reads 1 page from log"
+    rm -rf "$tmp"
+}
+
+test_pagecount_zero_when_no_output_line() {
+    local tmp
+    tmp="$(mktemp -d)"
+    export LOG_DIR="$tmp"
+    printf 'This is pdfTeX; a fatal error occurred, no PDF finalized.\n' >"$tmp/manuscript.log"
+    local n
+    n="$(pdf_produced_pagecount "$tmp/manuscript.pdf")"
+    assert_eq "0" "$n" "pdf_produced_pagecount returns 0 when no Output-written line"
+    rm -rf "$tmp"
+}
+
+test_pagecount_zero_when_no_log() {
+    local tmp
+    tmp="$(mktemp -d)"
+    export LOG_DIR="$tmp"
+    local n
+    n="$(pdf_produced_pagecount "$tmp/manuscript.pdf")"
+    assert_eq "0" "$n" "pdf_produced_pagecount returns 0 when log absent (no PDF, no pdfinfo target)"
+    rm -rf "$tmp"
 }
 
 # Run tests
@@ -50,7 +91,17 @@ main() {
     echo "Testing: compilation_compiled_tex_to_compiled_pdf.sh"
     echo "========================================"
 
-    test_placeholder
+    setup_module
+
+    if ! declare -F pdf_produced_pagecount >/dev/null; then
+        echo -e "${RED}✗${NC} could not source module / pdf_produced_pagecount undefined"
+        exit 1
+    fi
+
+    test_pagecount_from_log_multipage
+    test_pagecount_from_log_single_page
+    test_pagecount_zero_when_no_output_line
+    test_pagecount_zero_when_no_log
 
     echo "========================================"
     echo "Results: $TESTS_PASSED/$TESTS_RUN passed"
@@ -60,153 +111,4 @@ main() {
 
 main "$@"
 
-# --------------------------------------------------------------------------------
-# Start of Source Code from: /home/ywatanabe/proj/scitex-writer/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
-# --------------------------------------------------------------------------------
-# #!/bin/bash
-# # -*- coding: utf-8 -*-
-# # Timestamp: "2025-11-11 23:18:00 (ywatanabe)"
-# # File: ./scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
-# # Main compilation orchestrator - delegates to engine-specific modules
-# 
-# ORIG_DIR="$(pwd)"
-# THIS_DIR="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
-# ENGINES_DIR="${THIS_DIR}/engines"
-# LOG_PATH="$THIS_DIR/.$(basename $0).log"
-# echo > "$LOG_PATH"
-# 
-# GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
-# 
-# GRAY='\033[0;90m'
-# GREEN='\033[0;32m'
-# YELLOW='\033[0;33m'
-# RED='\033[0;31m'
-# NC='\033[0m' # No Color
-# 
-# echo_info() { echo -e "${GRAY}INFO: $1${NC}"; }
-# log_info() {
-#     if [ "${SCITEX_LOG_LEVEL:-1}" -ge 2 ]; then
-#         echo -e "  \033[0;90m→ $1\033[0m"
-#     fi
-# }
-# echo_success() { echo -e "${GREEN}SUCC: $1${NC}"; }
-# echo_warning() { echo -e "${YELLOW}WARN: $1${NC}"; }
-# echo_error() { echo -e "${RED}ERRO: $1${NC}"; }
-# echo_header() { echo_info "=== $1 ==="; }
-# # ---------------------------------------
-# 
-# # Configurations
-# source ./config/load_config.sh $SCITEX_WRITER_DOC_TYPE
-# 
-# # Source engine implementations (use absolute paths to avoid directory confusion)
-# source "${ENGINES_DIR}/compile_tectonic.sh"
-# source "${ENGINES_DIR}/compile_latexmk.sh"
-# source "${ENGINES_DIR}/compile_3pass.sh"
-# 
-# # Logging
-# touch "$LOG_PATH" >/dev/null 2>&1
-# echo
-# log_info "Running $0 ..."
-# 
-# compiled_tex_to_pdf() {
-#     log_info "    Converting $SCITEX_WRITER_COMPILED_TEX to PDF..."
-# 
-#     local tex_file="$SCITEX_WRITER_COMPILED_TEX"
-#     local engine="${SCITEX_WRITER_SELECTED_ENGINE:-3pass}"
-# 
-#     log_info "    Selected engine: $engine"
-# 
-#     # Dispatch to engine-specific implementation
-#     case "$engine" in
-#         tectonic)
-#             compile_with_tectonic "$tex_file"
-#             ;;
-#         latexmk)
-#             compile_with_latexmk "$tex_file"
-#             ;;
-#         3pass)
-#             compile_with_3pass "$tex_file"
-#             ;;
-#         *)
-#             echo_error "    Unknown compilation engine: $engine"
-#             echo_info "    Falling back to 3-pass compilation"
-#             compile_with_3pass "$tex_file"
-#             ;;
-#     esac
-# 
-#     local ret=$?
-# 
-#     # If compilation failed in auto mode, try next engine
-#     if [ $ret -eq 2 ] && [ "$SCITEX_WRITER_ENGINE" = "auto" ]; then
-#         echo_warning "    Engine '$engine' failed, trying fallback..."
-#         # Note: Fallback logic handled by compile_manuscript.sh
-#         # This is just a placeholder for future enhancement
-#     fi
-# 
-#     return $ret
-# }
-# 
-# cleanup() {
-#     # Use fallback if SCITEX_WRITER_COMPILED_PDF is not set or empty
-#     local pdf_file="${SCITEX_WRITER_COMPILED_PDF}"
-#     if [ -z "$pdf_file" ]; then
-#         pdf_file="./01_manuscript/manuscript.pdf"
-#     fi
-# 
-#     # PDF is generated in LOG_DIR, move to final location
-#     local pdf_basename=$(basename "$pdf_file")
-#     local pdf_in_logs="${LOG_DIR}/${pdf_basename}"
-# 
-#     if [ -f "$pdf_in_logs" ]; then
-#         # Move PDF from logs/ to final location
-#         mv "$pdf_in_logs" "$pdf_file"
-#         log_info "    Moved PDF: $pdf_in_logs -> $pdf_file"
-#     fi
-# 
-#     if [ -f "$pdf_file" ]; then
-#         local size=$(du -h "$pdf_file" | cut -f1)
-#         echo_success "    $pdf_file ready (${size})"
-# 
-#         # Create/update stable symlink to latest archive version (prevents corruption during compilation)
-#         local latest_path="${SCITEX_WRITER_ROOT_DIR}/${SCITEX_WRITER_DOC_TYPE}-latest.pdf"
-# 
-#         # Find the latest archived version (highest version number)
-#         local archive_dir="${SCITEX_WRITER_VERSIONS_DIR}"
-#         local latest_archive=$(ls -1 "$archive_dir"/${SCITEX_WRITER_DOC_TYPE}_v[0-9]*.pdf 2>/dev/null | grep -v "_diff.pdf" | sort -V | tail -1)
-# 
-#         if [ -n "$latest_archive" ]; then
-#             # Create relative symlink to archive
-#             ln -sf "archive/$(basename "$latest_archive")" "$latest_path"
-#             echo_success "    Symlink updated: $latest_path -> archive/$(basename "$latest_archive")"
-#         else
-#             # Fallback to current PDF if no archive exists
-#             ln -sf "$(basename "$pdf_file")" "$latest_path"
-#             echo_success "    Symlink updated: $latest_path -> $(basename "$pdf_file") (no archive yet)"
-#         fi
-#         # Note: For rsync, use -L flag to follow symlinks: rsync -avL ...
-# 
-#         sleep 1
-#     else
-#         echo_error "    $pdf_file was not created"
-# 
-#         local log_file="${pdf_file%.pdf}.log"
-#         if [ -f "$log_file" ]; then
-#             echo_error "    LaTeX errors:"
-#             grep "^!" "$log_file" 2>/dev/null | head -5
-#         fi
-# 
-#         return 1
-#     fi
-# }
-# 
-# main() {
-#     compiled_tex_to_pdf
-#     cleanup
-# }
-# 
-# main
-# 
-# # EOF
-# --------------------------------------------------------------------------------
-# End of Source Code from: /home/ywatanabe/proj/scitex-writer/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
-# --------------------------------------------------------------------------------
+# EOF


### PR DESCRIPTION
## Summary
Two dogfood fixes surfaced by neurovista's manuscript compile on a Spartan compute node.

**Ask 1 — promote a valid PDF on non-fatal engine exit.** `latexmk` returns non-zero (exit 12) on a *non-fatal* bibtex warning (e.g. a malformed/stub `.bib` entry → "repeated entry" / "I'm skipping whatever remains of this entry") even when pdfTeX finalized a complete PDF. The old `cleanup()` treated any non-zero exit as fatal, deleted the just-produced PDF, and aborted — losing a valid 25-page PDF over one stub reference.
  - `cleanup()` now: if a PDF was **freshly produced this run** (present in `logs/`) with **pages>0**, promote it and downgrade to a WARN (pointing at `logs/*.{log,blg}` to fix before submission); otherwise fail loud as before.
  - Page count comes from `pdf_produced_pagecount`, which reads pdfTeX's per-run `"Output written on … (N pages"` log line (immune to a stale PDF from a previous compile), with a `pdfinfo` fallback. Gated on `fresh_pdf` so a stale PDF can never be mistaken for new output — the fail-loud-on-no-PDF guarantee (2.23.1 / #188) is preserved.
  - `main` is now guarded (`[ "${BASH_SOURCE[0]}" = "${0}" ]`) so tests can source the module without triggering a compile. The module is invoked as an executable in production, so runtime behavior is unchanged.

**Ask 2 — de-dupe the bib merge by cite key.** `deduplicate_entries` matched only on DOI and (title, year). A stub entry duplicated across input `.bib` files (same cite key, no DOI, differing/absent title) slipped through twice → bibtex "repeated entry" → the failure in Ask 1. Cite key (entry `ID`) is now the **first** dedup key, since a repeated cite key is exactly what breaks bibtex.

Both fixes are pure bash/Python — fully CI-validatable, no TeX render required.

## Test plan
- [x] `test_merge_bibliographies.py`: +3 cases (repeated cite key collapses; cite key precedence over differing DOI/title; distinct keys survive). Logic also validated standalone in-container.
- [x] `test_compilation_compiled_tex_to_compiled_pdf.sh`: +4 cases for `pdf_produced_pagecount` (25-page, 1-page, no-output-line→0, no-log→0). Passes locally; `main`-guard confirmed (sourcing does not compile).
- [ ] CI green (gate — bibtexparser/shellcheck not available in the dev container).

Reported by neurovista (relayed via figrecipe). Ask 3 (dark-mode double-reflatten duplicating the override block) is tracked separately.