### PR TITLE
release: 2.24.6 to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.24.6] - 2026-07-01
+
+### Fixed
+- **Compile no longer discards a valid PDF over a non-fatal bibtex/latexmk
+  exit.** `latexmk` returns non-zero (exit 12) on a *non-fatal* bibtex warning
+  (e.g. a malformed/stub `.bib` entry → "repeated entry" / "I'm skipping
+  whatever remains of this entry") even when pdfTeX finalized a complete PDF.
+  `cleanup()` treated any non-zero exit as fatal, deleted the just-produced PDF,
+  and aborted — losing a valid multi-page PDF over one stub reference. It now
+  promotes a PDF that was *freshly produced this run* (present in `logs/`) with
+  pages > 0 — read from pdfTeX's per-run `"Output written on … (N pages"` log
+  line (immune to a stale PDF), with a `pdfinfo` fallback — and downgrades to a
+  WARN pointing at `logs/*.{log,blg}`. The fail-loud-on-no-PDF guarantee
+  (2.23.1) is preserved: a stale PDF can never be mistaken for new output.
+- **Bibliography merge now de-dupes by cite key.** `deduplicate_entries`
+  matched only on DOI and (title, year); a stub entry duplicated across input
+  `.bib` files (same cite key, no DOI, differing/absent title) slipped through
+  twice → bibtex "repeated entry" → dropped reference. Cite key (entry `ID`) is
+  now the first dedup key, since a repeated cite key is exactly what breaks
+  bibtex.
+- **Flattener injections are idempotent on reflatten.** A repeated
+  `--dark-mode` compile re-runs the flattener on content that already carries
+  the injected blocks; the dark-mode and build-id (`_build_id`) injections both
+  matched the first real `\begin{document}` every run and stacked a second copy
+  (duplicated dark-mode override → `\REDENDS`/`\hlref` undefined + stray
+  `\begin{document}`). Both are now guarded by a unique sentinel so a second
+  flatten is a no-op.
+
 ## [2.24.5] - 2026-07-01
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.24.5"
+version = "2.24.6"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/scripts/python/_build_id.py
+++ b/scripts/python/_build_id.py
@@ -119,6 +119,9 @@ def register_build(
         return None
 
 
+BUILD_BLOCK_SENTINEL = "% --- scitex-writer build identifier "
+
+
 def inject_build_metadata(content: str, build_id: str) -> str:
     r"""Inject ``\hypersetup{pdfsubject=build:...}`` before ``\begin{document}``.
 
@@ -136,8 +139,14 @@ def inject_build_metadata(content: str, build_id: str) -> str:
     if marker_re.search(content) is None:
         return content
 
+    # Idempotent: a repeated flatten (e.g. `--dark-mode` reruns the flattener on
+    # already-injected content) must NOT stack a second build block before
+    # \begin{document}. The sentinel comment is unique to this block.
+    if BUILD_BLOCK_SENTINEL in content:
+        return content
+
     block = (
-        "% --- scitex-writer build identifier "
+        BUILD_BLOCK_SENTINEL
         + "-" * 38
         + "\n"
         + f"\\providecommand{{\\scitexBuildID}}{{build:{build_id}}}\n"

--- a/scripts/python/compile_tex_structure.py
+++ b/scripts/python/compile_tex_structure.py
@@ -24,6 +24,10 @@ from _build_id import (  # noqa: E402
 )
 from _tex_signature import generate_signature  # noqa: E402
 
+# Unique marker for the inlined dark-mode block; also used as the idempotency
+# sentinel so a repeated flatten does not stack a second copy.
+DARK_MODE_SENTINEL = "% Dark mode styling (inlined at compile time)"
+
 
 def _is_style_input(input_file: str) -> bool:
     r"""True if an \input target is a preamble style file (latex_styles/)."""
@@ -340,12 +344,17 @@ def compile_tex_structure(
             for old_hex, new_hex in color_subs.items():
                 dark_mode_content = dark_mode_content.replace(old_hex, new_hex)
             dark_mode_injection = (
-                "\n% Dark mode styling (inlined at compile time)\n"
-                + dark_mode_content
-                + "\n"
+                "\n" + DARK_MODE_SENTINEL + "\n" + dark_mode_content + "\n"
             )
         else:
             print(f"WARNING: Dark mode file not found: {dark_mode_file}")
+            dark_mode_injection = ""
+
+        # Idempotent: a repeated flatten (running the flattener again on content
+        # that already carries the dark-mode block) must NOT stack a second copy
+        # before \begin{document} -- that duplicated the override and, pre-fix,
+        # surfaced as \REDENDS/\hlref-undefined and a stray \begin{document}.
+        if DARK_MODE_SENTINEL in expanded_content:
             dark_mode_injection = ""
 
         if dark_mode_injection:

--- a/scripts/python/merge_bibliographies.py
+++ b/scripts/python/merge_bibliographies.py
@@ -67,12 +67,13 @@ def merge_entries(existing: dict, duplicate: dict) -> dict:
 
 def deduplicate_entries(entries: List[dict]) -> tuple[List[dict], dict]:
     """
-    Deduplicate BibTeX entries by DOI and title.
+    Deduplicate BibTeX entries by cite key, DOI, and title.
 
     Returns:
         (unique_entries, stats)
     """
     unique = []
+    id_index = {}  # cite key (entry ID) -> index in unique list
     doi_index = {}  # DOI -> index in unique list
     title_index = {}  # (normalized_title, year) -> index in unique list
     duplicates_found = 0
@@ -83,12 +84,23 @@ def deduplicate_entries(entries: List[dict]) -> tuple[List[dict], dict]:
         title = entry.get("title", "")
         year = entry.get("year", "")
         title_norm = normalize_title(title)
+        cite_key = str(entry.get("ID", "")).strip()
 
         is_duplicate = False
         merge_with_idx = None
 
-        # Check by DOI first (most reliable)
-        if doi and doi in doi_index:
+        # Check by cite key (entry ID) FIRST. A repeated cite key is exactly
+        # what makes bibtex emit "repeated entry" / "I'm skipping whatever
+        # remains of this entry" and drop a whole reference -- so it must never
+        # reach the merged output, regardless of DOI/title. Common with
+        # auto-generated stub entries duplicated across input .bib files.
+        if cite_key and cite_key in id_index:
+            is_duplicate = True
+            merge_with_idx = id_index[cite_key]
+            duplicates_found += 1
+
+        # Check by DOI (most reliable content match)
+        elif doi and doi in doi_index:
             is_duplicate = True
             merge_with_idx = doi_index[doi]
             duplicates_found += 1
@@ -119,6 +131,8 @@ def deduplicate_entries(entries: List[dict]) -> tuple[List[dict], dict]:
             unique.append(entry)
 
             # Index it by position
+            if cite_key:
+                id_index[cite_key] = new_idx
             if doi:
                 doi_index[doi] = new_idx
             if title_norm and year:

--- a/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
+++ b/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
@@ -87,6 +87,24 @@ compiled_tex_to_pdf() {
     return $ret
 }
 
+# Ground-truth page count of the PDF just produced by the engine. pdfTeX writes
+# "Output written on <path> (N pages, ...)" to the .log ONLY when it finalized a
+# PDF this run, so that line is the per-run source of truth (immune to a stale
+# PDF left by a previous successful compile). Falls back to pdfinfo. Prints the
+# page count, or 0 if it cannot be established.
+pdf_produced_pagecount() {
+    local pdf_path="$1"
+    local log_file="${LOG_DIR}/$(basename "${pdf_path%.pdf}").log"
+    local pages=""
+    if [ -f "$log_file" ]; then
+        pages=$(grep -oE "Output written on [^(]*\([0-9]+ page" "$log_file" 2>/dev/null | grep -oE "[0-9]+ page" | grep -oE "^[0-9]+" | tail -1)
+    fi
+    if [ -z "$pages" ] && command -v pdfinfo >/dev/null 2>&1; then
+        pages=$(pdfinfo "$pdf_path" 2>/dev/null | awk '/^Pages:/ {print $2}')
+    fi
+    echo "${pages:-0}"
+}
+
 cleanup() {
     local compile_result=${1:-1}
 
@@ -101,17 +119,40 @@ cleanup() {
     pdf_basename=$(basename "$pdf_file")
     local pdf_in_logs="${LOG_DIR}/${pdf_basename}"
 
+    # Track whether a PDF was produced by THIS run (present in logs/). A stale
+    # PDF from a previous compile is NOT fresh, so it can never be mistaken for
+    # a valid new output below.
+    local fresh_pdf=false
     if [ -f "$pdf_in_logs" ]; then
         # Move PDF from logs/ to final location
         mv "$pdf_in_logs" "$pdf_file"
+        fresh_pdf=true
         log_info "    Moved PDF: $pdf_in_logs -> $pdf_file"
     fi
 
     if [ "$compile_result" -ne 0 ]; then
-        echo_error "    PDF compilation failed (exit code: $compile_result)"
-        # Remove stale PDF from previous compilation to avoid false positive
-        [ -f "$pdf_file" ] && rm -f "$pdf_file"
-        return 1
+        # A non-zero engine exit is NOT always fatal: latexmk returns non-zero
+        # on a non-fatal bibtex warning (e.g. a malformed/stub .bib entry ->
+        # "repeated entry" / "skipping whatever remains" -> exit 12) even when
+        # pdfTeX finalized a complete PDF. Losing a valid multi-page PDF over
+        # one stub reference is worse than shipping it with a warning. So: if a
+        # PDF was freshly produced this run with pages>0, PROMOTE it and
+        # downgrade to WARN; otherwise fail loud (delete stale, return 1).
+        local produced_pages=0
+        if [ "$fresh_pdf" = true ] && [ -f "$pdf_file" ]; then
+            produced_pages=$(pdf_produced_pagecount "$pdf_file")
+        fi
+        if [ "$fresh_pdf" = true ] && [ "${produced_pages:-0}" -gt 0 ] 2>/dev/null; then
+            echo_warning "    Engine exited non-zero (code: $compile_result) but a valid PDF was produced (${produced_pages} pages)."
+            echo_warning "    Promoting $pdf_file anyway — this is usually a non-fatal bib/citation warning (e.g. a stub entry)."
+            echo_warning "    → Fix before submission: inspect ${LOG_DIR}/${pdf_basename%.pdf}.{log,blg} for the offending entry."
+            # Fall through to the promotion/symlink path below.
+        else
+            echo_error "    PDF compilation failed (exit code: $compile_result)"
+            # Remove stale PDF from previous compilation to avoid false positive
+            [ -f "$pdf_file" ] && rm -f "$pdf_file"
+            return 1
+        fi
     fi
 
     if [ -f "$pdf_file" ]; then
@@ -161,6 +202,10 @@ main() {
     cleanup "$compile_result"
 }
 
-main
+# Only auto-run when executed directly, not when sourced (so tests can source
+# the file and exercise pdf_produced_pagecount / cleanup in isolation).
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    main
+fi
 
 # EOF

--- a/tests/scripts/python/test_build_id.py
+++ b/tests/scripts/python/test_build_id.py
@@ -57,3 +57,12 @@ def test_noop_when_only_commented_begin_document():
     out = inject_build_metadata(only_comment, "abc123")
     # Assert
     assert out == only_comment
+
+
+def test_idempotent_on_repeated_injection():
+    # Arrange: reflatten scenario -- inject twice on the same content.
+    once = inject_build_metadata(_CONTENT, "abc123")
+    # Act
+    twice = inject_build_metadata(once, "abc123")
+    # Assert: no second block stacked, output unchanged the second time.
+    assert (twice == once) and (twice.count("scitex-writer build identifier") == 1)

--- a/tests/scripts/python/test_compile_tex_structure.py
+++ b/tests/scripts/python/test_compile_tex_structure.py
@@ -459,6 +459,34 @@ class TestCompileTexStructure:
         # Assert
         assert dark_pos < doc_pos
 
+    def test_dark_mode_injection_is_idempotent_on_reflatten(self, tmp_path):
+        """Re-flattening dark-mode output must NOT stack a second dark block."""
+        # Arrange
+        dark_mode_dir = tmp_path / "00_shared" / "latex_styles"
+        dark_mode_dir.mkdir(parents=True)
+        (dark_mode_dir / "dark_mode.tex").write_text(
+            "% Dark mode test content\n\\pagecolor{black}\n\\color{white}"
+        )
+        man_dir = tmp_path / "01_manuscript"
+        man_dir.mkdir(parents=True)
+        base_file = man_dir / "base.tex"
+        base_file.write_text("\\begin{document}\nContent\n\\end{document}")
+        first = man_dir / "first.tex"
+        compile_tex_structure(
+            base_tex=base_file, output_tex=first, verbose=False, dark_mode=True
+        )
+        sentinel = "Dark mode styling (inlined at compile time)"
+        assert first.read_text().count(sentinel) == 1
+
+        # Act: reflatten the already-dark output again with dark_mode=True.
+        second = man_dir / "second.tex"
+        compile_tex_structure(
+            base_tex=first, output_tex=second, verbose=False, dark_mode=True
+        )
+
+        # Assert: still exactly one dark-mode block.
+        assert second.read_text().count(sentinel) == 1
+
 
 def _theme_project(tmp_path, theme):
     """Build a minimal project (config/ + 01_manuscript/base.tex) for theme tests."""

--- a/tests/scripts/python/test_compile_tex_structure.py
+++ b/tests/scripts/python/test_compile_tex_structure.py
@@ -476,7 +476,6 @@ class TestCompileTexStructure:
             base_tex=base_file, output_tex=first, verbose=False, dark_mode=True
         )
         sentinel = "Dark mode styling (inlined at compile time)"
-        assert first.read_text().count(sentinel) == 1
 
         # Act: reflatten the already-dark output again with dark_mode=True.
         second = man_dir / "second.tex"
@@ -484,8 +483,10 @@ class TestCompileTexStructure:
             base_tex=first, output_tex=second, verbose=False, dark_mode=True
         )
 
-        # Assert: still exactly one dark-mode block.
-        assert second.read_text().count(sentinel) == 1
+        # Assert: one block after the first flatten, still one after reflatten.
+        first_count = first.read_text().count(sentinel)
+        second_count = second.read_text().count(sentinel)
+        assert (first_count == 1) and (second_count == 1)
 
 
 def _theme_project(tmp_path, theme):

--- a/tests/scripts/python/test_merge_bibliographies.py
+++ b/tests/scripts/python/test_merge_bibliographies.py
@@ -280,6 +280,50 @@ class TestDeduplicateEntries:
         # Assert
         assert (len(unique) == 1) and (stats['total_input'] == 2) and (stats['unique_output'] == 1) and (stats['duplicates_found'] == 1)
 
+    def test_deduplicate_by_cite_key(self):
+        """Should deduplicate a repeated cite key (bibtex 'repeated entry')."""
+        # Arrange: a stub entry duplicated across input files. No DOI, and the
+        # stub's title/year need not match -- the shared cite key alone is what
+        # breaks bibtex, so it must collapse to one entry.
+        entries = [
+            {"ID": "PintoOrellana2023StatisticalIFF", "title": "Statistical IFF", "year": "2023"},
+            {"ID": "PintoOrellana2023StatisticalIFF", "note": "Auto-generated stub; replace before submission"},
+        ]
+
+        # Act
+        unique, stats = deduplicate_entries(entries)
+
+        # Assert
+        assert (len(unique) == 1) and (stats["duplicates_found"] == 1) and (stats["duplicates_merged"] == 1)
+
+    def test_deduplicate_cite_key_takes_precedence_over_differing_content(self):
+        """A repeated cite key collapses even when DOI/title differ."""
+        # Arrange
+        entries = [
+            {"ID": "dupkey", "doi": "10.1/a", "title": "Title A", "year": "2023"},
+            {"ID": "dupkey", "doi": "10.2/b", "title": "Title B", "year": "2024"},
+        ]
+
+        # Act
+        unique, stats = deduplicate_entries(entries)
+
+        # Assert
+        assert len(unique) == 1
+
+    def test_deduplicate_distinct_cite_keys_kept(self):
+        """Distinct cite keys with no DOI/title overlap must both survive."""
+        # Arrange
+        entries = [
+            {"ID": "keyA", "author": "Alice"},
+            {"ID": "keyB", "author": "Bob"},
+        ]
+
+        # Act
+        unique, stats = deduplicate_entries(entries)
+
+        # Assert
+        assert (len(unique) == 2) and (stats["duplicates_found"] == 0)
+
     def test_deduplicate_by_title_year(self):
         """Should deduplicate by normalized title + year."""
         # Arrange

--- a/tests/scripts/shell/modules/test_compilation_compiled_tex_to_compiled_pdf.sh
+++ b/tests/scripts/shell/modules/test_compilation_compiled_tex_to_compiled_pdf.sh
@@ -3,7 +3,8 @@
 # Test file for: compilation_compiled_tex_to_compiled_pdf.sh
 
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(realpath "$THIS_DIR/../..")"
+ROOT_DIR="$(cd "$THIS_DIR/../../../.." && pwd)"
+MODULE="$ROOT_DIR/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh"
 
 # Test counter
 TESTS_RUN=0
@@ -15,34 +16,74 @@ GREEN='\033[0;32m'
 RED='\033[0;31m'
 NC='\033[0m'
 
-assert_success() {
-    local cmd="$1"
-    local desc="${2:-$cmd}"
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local desc="${3:-}"
     ((TESTS_RUN++))
-    if eval "$cmd" > /dev/null 2>&1; then
+    if [ "$expected" = "$actual" ]; then
         echo -e "${GREEN}✓${NC} $desc"
         ((TESTS_PASSED++))
     else
-        echo -e "${RED}✗${NC} $desc"
+        echo -e "${RED}✗${NC} $desc (expected '$expected', got '$actual')"
         ((TESTS_FAILED++))
     fi
 }
 
-assert_file_exists() {
-    local file="$1"
-    ((TESTS_RUN++))
-    if [ -f "$file" ]; then
-        echo -e "${GREEN}✓${NC} File exists: $file"
-        ((TESTS_PASSED++))
-    else
-        echo -e "${RED}✗${NC} File missing: $file"
-        ((TESTS_FAILED++))
-    fi
+# Source the module for its helper functions. The module guards main() behind a
+# "run only when executed directly" check, so sourcing here does NOT trigger a
+# compile. config/load_config.sh resolves from the repo root; its stderr is
+# irrelevant to the function under test. We override LOG_DIR afterwards.
+setup_module() {
+    export SCITEX_WRITER_DOC_TYPE="${SCITEX_WRITER_DOC_TYPE:-manuscript}"
+    cd "$ROOT_DIR" || return 1
+    # shellcheck source=/dev/null
+    source "$MODULE" >/dev/null 2>&1 || true
 }
 
-# Add your tests here
-test_placeholder() {
-    echo "TODO: Add tests for compilation_compiled_tex_to_compiled_pdf.sh"
+# pdf_produced_pagecount reads the engine .log "Output written on ... (N pages"
+# line, which is the per-run source of truth for whether a valid PDF exists.
+test_pagecount_from_log_multipage() {
+    local tmp
+    tmp="$(mktemp -d)"
+    export LOG_DIR="$tmp"
+    printf 'Output written on %s/manuscript.pdf (25 pages, 4602154 bytes).\n' "$tmp" >"$tmp/manuscript.log"
+    local n
+    n="$(pdf_produced_pagecount "$tmp/manuscript.pdf")"
+    assert_eq "25" "$n" "pdf_produced_pagecount reads 25 pages from log"
+    rm -rf "$tmp"
+}
+
+test_pagecount_from_log_single_page() {
+    local tmp
+    tmp="$(mktemp -d)"
+    export LOG_DIR="$tmp"
+    printf 'Output written on %s/manuscript.pdf (1 page, 1234 bytes).\n' "$tmp" >"$tmp/manuscript.log"
+    local n
+    n="$(pdf_produced_pagecount "$tmp/manuscript.pdf")"
+    assert_eq "1" "$n" "pdf_produced_pagecount reads 1 page from log"
+    rm -rf "$tmp"
+}
+
+test_pagecount_zero_when_no_output_line() {
+    local tmp
+    tmp="$(mktemp -d)"
+    export LOG_DIR="$tmp"
+    printf 'This is pdfTeX; a fatal error occurred, no PDF finalized.\n' >"$tmp/manuscript.log"
+    local n
+    n="$(pdf_produced_pagecount "$tmp/manuscript.pdf")"
+    assert_eq "0" "$n" "pdf_produced_pagecount returns 0 when no Output-written line"
+    rm -rf "$tmp"
+}
+
+test_pagecount_zero_when_no_log() {
+    local tmp
+    tmp="$(mktemp -d)"
+    export LOG_DIR="$tmp"
+    local n
+    n="$(pdf_produced_pagecount "$tmp/manuscript.pdf")"
+    assert_eq "0" "$n" "pdf_produced_pagecount returns 0 when log absent (no PDF, no pdfinfo target)"
+    rm -rf "$tmp"
 }
 
 # Run tests
@@ -50,7 +91,17 @@ main() {
     echo "Testing: compilation_compiled_tex_to_compiled_pdf.sh"
     echo "========================================"
 
-    test_placeholder
+    setup_module
+
+    if ! declare -F pdf_produced_pagecount >/dev/null; then
+        echo -e "${RED}✗${NC} could not source module / pdf_produced_pagecount undefined"
+        exit 1
+    fi
+
+    test_pagecount_from_log_multipage
+    test_pagecount_from_log_single_page
+    test_pagecount_zero_when_no_output_line
+    test_pagecount_zero_when_no_log
 
     echo "========================================"
     echo "Results: $TESTS_PASSED/$TESTS_RUN passed"
@@ -60,153 +111,4 @@ main() {
 
 main "$@"
 
-# --------------------------------------------------------------------------------
-# Start of Source Code from: /home/ywatanabe/proj/scitex-writer/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
-# --------------------------------------------------------------------------------
-# #!/bin/bash
-# # -*- coding: utf-8 -*-
-# # Timestamp: "2025-11-11 23:18:00 (ywatanabe)"
-# # File: ./scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
-# # Main compilation orchestrator - delegates to engine-specific modules
-# 
-# ORIG_DIR="$(pwd)"
-# THIS_DIR="$(cd $(dirname ${BASH_SOURCE[0]}) && pwd)"
-# ENGINES_DIR="${THIS_DIR}/engines"
-# LOG_PATH="$THIS_DIR/.$(basename $0).log"
-# echo > "$LOG_PATH"
-# 
-# GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
-# 
-# GRAY='\033[0;90m'
-# GREEN='\033[0;32m'
-# YELLOW='\033[0;33m'
-# RED='\033[0;31m'
-# NC='\033[0m' # No Color
-# 
-# echo_info() { echo -e "${GRAY}INFO: $1${NC}"; }
-# log_info() {
-#     if [ "${SCITEX_LOG_LEVEL:-1}" -ge 2 ]; then
-#         echo -e "  \033[0;90m→ $1\033[0m"
-#     fi
-# }
-# echo_success() { echo -e "${GREEN}SUCC: $1${NC}"; }
-# echo_warning() { echo -e "${YELLOW}WARN: $1${NC}"; }
-# echo_error() { echo -e "${RED}ERRO: $1${NC}"; }
-# echo_header() { echo_info "=== $1 ==="; }
-# # ---------------------------------------
-# 
-# # Configurations
-# source ./config/load_config.sh $SCITEX_WRITER_DOC_TYPE
-# 
-# # Source engine implementations (use absolute paths to avoid directory confusion)
-# source "${ENGINES_DIR}/compile_tectonic.sh"
-# source "${ENGINES_DIR}/compile_latexmk.sh"
-# source "${ENGINES_DIR}/compile_3pass.sh"
-# 
-# # Logging
-# touch "$LOG_PATH" >/dev/null 2>&1
-# echo
-# log_info "Running $0 ..."
-# 
-# compiled_tex_to_pdf() {
-#     log_info "    Converting $SCITEX_WRITER_COMPILED_TEX to PDF..."
-# 
-#     local tex_file="$SCITEX_WRITER_COMPILED_TEX"
-#     local engine="${SCITEX_WRITER_SELECTED_ENGINE:-3pass}"
-# 
-#     log_info "    Selected engine: $engine"
-# 
-#     # Dispatch to engine-specific implementation
-#     case "$engine" in
-#         tectonic)
-#             compile_with_tectonic "$tex_file"
-#             ;;
-#         latexmk)
-#             compile_with_latexmk "$tex_file"
-#             ;;
-#         3pass)
-#             compile_with_3pass "$tex_file"
-#             ;;
-#         *)
-#             echo_error "    Unknown compilation engine: $engine"
-#             echo_info "    Falling back to 3-pass compilation"
-#             compile_with_3pass "$tex_file"
-#             ;;
-#     esac
-# 
-#     local ret=$?
-# 
-#     # If compilation failed in auto mode, try next engine
-#     if [ $ret -eq 2 ] && [ "$SCITEX_WRITER_ENGINE" = "auto" ]; then
-#         echo_warning "    Engine '$engine' failed, trying fallback..."
-#         # Note: Fallback logic handled by compile_manuscript.sh
-#         # This is just a placeholder for future enhancement
-#     fi
-# 
-#     return $ret
-# }
-# 
-# cleanup() {
-#     # Use fallback if SCITEX_WRITER_COMPILED_PDF is not set or empty
-#     local pdf_file="${SCITEX_WRITER_COMPILED_PDF}"
-#     if [ -z "$pdf_file" ]; then
-#         pdf_file="./01_manuscript/manuscript.pdf"
-#     fi
-# 
-#     # PDF is generated in LOG_DIR, move to final location
-#     local pdf_basename=$(basename "$pdf_file")
-#     local pdf_in_logs="${LOG_DIR}/${pdf_basename}"
-# 
-#     if [ -f "$pdf_in_logs" ]; then
-#         # Move PDF from logs/ to final location
-#         mv "$pdf_in_logs" "$pdf_file"
-#         log_info "    Moved PDF: $pdf_in_logs -> $pdf_file"
-#     fi
-# 
-#     if [ -f "$pdf_file" ]; then
-#         local size=$(du -h "$pdf_file" | cut -f1)
-#         echo_success "    $pdf_file ready (${size})"
-# 
-#         # Create/update stable symlink to latest archive version (prevents corruption during compilation)
-#         local latest_path="${SCITEX_WRITER_ROOT_DIR}/${SCITEX_WRITER_DOC_TYPE}-latest.pdf"
-# 
-#         # Find the latest archived version (highest version number)
-#         local archive_dir="${SCITEX_WRITER_VERSIONS_DIR}"
-#         local latest_archive=$(ls -1 "$archive_dir"/${SCITEX_WRITER_DOC_TYPE}_v[0-9]*.pdf 2>/dev/null | grep -v "_diff.pdf" | sort -V | tail -1)
-# 
-#         if [ -n "$latest_archive" ]; then
-#             # Create relative symlink to archive
-#             ln -sf "archive/$(basename "$latest_archive")" "$latest_path"
-#             echo_success "    Symlink updated: $latest_path -> archive/$(basename "$latest_archive")"
-#         else
-#             # Fallback to current PDF if no archive exists
-#             ln -sf "$(basename "$pdf_file")" "$latest_path"
-#             echo_success "    Symlink updated: $latest_path -> $(basename "$pdf_file") (no archive yet)"
-#         fi
-#         # Note: For rsync, use -L flag to follow symlinks: rsync -avL ...
-# 
-#         sleep 1
-#     else
-#         echo_error "    $pdf_file was not created"
-# 
-#         local log_file="${pdf_file%.pdf}.log"
-#         if [ -f "$log_file" ]; then
-#             echo_error "    LaTeX errors:"
-#             grep "^!" "$log_file" 2>/dev/null | head -5
-#         fi
-# 
-#         return 1
-#     fi
-# }
-# 
-# main() {
-#     compiled_tex_to_pdf
-#     cleanup
-# }
-# 
-# main
-# 
-# # EOF
-# --------------------------------------------------------------------------------
-# End of Source Code from: /home/ywatanabe/proj/scitex-writer/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
-# --------------------------------------------------------------------------------
+# EOF


### PR DESCRIPTION
## Summary
Promote 2.24.6 to main. Bundles the compile-robustness fixes surfaced by neurovista's dark-mode manuscript compile:
- #216 — PDF promotion tolerates non-fatal latexmk/bibtex exit; bib merge de-dupes by cite key.
- #217 — dark-mode + build-id flattener injections idempotent on reflatten.
- #218 — version bump + CHANGELOG.

Tag v2.24.6 after merge → PyPI publish.