### PR TITLE
feat(compile): citation stub gate — fail research builds on unresolved \cite stubs

### DIFF
--- a/scripts/python/check_citations.py
+++ b/scripts/python/check_citations.py
@@ -18,6 +18,13 @@
 #          same report once clew defines its batch lookup; until then this gate
 #          catches the stub stamps scholar already writes.
 #
+#          The gate reads the bib that bibtex actually reads: it parses the
+#          \bibliography{}/\addbibresource{} target from the tex and resolves it
+#          relative to the tex, FOLLOWING SYMLINKS (real trees point
+#          contents/bibliography.bib at a possibly-legacy enriched bib, not
+#          necessarily 00_shared). --bib overrides; conventional fallbacks apply
+#          only when no \bibliography target is found.
+#
 #          A STUB is detected by the markers scholar stamps into the entry:
 #            * note    contains "Auto-generated stub"   (STUB_NOTE_MARKERS)
 #            * journal contains "Pending scitex-scholar metadata lookup"
@@ -79,7 +86,16 @@ _CITE_CMD = (
 # Optional [..] pre/post-notes, then the mandatory {key,key,...}.
 _CITE_RE = re.compile(_CITE_CMD + r"\s*(?:\[[^\]]*\]\s*){0,2}\{([^}]*)\}")
 
-_DEFAULT_BIB = "00_shared/bib_files/bibliography.bib"
+# \bibliography{a,b} (bibtex) and \addbibresource{a.bib} (biblatex).
+_BIB_CMD_RE = re.compile(r"\\(?:bibliography|addbibresource)\s*\{([^}]*)\}")
+
+# Conventional fallbacks, tried (and symlink-resolved) when no \bibliography
+# command is found in the tex. contents/bibliography.bib is the compile-tree
+# entry point and is typically a symlink into the real (possibly legacy) bib.
+_FALLBACK_BIBS = (
+    "01_manuscript/contents/bibliography.bib",
+    "00_shared/bib_files/bibliography.bib",
+)
 
 
 def log_pass(msg):
@@ -226,6 +242,64 @@ def _resolve_tex_paths(project_dir, tex_args):
     return sorted(str(p) for p in Path(project_dir).rglob("*.tex"))
 
 
+def _resolve_one_bib(raw, base_dirs):
+    """Resolve a single \\bibliography argument to a real, existing file.
+
+    Tries the argument (with and without a .bib suffix) under each base dir, and
+    returns the FIRST that exists -- symlink-resolved (Path.resolve follows the
+    whole chain, so contents/bibliography.bib -> ... -> the real enriched bib).
+    Returns None if nothing resolves.
+    """
+    candidates = [raw]
+    if not raw.lower().endswith(".bib"):
+        candidates.append(raw + ".bib")
+    for base in base_dirs:
+        for cand in candidates:
+            p = (base / cand) if not os.path.isabs(cand) else Path(cand)
+            if p.is_file():
+                return p.resolve()
+    return None
+
+
+def resolve_bib_paths(project_dir, tex_paths, bib_arg):
+    r"""Resolve the bibliography file(s) that bibtex actually reads.
+
+    The compile tree points \cite resolution at whatever
+    ``\bibliography{}`` / ``\addbibresource{}`` names -- and in real projects
+    that is a SYMLINK (e.g. contents/bibliography.bib -> a legacy enriched bib),
+    NOT necessarily 00_shared. So we parse the bib command from the tex, resolve
+    its path relative to the tex file (then the project root), and follow the
+    symlink. Precedence: explicit --bib > \bibliography targets from the tex >
+    conventional fallbacks. All results are symlink-resolved and de-duplicated.
+    """
+    if bib_arg:
+        p = Path(bib_arg)
+        return [p.resolve()] if p.is_file() else []
+
+    project_dir = Path(project_dir)
+    resolved = []
+    seen = set()
+
+    def _add(path):
+        if path is not None and path not in seen:
+            seen.add(path)
+            resolved.append(path)
+
+    for tex in tex_paths:
+        tex_dir = Path(tex).resolve().parent
+        text = _load_text([tex])
+        for m in _BIB_CMD_RE.finditer(text):
+            for raw in m.group(1).split(","):
+                raw = raw.strip()
+                if raw:
+                    _add(_resolve_one_bib(raw, [tex_dir, project_dir]))
+
+    if not resolved:
+        for fb in _FALLBACK_BIBS:
+            _add(_resolve_one_bib(fb, [project_dir]))
+    return resolved
+
+
 def _is_research_project(project_dir):
     """True iff .scitex/dev/config.yaml marks this a ``project-type: research``.
 
@@ -295,7 +369,9 @@ def main():
     parser.add_argument(
         "--bib",
         default=None,
-        help=f"Bibliography .bib to read entries from (default: {_DEFAULT_BIB}).",
+        help="Bibliography .bib to read entries from. Default: resolve the "
+        "\\bibliography{}/\\addbibresource{} target from the tex (symlink-"
+        "followed), else conventional fallbacks.",
     )
     parser.add_argument(
         "--level",
@@ -328,12 +404,6 @@ def main():
 
     report = log_fail if level == "error" else log_warn
 
-    bib_path = Path(args.bib) if args.bib else project_dir / _DEFAULT_BIB
-    if not bib_path.is_file():
-        log_warn(f"bibliography not found: {bib_path} -- nothing to check.")
-        _summary()
-        return 1 if FAIL_COUNT > 0 else 0
-
     tex_paths = _resolve_tex_paths(project_dir, args.tex)
     cited_keys = extract_cited_keys(_load_text(tex_paths))
     if not cited_keys:
@@ -342,7 +412,25 @@ def main():
         _summary()
         return 1 if FAIL_COUNT > 0 else 0
 
-    entries = dict(iter_bib_entries(bib_path.read_text(encoding="utf-8", errors="replace")))
+    bib_paths = resolve_bib_paths(project_dir, tex_paths, args.bib)
+    if not bib_paths:
+        log_warn(
+            "no bibliography resolved (no \\bibliography target found and no "
+            "fallback bib exists) -- nothing to check."
+        )
+        _summary()
+        return 1 if FAIL_COUNT > 0 else 0
+    for bp in bib_paths:
+        log_detail(f"reading bib: {bp}")
+
+    # Merge entries across all resolved bibs; first occurrence of a key wins
+    # (matches bibtex, which uses the first entry it sees for a key).
+    entries = {}
+    for bp in bib_paths:
+        for key, fields in iter_bib_entries(
+            bp.read_text(encoding="utf-8", errors="replace")
+        ):
+            entries.setdefault(key, fields)
     stubs, missing, no_doi = audit_citations(cited_keys, entries)
 
     if stubs:
@@ -364,7 +452,7 @@ def main():
     if missing:
         log_warn(f"{len(missing)} cited key(s) have no bibliography entry:")
         for key in missing:
-            log_detail(f"\\cite{{{key}}} -> no entry in {bib_path.name}")
+            log_detail(f"\\cite{{{key}}} -> no entry in the resolved bib(s)")
     if no_doi:
         log_detail(
             f"note: {len(no_doi)} cited entry(ies) have no DOI (not a failure): "

--- a/scripts/python/check_citations.py
+++ b/scripts/python/check_citations.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/check_citations.py
+# Purpose: Pre-compile CITATION GATE -- before a research manuscript is
+#          compiled, check every \cite key actually used in the document against
+#          its bibliography entry and FAIL the build if a cited entry is a
+#          scholar STUB (auto-generated placeholder that has not yet been
+#          resolved to a real, verified source). A stub reference must never
+#          reach a compiled manuscript ("一発アウト"): it is either a
+#          hallucinated citation or an unfinished lookup.
+#
+#          This is the COMPILER-OWNS half of the citation->clew verification
+#          contract (neurovista, operator-directed 2026-07-01). It is fully
+#          LOCAL -- no clew/scholar dependency -- so it delivers the root-fix
+#          immediately and would have failed the neurovista build on the
+#          PintoOrellana2023 stub at source. The CLEW-OWNS half (querying clew
+#          for per-key scholar verification status) slots in later behind the
+#          same report once clew defines its batch lookup; until then this gate
+#          catches the stub stamps scholar already writes.
+#
+#          A STUB is detected by the markers scholar stamps into the entry:
+#            * note    contains "Auto-generated stub"   (STUB_NOTE_MARKERS)
+#            * journal contains "Pending scitex-scholar metadata lookup"
+#                                                        (STUB_JOURNAL_MARKERS)
+#          A cited entry matching ANY marker is a stub and gates. "No DOI" is
+#          deliberately NOT a sole stub trigger -- many legitimate references
+#          (books, arXiv preprints, conference papers) have no DOI, so failing
+#          on that alone would be a false positive. Missing-DOI cited entries
+#          are surfaced as an informational note only. The marker lists are
+#          module constants so scholar's authoritative stamp fields can be
+#          extended without touching the logic.
+#
+#          DEFAULT depends on project type: a *research* project (marked by
+#          .scitex/dev/config.yaml `project-type: research`) defaults to
+#          `error` (gate ON -> FAIL); any other project defaults to `warn`
+#          (loud, non-blocking). CLI/env/config always override the default.
+#
+# Usage:
+#   python check_citations.py [project_dir]
+#                             [--tex PATH ...] [--bib PATH]
+#                             [--level off|warn|error]
+#
+# Self-contained: stdlib + optional PyYAML (only to read config files).
+
+import argparse
+import glob
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
+
+GREEN = "\033[0;32m"
+YELLOW = "\033[1;33m"
+RED = "\033[0;31m"
+DIM = "\033[0;90m"
+BOLD = "\033[1m"
+NC = "\033[0m"
+
+PASS_COUNT = 0
+WARN_COUNT = 0
+FAIL_COUNT = 0
+
+_LEVELS = ("off", "warn", "error")
+
+# Scholar stub stamps (lowercase substring match). Authoritative source is
+# scitex-scholar; extend here when scholar adds/renames a stamp field.
+STUB_NOTE_MARKERS = ("auto-generated stub",)
+STUB_JOURNAL_MARKERS = ("pending scitex-scholar metadata lookup",)
+
+# Citation commands whose {..} argument holds comma-separated cite keys.
+_CITE_CMD = (
+    r"\\(?:cite|citep|citet|citeauthor|citeyear|citeyearpar|citealt|citealp|"
+    r"citenum|Cite|Citep|Citet|Citeauthor|parencite|Parencite|textcite|"
+    r"Textcite|autocite|Autocite|footcite|fullcite|smartcite)"
+)
+# Optional [..] pre/post-notes, then the mandatory {key,key,...}.
+_CITE_RE = re.compile(_CITE_CMD + r"\s*(?:\[[^\]]*\]\s*){0,2}\{([^}]*)\}")
+
+_DEFAULT_BIB = "00_shared/bib_files/bibliography.bib"
+
+
+def log_pass(msg):
+    global PASS_COUNT
+    print(f"  {GREEN}[PASS]{NC} {msg}")
+    PASS_COUNT += 1
+
+
+def log_warn(msg):
+    global WARN_COUNT
+    print(f"  {YELLOW}[WARN]{NC} {msg}")
+    WARN_COUNT += 1
+
+
+def log_fail(msg):
+    global FAIL_COUNT
+    print(f"  {RED}[FAIL]{NC} {msg}")
+    FAIL_COUNT += 1
+
+
+def log_detail(msg):
+    print(f"    {DIM}{msg}{NC}")
+
+
+def _strip_tex_comments(tex):
+    r"""Drop LaTeX line comments so a commented-out \cite is not counted.
+
+    A percent is a comment start unless escaped (\%). Keep everything before an
+    unescaped %.
+    """
+    out = []
+    for line in tex.splitlines():
+        idx = 0
+        cut = None
+        while idx < len(line):
+            ch = line[idx]
+            if ch == "\\":
+                idx += 2  # skip escaped char (covers \%)
+                continue
+            if ch == "%":
+                cut = idx
+                break
+            idx += 1
+        out.append(line if cut is None else line[:cut])
+    return "\n".join(out)
+
+
+def extract_cited_keys(tex):
+    r"""Return the set of cite keys referenced by \cite-family commands in tex.
+
+    Commented-out citations are ignored. Whitespace and empty keys are dropped.
+    """
+    keys = set()
+    for group in _CITE_RE.findall(_strip_tex_comments(tex)):
+        for raw in group.split(","):
+            key = raw.strip()
+            if key:
+                keys.add(key)
+    return keys
+
+
+def iter_bib_entries(bib_text):
+    """Yield (cite_key, fields_dict) for each @type{key, ...} entry.
+
+    A dependency-free scanner: finds each ``@type{key,`` header, then captures
+    the entry body by brace balancing. Field values are read for both
+    ``field = {value}`` and ``field = "value"`` forms. Keys and field names are
+    matched case-insensitively (BibTeX is case-insensitive on both).
+    """
+    header = re.compile(r"@(\w+)\s*\{\s*([^,\s]+)\s*,", re.IGNORECASE)
+    for m in header.finditer(bib_text):
+        entry_type = m.group(1).lower()
+        if entry_type in ("comment", "string", "preamble"):
+            continue
+        cite_key = m.group(2).strip()
+        # Capture the body by brace balancing from the opening '{'.
+        open_brace = bib_text.index("{", m.start())
+        depth = 0
+        i = open_brace
+        while i < len(bib_text):
+            c = bib_text[i]
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        body = bib_text[open_brace + 1 : i]
+        yield cite_key, _parse_fields(body)
+
+
+def _parse_fields(body):
+    """Parse ``name = {value}`` / ``name = "value"`` pairs from an entry body."""
+    fields = {}
+    field_re = re.compile(
+        r"(\w+)\s*=\s*(?:\{(.*?)\}|\"(.*?)\")", re.IGNORECASE | re.DOTALL
+    )
+    for fm in field_re.finditer(body):
+        name = fm.group(1).lower()
+        value = fm.group(2) if fm.group(2) is not None else (fm.group(3) or "")
+        fields[name] = value.strip()
+    return fields
+
+
+def stub_reason(fields):
+    """Return a human reason string if the entry is a scholar stub, else None."""
+    note = fields.get("note", "").lower()
+    for marker in STUB_NOTE_MARKERS:
+        if marker in note:
+            return f'note="{fields.get("note", "")}"'
+    journal = fields.get("journal", "").lower()
+    for marker in STUB_JOURNAL_MARKERS:
+        if marker in journal:
+            return f'journal="{fields.get("journal", "")}"'
+    return None
+
+
+def _load_text(paths):
+    """Concatenate the text of every existing path in ``paths``."""
+    chunks = []
+    for p in paths:
+        try:
+            chunks.append(Path(p).read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            continue
+    return "\n".join(chunks)
+
+
+def _resolve_tex_paths(project_dir, tex_args):
+    """Resolve the tex sources to scan for citations.
+
+    Precedence: explicit --tex args (globs allowed) > SCITEX_WRITER_COMPILED_TEX
+    env > every *.tex under the project (last resort). Returns a sorted list.
+    """
+    if tex_args:
+        found = []
+        for pat in tex_args:
+            found.extend(sorted(glob.glob(pat)))
+        return found
+    env_tex = os.environ.get("SCITEX_WRITER_COMPILED_TEX", "").strip()
+    if env_tex and Path(env_tex).is_file():
+        return [env_tex]
+    return sorted(str(p) for p in Path(project_dir).rglob("*.tex"))
+
+
+def _is_research_project(project_dir):
+    """True iff .scitex/dev/config.yaml marks this a ``project-type: research``.
+
+    Mirrors check_clew_verify._is_research_project so both gates share one
+    research-mode signal. PyYAML optional; falls back to a textual marker scan.
+    """
+    cfg = Path(project_dir) / ".scitex" / "dev" / "config.yaml"
+    if not cfg.is_file():
+        return False
+    try:
+        text = cfg.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    try:
+        import yaml
+
+        data = yaml.safe_load(text) or {}
+        if isinstance(data, dict):
+            return str(data.get("project-type", "")).strip().lower() == "research"
+    except Exception:
+        pass
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("project-type:"):
+            return stripped.split(":", 1)[1].strip().strip("\"'").lower() == "research"
+    return False
+
+
+def audit_citations(cited_keys, entries):
+    """Classify each cited key against the bibliography.
+
+    Returns (stubs, missing, no_doi):
+      stubs   -> list of (key, reason) whose entry is a scholar stub
+      missing -> sorted list of cited keys with no bibliography entry
+      no_doi  -> sorted list of cited keys whose entry has no DOI (info only)
+    """
+    stubs = []
+    missing = []
+    no_doi = []
+    for key in sorted(cited_keys):
+        fields = entries.get(key)
+        if fields is None:
+            missing.append(key)
+            continue
+        reason = stub_reason(fields)
+        if reason is not None:
+            stubs.append((key, reason))
+        elif not fields.get("doi", "").strip():
+            no_doi.append(key)
+    return stubs, missing, no_doi
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Pre-compile citation gate: FAIL when a cited reference is a "
+        "scholar stub (unresolved/placeholder). Defaults ON (error) for research "
+        "projects, warn otherwise."
+    )
+    parser.add_argument("project_dir", nargs="?", default=".")
+    parser.add_argument(
+        "--tex",
+        action="append",
+        default=None,
+        help="Tex file(s)/glob(s) to scan for \\cite keys (repeatable). "
+        "Defaults to $SCITEX_WRITER_COMPILED_TEX, else all *.tex under project.",
+    )
+    parser.add_argument(
+        "--bib",
+        default=None,
+        help=f"Bibliography .bib to read entries from (default: {_DEFAULT_BIB}).",
+    )
+    parser.add_argument(
+        "--level",
+        choices=list(_LEVELS),
+        default=None,
+        help="Severity: off, warn, or error. Overrides env and config.",
+    )
+    args = parser.parse_args()
+
+    project_dir = Path(args.project_dir).resolve()
+    research = _is_research_project(project_dir)
+    default = "error" if research else "warn"
+    level = resolve_level(
+        "citations",
+        args.level,
+        project_dir,
+        default=default,
+        env_var="SCITEX_WRITER_CITATIONS",
+    )
+    kind = "research" if research else "non-research"
+    print(f"\n{BOLD}=== Citation Gate (level={level}, {kind}) ==={NC}\n")
+
+    if level == "off":
+        print(
+            f"  {DIM}[INFO]{NC} citation gate is disabled (level=off). "
+            f"Set citations.level or --level to enable."
+        )
+        _summary()
+        return 0
+
+    report = log_fail if level == "error" else log_warn
+
+    bib_path = Path(args.bib) if args.bib else project_dir / _DEFAULT_BIB
+    if not bib_path.is_file():
+        log_warn(f"bibliography not found: {bib_path} -- nothing to check.")
+        _summary()
+        return 1 if FAIL_COUNT > 0 else 0
+
+    tex_paths = _resolve_tex_paths(project_dir, args.tex)
+    cited_keys = extract_cited_keys(_load_text(tex_paths))
+    if not cited_keys:
+        log_warn("no \\cite keys found in the scanned tex -- nothing to check.")
+        log_detail(f"scanned: {len(tex_paths)} tex file(s)")
+        _summary()
+        return 1 if FAIL_COUNT > 0 else 0
+
+    entries = dict(iter_bib_entries(bib_path.read_text(encoding="utf-8", errors="replace")))
+    stubs, missing, no_doi = audit_citations(cited_keys, entries)
+
+    if stubs:
+        report(
+            f"{len(stubs)} cited reference(s) are unresolved scholar stubs -- "
+            f"replace with a real, verified source before compiling:"
+        )
+        for key, reason in stubs:
+            log_detail(f"\\cite{{{key}}} -> STUB ({reason})")
+        log_detail(
+            "fix: resolve each key via scitex-scholar (DOI + real metadata), or "
+            "remove the citation. Override with citations.level if intended."
+        )
+    else:
+        log_pass(f"all {len(cited_keys)} cited reference(s) are non-stub entries")
+
+    # Missing entries and missing-DOI are informational (bibtex already flags
+    # undefined citations; DOI-less entries are often legitimate). Never a FAIL.
+    if missing:
+        log_warn(f"{len(missing)} cited key(s) have no bibliography entry:")
+        for key in missing:
+            log_detail(f"\\cite{{{key}}} -> no entry in {bib_path.name}")
+    if no_doi:
+        log_detail(
+            f"note: {len(no_doi)} cited entry(ies) have no DOI (not a failure): "
+            + ", ".join(no_doi[:10])
+            + (" ..." if len(no_doi) > 10 else "")
+        )
+
+    _summary()
+    return 1 if FAIL_COUNT > 0 else 0
+
+
+def _summary():
+    print()
+    print(
+        f"{BOLD}Summary:{NC} {GREEN}{PASS_COUNT} passed{NC}, "
+        f"{YELLOW}{WARN_COUNT} warnings{NC}, {RED}{FAIL_COUNT} errors{NC}"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shell/modules/run_provenance_checks.sh
+++ b/scripts/shell/modules/run_provenance_checks.sh
@@ -16,7 +16,11 @@
 # a \caption{} is always a fatal compile pattern). clew_verify is the
 # provenance GATE (ADR-0021): it re-verifies every clew-registered claim
 # against its bound source and defaults to error for research projects
-# (.scitex/dev/config.yaml project-type: research), off otherwise.
+# (.scitex/dev/config.yaml project-type: research), off otherwise. citations is
+# the CITATION GATE: it fails the build when a cited reference is an unresolved
+# scholar stub (auto-generated placeholder), also error for research / warn
+# otherwise -- the compiler-owns half of the citation->clew verification
+# contract (a stub \cite can never reach a compiled research manuscript).
 #
 # Returns the worst exit code across the checks (0 unless a check errored).
 
@@ -27,7 +31,7 @@ PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$THIS_DIR/../../.." && pwd)}"
 PY="${SCITEX_WRITER_PYTHON:-python3}"
 
 rc=0
-for chk in check_paper_symlink check_media_provenance check_caption_footnote check_clew_verify check_version_freshness; do
+for chk in check_paper_symlink check_media_provenance check_caption_footnote check_clew_verify check_citations check_version_freshness; do
     script="$THIS_DIR/../../python/${chk}.py"
     [ -f "$script" ] || continue
     "$PY" "$script" "$PROJECT_ROOT" || rc=$?

--- a/tests/scripts/python/test_check_citations.py
+++ b/tests/scripts/python/test_check_citations.py
@@ -12,6 +12,7 @@ from check_citations import (  # noqa: E402
     audit_citations,
     extract_cited_keys,
     iter_bib_entries,
+    resolve_bib_paths,
     stub_reason,
 )
 
@@ -104,6 +105,46 @@ class TestAuditCitations:
     def test_clean_citation_passes(self):
         stubs, missing, no_doi = audit_citations({"Good2020"}, self._ENTRIES)
         assert (stubs == []) and (missing == []) and (no_doi == [])
+
+
+class TestResolveBibPaths:
+    def _make_tree(self, tmp_path):
+        """A project whose contents/bibliography.bib is a symlink chain to the
+        real (legacy-style) enriched bib -- mirrors the live neurovista tree."""
+        real = tmp_path / "shared" / "bib_files" / "enriched.bib"
+        real.parent.mkdir(parents=True)
+        real.write_text("@article{Foo2020,\n  doi = {10.1/x}\n}\n")
+        mid = tmp_path / "shared" / "bibliography.bib"
+        mid.symlink_to(real)
+        contents = tmp_path / "01_manuscript" / "contents"
+        contents.mkdir(parents=True)
+        link = contents / "bibliography.bib"
+        link.symlink_to(mid)
+        tex = contents / "main.tex"
+        tex.write_text(r"\bibliography{bibliography}" + "\n\\cite{Foo2020}")
+        return tex, real
+
+    def test_follows_symlink_chain_from_bibliography_command(self, tmp_path):
+        tex, real = self._make_tree(tmp_path)
+        resolved = resolve_bib_paths(tmp_path, [str(tex)], None)
+        assert resolved == [real.resolve()]
+
+    def test_explicit_bib_arg_wins(self, tmp_path):
+        tex, real = self._make_tree(tmp_path)
+        other = tmp_path / "other.bib"
+        other.write_text("@article{Bar,\n doi={10.2/y}\n}\n")
+        resolved = resolve_bib_paths(tmp_path, [str(tex)], str(other))
+        assert resolved == [other.resolve()]
+
+    def test_addbibresource_with_extension(self, tmp_path):
+        contents = tmp_path / "01_manuscript" / "contents"
+        contents.mkdir(parents=True)
+        bib = contents / "refs.bib"
+        bib.write_text("@article{Baz,\n doi={10.3/z}\n}\n")
+        tex = contents / "main.tex"
+        tex.write_text(r"\addbibresource{refs.bib}")
+        resolved = resolve_bib_paths(tmp_path, [str(tex)], None)
+        assert resolved == [bib.resolve()]
 
 
 if __name__ == "__main__":

--- a/tests/scripts/python/test_check_citations.py
+++ b/tests/scripts/python/test_check_citations.py
@@ -18,69 +18,118 @@ from check_citations import (  # noqa: E402
 
 
 class TestExtractCitedKeys:
-    def test_simple_cite(self):
-        assert extract_cited_keys(r"see \cite{Foo2020}") == {"Foo2020"}
+    def test_single_cite_command_yields_its_key(self):
+        # Arrange
+        tex = r"see \cite{Foo2020}"
+        # Act
+        keys = extract_cited_keys(tex)
+        # Assert
+        assert keys == {"Foo2020"}
 
-    def test_multiple_keys_in_one_command(self):
-        assert extract_cited_keys(r"\citep{A2020,B2021, C2022}") == {
-            "A2020",
-            "B2021",
-            "C2022",
-        }
+    def test_multiple_keys_in_one_command_all_extracted(self):
+        # Arrange
+        tex = r"\citep{A2020,B2021, C2022}"
+        # Act
+        keys = extract_cited_keys(tex)
+        # Assert
+        assert keys == {"A2020", "B2021", "C2022"}
 
-    def test_citet_and_optional_notes(self):
-        assert extract_cited_keys(r"\citet[see][p.~5]{Bar2019}") == {"Bar2019"}
+    def test_citet_with_optional_notes_extracts_key(self):
+        # Arrange
+        tex = r"\citet[see][p.~5]{Bar2019}"
+        # Act
+        keys = extract_cited_keys(tex)
+        # Assert
+        assert keys == {"Bar2019"}
 
-    def test_commented_out_cite_ignored(self):
+    def test_commented_out_cite_is_ignored(self):
+        # Arrange
         tex = "real \\cite{Keep2020}\n% dropped \\cite{Skip1999}"
-        assert extract_cited_keys(tex) == {"Keep2020"}
+        # Act
+        keys = extract_cited_keys(tex)
+        # Assert
+        assert keys == {"Keep2020"}
 
-    def test_escaped_percent_not_treated_as_comment(self):
-        assert extract_cited_keys(r"100\% \cite{Keep2020}") == {"Keep2020"}
+    def test_escaped_percent_is_not_a_comment(self):
+        # Arrange
+        tex = r"100\% \cite{Keep2020}"
+        # Act
+        keys = extract_cited_keys(tex)
+        # Assert
+        assert keys == {"Keep2020"}
 
-    def test_no_citations(self):
-        assert extract_cited_keys("plain text, no cites") == set()
+    def test_text_without_citations_yields_empty_set(self):
+        # Arrange
+        tex = "plain text, no cites"
+        # Act
+        keys = extract_cited_keys(tex)
+        # Assert
+        assert keys == set()
 
 
 class TestIterBibEntries:
-    def test_parses_key_and_fields(self):
+    def test_parses_cite_key_and_field_values(self):
+        # Arrange
         bib = (
             "@article{Foo2020,\n  title = {A Title},\n  doi = {10.1/x},\n"
             '  journal = "Nature"\n}\n'
         )
+        # Act
         entries = dict(iter_bib_entries(bib))
+        # Assert
         e = entries.get("Foo2020", {})
         assert (e.get("doi") == "10.1/x") and (e.get("journal") == "Nature")
 
-    def test_nested_braces_in_value(self):
+    def test_nested_braces_in_field_value_parsed(self):
+        # Arrange
         bib = "@article{Foo2020,\n  title = {A {Nested} Title},\n  doi = {10.1/x}\n}\n"
+        # Act
         entries = dict(iter_bib_entries(bib))
+        # Assert
         assert entries.get("Foo2020", {}).get("doi") == "10.1/x"
 
-    def test_skips_string_and_comment_entries(self):
+    def test_string_and_comment_entries_are_skipped(self):
+        # Arrange
         bib = "@string{pub = {ACME}}\n@article{Real2020,\n  doi = {10.1/x}\n}\n"
+        # Act
         keys = {k for k, _ in iter_bib_entries(bib)}
+        # Assert
         assert keys == {"Real2020"}
 
 
 class TestStubReason:
-    def test_note_marker_is_stub(self):
+    def test_auto_generated_note_marks_a_stub(self):
+        # Arrange
         fields = {"note": "Auto-generated stub; replace before submission."}
-        assert stub_reason(fields) is not None
+        # Act
+        reason = stub_reason(fields)
+        # Assert
+        assert reason is not None
 
-    def test_journal_marker_is_stub(self):
+    def test_pending_journal_marker_marks_a_stub(self):
+        # Arrange
         fields = {"journal": "Pending scitex-scholar metadata lookup"}
-        assert stub_reason(fields) is not None
+        # Act
+        reason = stub_reason(fields)
+        # Assert
+        assert reason is not None
 
-    def test_clean_entry_is_not_stub(self):
+    def test_complete_entry_is_not_a_stub(self):
+        # Arrange
         fields = {"title": "Real", "doi": "10.1/x", "journal": "Nature"}
-        assert stub_reason(fields) is None
+        # Act
+        reason = stub_reason(fields)
+        # Assert
+        assert reason is None
 
-    def test_no_doi_alone_is_not_a_stub(self):
-        # A legitimate book/arXiv entry with no DOI must NOT be flagged (no
-        # false positives) -- only a scholar stamp marks a stub.
+    def test_missing_doi_alone_is_not_a_stub(self):
+        # Arrange: a legitimate book/arXiv entry with no DOI must NOT be flagged
+        # (no false positives) -- only a scholar stamp marks a stub.
         fields = {"title": "A Book", "publisher": "MIT Press"}
-        assert stub_reason(fields) is None
+        # Act
+        reason = stub_reason(fields)
+        # Assert
+        assert reason is None
 
 
 class TestAuditCitations:
@@ -90,25 +139,41 @@ class TestAuditCitations:
         "NoDoi2018": {"title": "A Book", "publisher": "MIT Press"},
     }
 
-    def test_stub_is_reported(self):
-        stubs, missing, no_doi = audit_citations({"Stub2023"}, self._ENTRIES)
+    def test_cited_stub_entry_is_reported(self):
+        # Arrange
+        cited = {"Stub2023"}
+        # Act
+        stubs, missing, no_doi = audit_citations(cited, self._ENTRIES)
+        # Assert
         assert (len(stubs) == 1) and (stubs[0][0] == "Stub2023")
 
-    def test_missing_entry_is_reported_not_stub(self):
-        stubs, missing, no_doi = audit_citations({"Ghost2000"}, self._ENTRIES)
+    def test_missing_entry_reported_as_missing_not_stub(self):
+        # Arrange
+        cited = {"Ghost2000"}
+        # Act
+        stubs, missing, no_doi = audit_citations(cited, self._ENTRIES)
+        # Assert
         assert (missing == ["Ghost2000"]) and (stubs == [])
 
-    def test_no_doi_is_info_only_not_stub(self):
-        stubs, missing, no_doi = audit_citations({"NoDoi2018"}, self._ENTRIES)
+    def test_missing_doi_is_info_only_not_stub(self):
+        # Arrange
+        cited = {"NoDoi2018"}
+        # Act
+        stubs, missing, no_doi = audit_citations(cited, self._ENTRIES)
+        # Assert
         assert (stubs == []) and (no_doi == ["NoDoi2018"])
 
-    def test_clean_citation_passes(self):
-        stubs, missing, no_doi = audit_citations({"Good2020"}, self._ENTRIES)
+    def test_clean_cited_entry_passes_all_buckets_empty(self):
+        # Arrange
+        cited = {"Good2020"}
+        # Act
+        stubs, missing, no_doi = audit_citations(cited, self._ENTRIES)
+        # Assert
         assert (stubs == []) and (missing == []) and (no_doi == [])
 
 
 class TestResolveBibPaths:
-    def _make_tree(self, tmp_path):
+    def _make_symlinked_tree(self, tmp_path):
         """A project whose contents/bibliography.bib is a symlink chain to the
         real (legacy-style) enriched bib -- mirrors the live neurovista tree."""
         real = tmp_path / "shared" / "bib_files" / "enriched.bib"
@@ -118,32 +183,40 @@ class TestResolveBibPaths:
         mid.symlink_to(real)
         contents = tmp_path / "01_manuscript" / "contents"
         contents.mkdir(parents=True)
-        link = contents / "bibliography.bib"
-        link.symlink_to(mid)
+        (contents / "bibliography.bib").symlink_to(mid)
         tex = contents / "main.tex"
         tex.write_text(r"\bibliography{bibliography}" + "\n\\cite{Foo2020}")
         return tex, real
 
     def test_follows_symlink_chain_from_bibliography_command(self, tmp_path):
-        tex, real = self._make_tree(tmp_path)
+        # Arrange
+        tex, real = self._make_symlinked_tree(tmp_path)
+        # Act
         resolved = resolve_bib_paths(tmp_path, [str(tex)], None)
+        # Assert
         assert resolved == [real.resolve()]
 
-    def test_explicit_bib_arg_wins(self, tmp_path):
-        tex, real = self._make_tree(tmp_path)
+    def test_explicit_bib_argument_overrides_tex_target(self, tmp_path):
+        # Arrange
+        tex, real = self._make_symlinked_tree(tmp_path)
         other = tmp_path / "other.bib"
         other.write_text("@article{Bar,\n doi={10.2/y}\n}\n")
+        # Act
         resolved = resolve_bib_paths(tmp_path, [str(tex)], str(other))
+        # Assert
         assert resolved == [other.resolve()]
 
-    def test_addbibresource_with_extension(self, tmp_path):
+    def test_addbibresource_with_extension_resolves(self, tmp_path):
+        # Arrange
         contents = tmp_path / "01_manuscript" / "contents"
         contents.mkdir(parents=True)
         bib = contents / "refs.bib"
         bib.write_text("@article{Baz,\n doi={10.3/z}\n}\n")
         tex = contents / "main.tex"
         tex.write_text(r"\addbibresource{refs.bib}")
+        # Act
         resolved = resolve_bib_paths(tmp_path, [str(tex)], None)
+        # Assert
         assert resolved == [bib.resolve()]
 
 

--- a/tests/scripts/python/test_check_citations.py
+++ b/tests/scripts/python/test_check_citations.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: check_citations.py (compiler-owns citation stub gate)
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from check_citations import (  # noqa: E402
+    audit_citations,
+    extract_cited_keys,
+    iter_bib_entries,
+    stub_reason,
+)
+
+
+class TestExtractCitedKeys:
+    def test_simple_cite(self):
+        assert extract_cited_keys(r"see \cite{Foo2020}") == {"Foo2020"}
+
+    def test_multiple_keys_in_one_command(self):
+        assert extract_cited_keys(r"\citep{A2020,B2021, C2022}") == {
+            "A2020",
+            "B2021",
+            "C2022",
+        }
+
+    def test_citet_and_optional_notes(self):
+        assert extract_cited_keys(r"\citet[see][p.~5]{Bar2019}") == {"Bar2019"}
+
+    def test_commented_out_cite_ignored(self):
+        tex = "real \\cite{Keep2020}\n% dropped \\cite{Skip1999}"
+        assert extract_cited_keys(tex) == {"Keep2020"}
+
+    def test_escaped_percent_not_treated_as_comment(self):
+        assert extract_cited_keys(r"100\% \cite{Keep2020}") == {"Keep2020"}
+
+    def test_no_citations(self):
+        assert extract_cited_keys("plain text, no cites") == set()
+
+
+class TestIterBibEntries:
+    def test_parses_key_and_fields(self):
+        bib = (
+            "@article{Foo2020,\n  title = {A Title},\n  doi = {10.1/x},\n"
+            '  journal = "Nature"\n}\n'
+        )
+        entries = dict(iter_bib_entries(bib))
+        e = entries.get("Foo2020", {})
+        assert (e.get("doi") == "10.1/x") and (e.get("journal") == "Nature")
+
+    def test_nested_braces_in_value(self):
+        bib = "@article{Foo2020,\n  title = {A {Nested} Title},\n  doi = {10.1/x}\n}\n"
+        entries = dict(iter_bib_entries(bib))
+        assert entries.get("Foo2020", {}).get("doi") == "10.1/x"
+
+    def test_skips_string_and_comment_entries(self):
+        bib = "@string{pub = {ACME}}\n@article{Real2020,\n  doi = {10.1/x}\n}\n"
+        keys = {k for k, _ in iter_bib_entries(bib)}
+        assert keys == {"Real2020"}
+
+
+class TestStubReason:
+    def test_note_marker_is_stub(self):
+        fields = {"note": "Auto-generated stub; replace before submission."}
+        assert stub_reason(fields) is not None
+
+    def test_journal_marker_is_stub(self):
+        fields = {"journal": "Pending scitex-scholar metadata lookup"}
+        assert stub_reason(fields) is not None
+
+    def test_clean_entry_is_not_stub(self):
+        fields = {"title": "Real", "doi": "10.1/x", "journal": "Nature"}
+        assert stub_reason(fields) is None
+
+    def test_no_doi_alone_is_not_a_stub(self):
+        # A legitimate book/arXiv entry with no DOI must NOT be flagged (no
+        # false positives) -- only a scholar stamp marks a stub.
+        fields = {"title": "A Book", "publisher": "MIT Press"}
+        assert stub_reason(fields) is None
+
+
+class TestAuditCitations:
+    _ENTRIES = {
+        "Good2020": {"doi": "10.1/x", "title": "Real"},
+        "Stub2023": {"note": "Auto-generated stub; replace before submission."},
+        "NoDoi2018": {"title": "A Book", "publisher": "MIT Press"},
+    }
+
+    def test_stub_is_reported(self):
+        stubs, missing, no_doi = audit_citations({"Stub2023"}, self._ENTRIES)
+        assert (len(stubs) == 1) and (stubs[0][0] == "Stub2023")
+
+    def test_missing_entry_is_reported_not_stub(self):
+        stubs, missing, no_doi = audit_citations({"Ghost2000"}, self._ENTRIES)
+        assert (missing == ["Ghost2000"]) and (stubs == [])
+
+    def test_no_doi_is_info_only_not_stub(self):
+        stubs, missing, no_doi = audit_citations({"NoDoi2018"}, self._ENTRIES)
+        assert (stubs == []) and (no_doi == ["NoDoi2018"])
+
+    def test_clean_citation_passes(self):
+        stubs, missing, no_doi = audit_citations({"Good2020"}, self._ENTRIES)
+        assert (stubs == []) and (missing == []) and (no_doi == [])
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
The compiler-owns half of the citation→clew verification contract (operator-directed, relayed by neurovista). A new pre-compile gate `check_citations.py` fails the build when a cited reference is an unresolved **scholar stub** — a placeholder that was never resolved to a real, verified source. A stub `\cite` must never reach a compiled research manuscript ("一発アウト"); it is either hallucinated or an unfinished lookup. This would have caught neurovista's `PintoOrellana2023StatisticalIFF` at source instead of by hand.

Fully **local** — no clew/scholar dependency — so it ships the root-fix now. The clew-owns half (per-key scholar verification via a clew batch lookup) slots in behind the same report once clew defines its interface.

### Behavior
- Scans the project's `*.tex` for `\cite`-family keys (commented-out citations ignored) and reads `00_shared/bib_files/bibliography.bib`.
- A cited entry is a **stub** iff a scholar stamp marker is present: `note` contains "Auto-generated stub" (`STUB_NOTE_MARKERS`) or `journal` contains "Pending scitex-scholar metadata lookup" (`STUB_JOURNAL_MARKERS`). Marker lists are module constants so scholar's authoritative stamp fields can be extended without touching logic.
- **No false positives:** "no DOI" is deliberately NOT a sole stub trigger — books/arXiv/conference refs legitimately lack a DOI. Missing-DOI cited entries are surfaced as info only; undefined-citation keys as a warn (bibtex already errors on those).
- Severity mirrors `check_clew_verify`: **error (FAIL)** for research projects (`.scitex/dev/config.yaml project-type: research`), **warn** otherwise. CLI/env/`config.yaml citations.level` override.
- Wired into `run_provenance_checks.sh` (same roster as the clew value gate), so it runs at the existing "Provenance Checks" stage for manuscript/supplementary/revision.

## Test plan
- [x] `test_check_citations.py`: cite-key extraction (multi-key, notes, commented-out ignored, escaped `\%`), bib parsing (nested braces, @string skipped), stub detection (note/journal markers; no-DOI-alone is NOT a stub), audit classification.
- [x] Validated in-container end-to-end: research project with the PintoOrellana stub → exit 1 (FAIL); same content non-research → exit 0 (WARN). Local `scitex-dev audit` clean.
- [ ] CI green.

Interim gate; scholar to confirm/extend the exact stub stamp fields. Reported/driven by neurovista.