### PR TITLE
chore(release): 2.24.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.24.6] - 2026-07-01
+
+### Fixed
+- **Compile no longer discards a valid PDF over a non-fatal bibtex/latexmk
+  exit.** `latexmk` returns non-zero (exit 12) on a *non-fatal* bibtex warning
+  (e.g. a malformed/stub `.bib` entry → "repeated entry" / "I'm skipping
+  whatever remains of this entry") even when pdfTeX finalized a complete PDF.
+  `cleanup()` treated any non-zero exit as fatal, deleted the just-produced PDF,
+  and aborted — losing a valid multi-page PDF over one stub reference. It now
+  promotes a PDF that was *freshly produced this run* (present in `logs/`) with
+  pages > 0 — read from pdfTeX's per-run `"Output written on … (N pages"` log
+  line (immune to a stale PDF), with a `pdfinfo` fallback — and downgrades to a
+  WARN pointing at `logs/*.{log,blg}`. The fail-loud-on-no-PDF guarantee
+  (2.23.1) is preserved: a stale PDF can never be mistaken for new output.
+- **Bibliography merge now de-dupes by cite key.** `deduplicate_entries`
+  matched only on DOI and (title, year); a stub entry duplicated across input
+  `.bib` files (same cite key, no DOI, differing/absent title) slipped through
+  twice → bibtex "repeated entry" → dropped reference. Cite key (entry `ID`) is
+  now the first dedup key, since a repeated cite key is exactly what breaks
+  bibtex.
+- **Flattener injections are idempotent on reflatten.** A repeated
+  `--dark-mode` compile re-runs the flattener on content that already carries
+  the injected blocks; the dark-mode and build-id (`_build_id`) injections both
+  matched the first real `\begin{document}` every run and stacked a second copy
+  (duplicated dark-mode override → `\REDENDS`/`\hlref` undefined + stray
+  `\begin{document}`). Both are now guarded by a unique sentinel so a second
+  flatten is a no-op.
+
 ## [2.24.5] - 2026-07-01
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.24.5"
+version = "2.24.6"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary
Patch release bundling the compile-robustness fixes from #216 and #217 (dogfood bugs surfaced by neurovista's dark-mode manuscript compile on Spartan).

- Compile promotes a valid PDF on a non-fatal latexmk/bibtex exit instead of aborting + deleting it (#216).
- Bibliography merge de-dupes by cite key, killing the "repeated entry" bibtex failure at the source (#216).
- Dark-mode + build-id flattener injections are idempotent on reflatten (#217).

Version bump + CHANGELOG only; the fixes are already merged to develop.

## Test plan
- [ ] CI green → merge → develop→main → tag v2.24.6 → PyPI publish.