### PR TITLE
fix(flatten): idempotent dark-mode + build-id injection on reflatten

### DIFF
--- a/scripts/python/_build_id.py
+++ b/scripts/python/_build_id.py
@@ -119,6 +119,9 @@ def register_build(
         return None
 
 
+BUILD_BLOCK_SENTINEL = "% --- scitex-writer build identifier "
+
+
 def inject_build_metadata(content: str, build_id: str) -> str:
     r"""Inject ``\hypersetup{pdfsubject=build:...}`` before ``\begin{document}``.
 
@@ -136,8 +139,14 @@ def inject_build_metadata(content: str, build_id: str) -> str:
     if marker_re.search(content) is None:
         return content
 
+    # Idempotent: a repeated flatten (e.g. `--dark-mode` reruns the flattener on
+    # already-injected content) must NOT stack a second build block before
+    # \begin{document}. The sentinel comment is unique to this block.
+    if BUILD_BLOCK_SENTINEL in content:
+        return content
+
     block = (
-        "% --- scitex-writer build identifier "
+        BUILD_BLOCK_SENTINEL
         + "-" * 38
         + "\n"
         + f"\\providecommand{{\\scitexBuildID}}{{build:{build_id}}}\n"

--- a/scripts/python/compile_tex_structure.py
+++ b/scripts/python/compile_tex_structure.py
@@ -24,6 +24,10 @@ from _build_id import (  # noqa: E402
 )
 from _tex_signature import generate_signature  # noqa: E402
 
+# Unique marker for the inlined dark-mode block; also used as the idempotency
+# sentinel so a repeated flatten does not stack a second copy.
+DARK_MODE_SENTINEL = "% Dark mode styling (inlined at compile time)"
+
 
 def _is_style_input(input_file: str) -> bool:
     r"""True if an \input target is a preamble style file (latex_styles/)."""
@@ -340,12 +344,17 @@ def compile_tex_structure(
             for old_hex, new_hex in color_subs.items():
                 dark_mode_content = dark_mode_content.replace(old_hex, new_hex)
             dark_mode_injection = (
-                "\n% Dark mode styling (inlined at compile time)\n"
-                + dark_mode_content
-                + "\n"
+                "\n" + DARK_MODE_SENTINEL + "\n" + dark_mode_content + "\n"
             )
         else:
             print(f"WARNING: Dark mode file not found: {dark_mode_file}")
+            dark_mode_injection = ""
+
+        # Idempotent: a repeated flatten (running the flattener again on content
+        # that already carries the dark-mode block) must NOT stack a second copy
+        # before \begin{document} -- that duplicated the override and, pre-fix,
+        # surfaced as \REDENDS/\hlref-undefined and a stray \begin{document}.
+        if DARK_MODE_SENTINEL in expanded_content:
             dark_mode_injection = ""
 
         if dark_mode_injection:

--- a/tests/scripts/python/test_build_id.py
+++ b/tests/scripts/python/test_build_id.py
@@ -57,3 +57,12 @@ def test_noop_when_only_commented_begin_document():
     out = inject_build_metadata(only_comment, "abc123")
     # Assert
     assert out == only_comment
+
+
+def test_idempotent_on_repeated_injection():
+    # Arrange: reflatten scenario -- inject twice on the same content.
+    once = inject_build_metadata(_CONTENT, "abc123")
+    # Act
+    twice = inject_build_metadata(once, "abc123")
+    # Assert: no second block stacked, output unchanged the second time.
+    assert (twice == once) and (twice.count("scitex-writer build identifier") == 1)

--- a/tests/scripts/python/test_compile_tex_structure.py
+++ b/tests/scripts/python/test_compile_tex_structure.py
@@ -459,6 +459,34 @@ class TestCompileTexStructure:
         # Assert
         assert dark_pos < doc_pos
 
+    def test_dark_mode_injection_is_idempotent_on_reflatten(self, tmp_path):
+        """Re-flattening dark-mode output must NOT stack a second dark block."""
+        # Arrange
+        dark_mode_dir = tmp_path / "00_shared" / "latex_styles"
+        dark_mode_dir.mkdir(parents=True)
+        (dark_mode_dir / "dark_mode.tex").write_text(
+            "% Dark mode test content\n\\pagecolor{black}\n\\color{white}"
+        )
+        man_dir = tmp_path / "01_manuscript"
+        man_dir.mkdir(parents=True)
+        base_file = man_dir / "base.tex"
+        base_file.write_text("\\begin{document}\nContent\n\\end{document}")
+        first = man_dir / "first.tex"
+        compile_tex_structure(
+            base_tex=base_file, output_tex=first, verbose=False, dark_mode=True
+        )
+        sentinel = "Dark mode styling (inlined at compile time)"
+        assert first.read_text().count(sentinel) == 1
+
+        # Act: reflatten the already-dark output again with dark_mode=True.
+        second = man_dir / "second.tex"
+        compile_tex_structure(
+            base_tex=first, output_tex=second, verbose=False, dark_mode=True
+        )
+
+        # Assert: still exactly one dark-mode block.
+        assert second.read_text().count(sentinel) == 1
+
 
 def _theme_project(tmp_path, theme):
     """Build a minimal project (config/ + 01_manuscript/base.tex) for theme tests."""

--- a/tests/scripts/python/test_compile_tex_structure.py
+++ b/tests/scripts/python/test_compile_tex_structure.py
@@ -476,7 +476,6 @@ class TestCompileTexStructure:
             base_tex=base_file, output_tex=first, verbose=False, dark_mode=True
         )
         sentinel = "Dark mode styling (inlined at compile time)"
-        assert first.read_text().count(sentinel) == 1
 
         # Act: reflatten the already-dark output again with dark_mode=True.
         second = man_dir / "second.tex"
@@ -484,8 +483,10 @@ class TestCompileTexStructure:
             base_tex=first, output_tex=second, verbose=False, dark_mode=True
         )
 
-        # Assert: still exactly one dark-mode block.
-        assert second.read_text().count(sentinel) == 1
+        # Assert: one block after the first flatten, still one after reflatten.
+        first_count = first.read_text().count(sentinel)
+        second_count = second.read_text().count(sentinel)
+        assert (first_count == 1) and (second_count == 1)
 
 
 def _theme_project(tmp_path, theme):


### PR DESCRIPTION
## Summary
Ask 3 from neurovista's dark-mode compile report (the "SEPARATE known bug"): a repeated `--dark-mode` compile re-runs the flattener on content that already carries the injected blocks, and the injections were **not idempotent** — each run stacked another copy before `\begin{document}`. The duplicated dark-mode override surfaced as `\REDENDS` / `\hlref` undefined + a stray `\begin{document}`; workaround was "don't reflatten twice."

Root cause: both line-anchored injections match the first real `\begin{document}` every run, so re-flattening prepends a second block.

Fix — guard both injections with a unique sentinel:
- `compile_tex_structure.py`: skip dark-mode injection if `DARK_MODE_SENTINEL` (`% Dark mode styling (inlined at compile time)`) is already present.
- `_build_id.py`: `inject_build_metadata` returns content unchanged if `BUILD_BLOCK_SENTINEL` (`% --- scitex-writer build identifier `) is already present. (Same double-injection class of bug — the `\AtBeginDocument{\hypersetup...}` block was being stacked too.)

Both sentinels are extracted to named constants so the marker and the guard can't drift apart. Runtime output for a single flatten is unchanged.

## Test plan
- [x] `test_build_id.py`: +`test_idempotent_on_repeated_injection` (inject twice → identical, one block).
- [x] `test_compile_tex_structure.py`: +`test_dark_mode_injection_is_idempotent_on_reflatten` (compile dark → reflatten dark → exactly one dark block).
- [x] Both validated in-container by calling the real functions twice (pytest unavailable in dev container; CI is the gate for the suite).
- [ ] CI green.

Complements #216 (PDF promotion + bib cite-key de-dupe). Reported by neurovista, relayed via figrecipe.