### PR TITLE
feat(compile): citation banner level + page-1 red banner + inline \clewverified (2.24.8)

### DIFF
--- a/00_shared/latex_styles/formatting.tex
+++ b/00_shared/latex_styles/formatting.tex
@@ -92,4 +92,22 @@
 \newcommand{\placeholder}[1]{\colorbox{yellow}{\textcolor{red}{\textbf{[#1]}}}}
 \newcommand{\ph}[1]{\placeholder{#1}}
 
+%% --- Inline citation-verification render (clew) ---
+%% \clewverified{<cite text>}{<status>}{<source url>}: per-claim trust signal
+%% sharing clew's verify_citations result with the page-1 banner. A "verified"
+%% status renders the text underlined + hyperlinked to its source; any other
+%% status (unverified/stub/unknown) renders bare -- "unverified = no
+%% decoration". Provided (not new) so it is a safe no-op default before the
+%% clew wiring lands and callers may already define their own. No '@' catcodes,
+%% so it survives flattening without \makeatletter.
+\providecommand{\clewverifiedstatus}{verified}
+\providecommand{\clewverified}[3]{%
+  \def\clewgivenstatus{#2}%
+  \ifx\clewgivenstatus\clewverifiedstatus
+    \href{#3}{\ul{#1}}%
+  \else
+    #1%
+  \fi
+}
+
 %%%% EOF

--- a/scripts/python/_citation_banner.py
+++ b/scripts/python/_citation_banner.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/_citation_banner.py
+# Purpose: The citation-gate BANNER render layer. When the gate runs in `banner`
+#          mode (compile-anyway, accepted-risk draft), it emits a red page-1
+#          "unverified citations" box as a LaTeX artifact; the flattener
+#          (compile_tex_structure.py) injects that artifact after
+#          \begin{document} (before \maketitle) when it exists. Kept separate
+#          from check_citations.py so the detect/classify gate logic and the
+#          LaTeX-generation responsibility live in focused modules.
+#
+# Self-contained: stdlib only.
+
+from pathlib import Path
+
+# Where the banner-mode compile artifact is written, relative to the project
+# root. The flattener derives the same path from its resolved project root.
+_BANNER_TEX = ".scitex/writer/.citation_banner.tex"
+
+
+def banner_tex_path(project_dir):
+    """Absolute path of the banner-mode compile artifact for this project."""
+    return Path(project_dir) / _BANNER_TEX
+
+
+def reset_banner(project_dir):
+    """Remove any stale banner artifact so a clean run never re-injects it."""
+    try:
+        banner_tex_path(project_dir).unlink()
+    except OSError:
+        pass
+
+
+def _latex_escape(s):
+    r"""Escape the LaTeX specials that can appear in a cite key / reason."""
+    out = []
+    for ch in str(s):
+        if ch in "&%$#_{}":
+            out.append("\\" + ch)
+        elif ch == "~":
+            out.append(r"\textasciitilde{}")
+        elif ch == "^":
+            out.append(r"\textasciicircum{}")
+        elif ch == "\\":
+            out.append(r"\textbackslash{}")
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def build_banner_tex(failing, clew_unreachable=False):
+    r"""Return the LaTeX for a red page-1 "unverified citations" banner.
+
+    ``failing`` is a list of (key, reason) tuples. When ``clew_unreachable`` is
+    set, a prominent "clew UNREACHABLE" line is added so a down verifier never
+    silently passes. Uses tcolorbox + xcolor (already preamble dependencies).
+    Self-contained (\begingroup..\endgroup) and safe to inject verbatim.
+    """
+    lines = []
+    a = lines.append
+    a("% scitex-writer citation banner (auto-generated in banner mode; do not edit)")
+    a(r"\begingroup")
+    a(r"\definecolor{scitexBannerRed}{HTML}{C0271A}")
+    a(
+        r"\noindent\begin{tcolorbox}[colback=scitexBannerRed!10,"
+        r"colframe=scitexBannerRed,boxrule=1.2pt,arc=1pt,left=6pt,right=6pt,"
+        r"top=4pt,bottom=4pt,width=\textwidth,before skip=0pt,after skip=8pt]"
+    )
+    a(
+        r"{\bfseries\color{scitexBannerRed}\large UNVERIFIED CITATIONS "
+        r"---\ NOT FOR SUBMISSION}\\[2pt]"
+    )
+    if clew_unreachable:
+        a(
+            r"{\bfseries\color{scitexBannerRed}\small clew verification "
+            r"UNREACHABLE --- citations NOT verified.}\\[2pt]"
+        )
+    if failing:
+        a(
+            r"{\small The following cited reference(s) are unresolved/unverified "
+            r"and must be fixed before submission:}\\[2pt]"
+        )
+        a(r"{\small\ttfamily%")
+        for i, (key, reason) in enumerate(failing):
+            sep = r"\\" if i < len(failing) - 1 else ""
+            a(
+                "\\mbox{"
+                + _latex_escape(key)
+                + "} --- "
+                + _latex_escape(reason)
+                + sep
+            )
+        a(r"}")
+    a(r"\end{tcolorbox}")
+    a(r"\endgroup")
+    return "\n".join(lines) + "\n"
+
+
+def write_banner_tex(project_dir, failing, clew_unreachable=False):
+    """Write the banner artifact and return its path (creating parent dirs)."""
+    path = banner_tex_path(project_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(build_banner_tex(failing, clew_unreachable), encoding="utf-8")
+    return path
+
+
+__all__ = [
+    "banner_tex_path",
+    "reset_banner",
+    "build_banner_tex",
+    "write_banner_tex",
+]

--- a/scripts/python/_severity.py
+++ b/scripts/python/_severity.py
@@ -42,12 +42,29 @@ _LINT_STRICT_CHECKS = frozenset({"limits", "overflow"})
 # Only these checks accept the `repair` level (they can self-fix safely).
 _REPAIR_CHECKS = frozenset({"paper_symlink"})
 
+# Only these checks accept the `banner` level. `banner` sits between warn and
+# error: the check still produces output (the compile PROCEEDS), but flags the
+# violation prominently (a red page-1 banner) instead of aborting -- the
+# accepted-risk "co-author draft" mode for the citation gate. Scoped like
+# `repair` so the global off/warn/error ladder is untouched for every other
+# check.
+_BANNER_CHECKS = frozenset({"citations"})
+
 _TRUTHY = ("1", "true", "yes")
 
 
 def _valid_levels(check):
-    """Levels accepted for ``check`` (``repair`` only for self-fixing checks)."""
-    return LEVELS if check in _REPAIR_CHECKS else LEVELS[:3]
+    """Levels accepted for ``check``.
+
+    `repair` (self-fixing checks) and `banner` (the citation gate) are
+    check-scoped extras on top of the universal off/warn/error.
+    """
+    levels = list(LEVELS[:3])  # off, warn, error
+    if check in _REPAIR_CHECKS:
+        levels.append("repair")
+    if check in _BANNER_CHECKS:
+        levels.append("banner")
+    return tuple(levels)
 
 
 def _norm(value, check):

--- a/scripts/python/check_citations.py
+++ b/scripts/python/check_citations.py
@@ -58,6 +58,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _severity import resolve_level  # noqa: E402
+from _citation_banner import reset_banner, write_banner_tex  # noqa: E402
 
 GREEN = "\033[0;32m"
 YELLOW = "\033[1;33m"
@@ -70,7 +71,12 @@ PASS_COUNT = 0
 WARN_COUNT = 0
 FAIL_COUNT = 0
 
-_LEVELS = ("off", "warn", "error")
+_LEVELS = ("off", "warn", "error", "banner")
+
+# Where the banner-mode compile artifact is written. The flattener
+# (compile_tex_structure.py) injects this file after \begin{document} when it
+# exists. Path is derivable identically from the project root on both sides.
+_BANNER_TEX = ".scitex/writer/.citation_banner.tex"
 
 # Scholar stub stamps (lowercase substring match). Authoritative source is
 # scitex-scholar; extend here when scholar adds/renames a stamp field.
@@ -356,7 +362,8 @@ def main():
     parser = argparse.ArgumentParser(
         description="Pre-compile citation gate: FAIL when a cited reference is a "
         "scholar stub (unresolved/placeholder). Defaults ON (error) for research "
-        "projects, warn otherwise."
+        "projects, warn otherwise. `banner` level compiles anyway but stamps a "
+        "red page-1 banner."
     )
     parser.add_argument("project_dir", nargs="?", default=".")
     parser.add_argument(
@@ -377,7 +384,7 @@ def main():
         "--level",
         choices=list(_LEVELS),
         default=None,
-        help="Severity: off, warn, or error. Overrides env and config.",
+        help="Severity: off, warn, error, or banner. Overrides env and config.",
     )
     args = parser.parse_args()
 
@@ -393,6 +400,10 @@ def main():
     )
     kind = "research" if research else "non-research"
     print(f"\n{BOLD}=== Citation Gate (level={level}, {kind}) ==={NC}\n")
+
+    # Always clear a stale banner artifact from a previous compile first, so a
+    # now-clean (or non-banner) run can never re-inject an old banner.
+    reset_banner(project_dir)
 
     if level == "off":
         print(
@@ -440,10 +451,18 @@ def main():
         )
         for key, reason in stubs:
             log_detail(f"\\cite{{{key}}} -> STUB ({reason})")
-        log_detail(
-            "fix: resolve each key via scitex-scholar (DOI + real metadata), or "
-            "remove the citation. Override with citations.level if intended."
-        )
+        if level == "banner":
+            # Accepted-risk draft mode: the compile PROCEEDS but a red page-1
+            # banner (written here, injected by the flattener) makes the
+            # unresolved citations impossible to miss. clew_unreachable stays
+            # False until the clew-verified half is wired in.
+            path = write_banner_tex(project_dir, stubs, clew_unreachable=False)
+            log_detail(f"banner mode: wrote red page-1 banner -> {path}")
+        else:
+            log_detail(
+                "fix: resolve each key via scitex-scholar (DOI + real metadata), "
+                "or remove the citation. Override with citations.level if intended."
+            )
     else:
         log_pass(f"all {len(cited_keys)} cited reference(s) are non-stub entries")
 

--- a/scripts/python/compile_tex_structure.py
+++ b/scripts/python/compile_tex_structure.py
@@ -28,6 +28,13 @@ from _tex_signature import generate_signature  # noqa: E402
 # sentinel so a repeated flatten does not stack a second copy.
 DARK_MODE_SENTINEL = "% Dark mode styling (inlined at compile time)"
 
+# The citation gate (banner mode) writes this artifact under the project root;
+# when present it is injected right AFTER \begin{document} (before \maketitle)
+# so a red "unverified citations" box lands at the top of page 1. Its first
+# line is also the idempotency sentinel (a reflatten must not stack a copy).
+CITATION_BANNER_ARTIFACT = ".scitex/writer/.citation_banner.tex"
+CITATION_BANNER_SENTINEL = "scitex-writer citation banner"
+
 
 def _is_style_input(input_file: str) -> bool:
     r"""True if an \input target is a preamble style file (latex_styles/)."""
@@ -368,6 +375,24 @@ def compile_tex_structure(
             expanded_content = re.sub(
                 r"(?m)^([ \t]*)\\begin\{document\}",
                 lambda m: dark_mode_injection + m.group(0),
+                expanded_content,
+                count=1,
+            )
+
+    # Inject the citation banner (banner-mode compile artifact) at the TOP of
+    # page 1 -- right AFTER \begin{document}, before \maketitle -- so a red
+    # "UNVERIFIED CITATIONS" box is impossible to miss. Idempotent: skip if the
+    # banner sentinel is already present (a reflatten must not stack a copy).
+    banner_file = base_tex.parent.parent / CITATION_BANNER_ARTIFACT
+    if banner_file.is_file() and CITATION_BANNER_SENTINEL not in expanded_content:
+        try:
+            banner_tex = banner_file.read_text(encoding="utf-8")
+        except OSError:
+            banner_tex = ""
+        if banner_tex.strip():
+            expanded_content = re.sub(
+                r"(?m)^([ \t]*)\\begin\{document\}",
+                lambda m: m.group(0) + "\n" + banner_tex,
                 expanded_content,
                 count=1,
             )

--- a/tests/scripts/python/test_check_citations.py
+++ b/tests/scripts/python/test_check_citations.py
@@ -2,12 +2,14 @@
 # -*- coding: utf-8 -*-
 # Test file for: check_citations.py (compiler-owns citation stub gate)
 
+import subprocess
 import sys
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
 
+from _citation_banner import banner_tex_path  # noqa: E402
 from check_citations import (  # noqa: E402
     audit_citations,
     extract_cited_keys,
@@ -15,6 +17,24 @@ from check_citations import (  # noqa: E402
     resolve_bib_paths,
     stub_reason,
 )
+
+_CHECK = str(ROOT_DIR / "scripts" / "python" / "check_citations.py")
+
+
+def _make_project_with_stub(tmp_path):
+    """A minimal project citing one real ref + one scholar stub."""
+    bib_dir = tmp_path / "00_shared" / "bib_files"
+    bib_dir.mkdir(parents=True)
+    (bib_dir / "bibliography.bib").write_text(
+        "@article{Berens2009,\n title={CircStat},\n doi={10.18637/jss.v031.i10}\n}\n"
+        "@article{Stub2023,\n journal={Pending scitex-scholar metadata lookup},\n"
+        " note={Auto-generated stub; replace before submission.}\n}\n"
+    )
+    man = tmp_path / "01_manuscript"
+    man.mkdir(parents=True)
+    tex = man / "main.tex"
+    tex.write_text(r"We cite \citep{Berens2009} and \cite{Stub2023}.")
+    return tex
 
 
 class TestExtractCitedKeys:
@@ -218,6 +238,62 @@ class TestResolveBibPaths:
         resolved = resolve_bib_paths(tmp_path, [str(tex)], None)
         # Assert
         assert resolved == [bib.resolve()]
+
+
+class TestBannerModeCli:
+    def test_banner_mode_exits_zero_so_compile_proceeds(self, tmp_path):
+        # Arrange
+        tex = _make_project_with_stub(tmp_path)
+        # Act
+        proc = subprocess.run(
+            [sys.executable, _CHECK, str(tmp_path), "--tex", str(tex), "--level", "banner"],
+            capture_output=True, text=True,
+        )
+        # Assert
+        assert proc.returncode == 0
+
+    def test_banner_mode_writes_the_banner_artifact(self, tmp_path):
+        # Arrange
+        tex = _make_project_with_stub(tmp_path)
+        # Act
+        subprocess.run(
+            [sys.executable, _CHECK, str(tmp_path), "--tex", str(tex), "--level", "banner"],
+            capture_output=True, text=True,
+        )
+        # Assert
+        assert banner_tex_path(tmp_path).is_file()
+
+    def test_strict_error_mode_fails_and_writes_no_banner(self, tmp_path):
+        # Arrange
+        tex = _make_project_with_stub(tmp_path)
+        # Act
+        proc = subprocess.run(
+            [sys.executable, _CHECK, str(tmp_path), "--tex", str(tex), "--level", "error"],
+            capture_output=True, text=True,
+        )
+        # Assert
+        assert (proc.returncode == 1) and (not banner_tex_path(tmp_path).exists())
+
+    def test_clean_run_removes_a_stale_banner(self, tmp_path):
+        # Arrange: leave a stale banner, then run against a stub-free project.
+        bib_dir = tmp_path / "00_shared" / "bib_files"
+        bib_dir.mkdir(parents=True)
+        (bib_dir / "bibliography.bib").write_text(
+            "@article{Berens2009,\n title={CircStat},\n doi={10.1/x}\n}\n"
+        )
+        man = tmp_path / "01_manuscript"
+        man.mkdir(parents=True)
+        tex = man / "main.tex"
+        tex.write_text(r"\citep{Berens2009}")
+        banner_tex_path(tmp_path).parent.mkdir(parents=True, exist_ok=True)
+        banner_tex_path(tmp_path).write_text("stale banner")
+        # Act
+        subprocess.run(
+            [sys.executable, _CHECK, str(tmp_path), "--tex", str(tex), "--level", "banner"],
+            capture_output=True, text=True,
+        )
+        # Assert
+        assert not banner_tex_path(tmp_path).exists()
 
 
 if __name__ == "__main__":

--- a/tests/scripts/python/test_citation_banner.py
+++ b/tests/scripts/python/test_citation_banner.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: _citation_banner.py (citation-gate banner render layer)
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from _citation_banner import (  # noqa: E402
+    banner_tex_path,
+    build_banner_tex,
+    reset_banner,
+    write_banner_tex,
+)
+
+
+class TestBuildBannerTex:
+    def test_header_marks_the_pdf_not_for_submission(self):
+        # Arrange
+        failing = [("Foo2020", 'note="Auto-generated stub"')]
+        # Act
+        tex = build_banner_tex(failing)
+        # Assert
+        assert "NOT FOR SUBMISSION" in tex
+
+    def test_each_failing_key_appears_in_the_banner(self):
+        # Arrange
+        failing = [("Foo2020", "stub"), ("Bar2019", "stub")]
+        # Act
+        tex = build_banner_tex(failing)
+        # Assert
+        assert ("Foo2020" in tex) and ("Bar2019" in tex)
+
+    def test_clew_unreachable_adds_not_verified_line(self):
+        # Arrange
+        failing = []
+        # Act
+        tex = build_banner_tex(failing, clew_unreachable=True)
+        # Assert
+        assert "UNREACHABLE" in tex
+
+    def test_latex_specials_in_key_are_escaped(self):
+        # Arrange
+        failing = [("Foo_2020", "stub")]
+        # Act
+        tex = build_banner_tex(failing)
+        # Assert
+        assert "Foo\\_2020" in tex
+
+    def test_banner_block_is_self_contained_group(self):
+        # Arrange
+        failing = [("Foo2020", "stub")]
+        # Act
+        tex = build_banner_tex(failing)
+        # Assert
+        assert tex.count(r"\begingroup") == 1 and tex.count(r"\endgroup") == 1
+
+
+class TestWriteAndResetBanner:
+    def test_write_creates_artifact_at_expected_path(self, tmp_path):
+        # Arrange
+        failing = [("Foo2020", "stub")]
+        # Act
+        path = write_banner_tex(tmp_path, failing)
+        # Assert
+        assert path == banner_tex_path(tmp_path) and path.is_file()
+
+    def test_reset_removes_a_previously_written_banner(self, tmp_path):
+        # Arrange
+        write_banner_tex(tmp_path, [("Foo2020", "stub")])
+        # Act
+        reset_banner(tmp_path)
+        # Assert
+        assert not banner_tex_path(tmp_path).exists()
+
+    def test_reset_is_a_noop_when_no_banner_exists(self, tmp_path):
+        # Arrange
+        # (no banner written)
+        # Act
+        reset_banner(tmp_path)
+        # Assert
+        assert not banner_tex_path(tmp_path).exists()
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/scripts/python/test_compile_tex_structure.py
+++ b/tests/scripts/python/test_compile_tex_structure.py
@@ -676,5 +676,62 @@ class TestStyleFallbackAndFailLoud:
         assert success is False
 
 
+class TestCitationBannerInjection:
+    """The flattener injects the banner artifact after \\begin{document}."""
+
+    def _project_with_banner(self, tmp_path):
+        man = tmp_path / "01_manuscript"
+        man.mkdir(parents=True)
+        base = man / "base.tex"
+        base.write_text("\\begin{document}\n\\maketitle\nBody\n\\end{document}\n")
+        artifact = tmp_path / ".scitex" / "writer" / ".citation_banner.tex"
+        artifact.parent.mkdir(parents=True)
+        artifact.write_text(
+            "% scitex-writer citation banner (auto-generated)\nBANNERBODY\n"
+        )
+        return base, man / "out.tex"
+
+    def test_banner_artifact_is_injected_into_output(self, tmp_path):
+        # Arrange
+        base, out = self._project_with_banner(tmp_path)
+        # Act
+        compile_tex_structure(base_tex=base, output_tex=out, verbose=False)
+        # Assert
+        assert "scitex-writer citation banner" in out.read_text()
+
+    def test_banner_is_injected_after_begin_document(self, tmp_path):
+        # Arrange
+        base, out = self._project_with_banner(tmp_path)
+        # Act
+        compile_tex_structure(base_tex=base, output_tex=out, verbose=False)
+        # Assert
+        content = out.read_text()
+        assert content.index("\\begin{document}") < content.index(
+            "scitex-writer citation banner"
+        )
+
+    def test_no_banner_injected_when_artifact_absent(self, tmp_path):
+        # Arrange
+        man = tmp_path / "01_manuscript"
+        man.mkdir(parents=True)
+        base = man / "base.tex"
+        base.write_text("\\begin{document}\nBody\n\\end{document}\n")
+        out = man / "out.tex"
+        # Act
+        compile_tex_structure(base_tex=base, output_tex=out, verbose=False)
+        # Assert
+        assert "citation banner" not in out.read_text()
+
+    def test_reflatten_does_not_duplicate_the_banner(self, tmp_path):
+        # Arrange
+        base, out = self._project_with_banner(tmp_path)
+        compile_tex_structure(base_tex=base, output_tex=out, verbose=False)
+        # Act: flatten the already-injected output again.
+        out2 = base.parent / "out2.tex"
+        compile_tex_structure(base_tex=out, output_tex=out2, verbose=False)
+        # Assert
+        assert out2.read_text().count("scitex-writer citation banner") == 1
+
+
 if __name__ == "__main__":
     pytest.main([os.path.abspath(__file__), "-v"])


### PR DESCRIPTION
## Summary (DRAFT — needs Spartan host-validation of the LaTeX render)
Operator-directed (relayed by neurovista, all 4 design points confirmed). Adds the "compile-anyway" red-banner mode + the inline per-claim verification render.

**1. `banner` severity level (check-scoped).** `_severity.py` adds `banner` as a level valid ONLY for the `citations` check (via `_BANNER_CHECKS`, mirroring the `repair` scoping) — the global off/warn/error ladder is untouched for every other check. Effective ladder for citations: **error/strict** (FAIL, no PDF — submission gate) > **banner** (PDF + red page-1 box — accepted-risk draft) > **warn** (console only) > **off**.

**2. Banner mode.** `check_citations.py` in `banner` mode writes a red page-1 banner artifact and returns 0 (compile proceeds); it resets any stale banner each run so a now-clean compile never re-injects one. **strict + clew-unreachable = FAIL** is the confirmed default (clew wiring not present yet → `clew_unreachable=False` for now; the hook is in place).

**3. Banner render + injection.** `_citation_banner.py` (extracted so `check_citations.py` stays <512 lines) builds the red tcolorbox ("UNVERIFIED CITATIONS — NOT FOR SUBMISSION" + failing keys/reasons, + a "clew UNREACHABLE" line when degraded). `compile_tex_structure.py` injects it **after `\begin{document}`, before `\maketitle`** (top of page 1), sentinel-guarded so a reflatten can't duplicate it (same idempotency as #217).

**4. Inline `\clewverified{text}{status}{source}`** in `formatting.tex`: verified → underline (`\ul`) + `\href` to source; any other status → bare ("unverified = no decoration"). `\providecommand` safe default, no `@` catcodes (flatten-safe). The per-cite DATA (which keys are verified) comes from `clew.verify_citations` — that half lands when scitex-clew defines its batch lookup; the banner content + inline macro share the one result.

## Why draft
The banner box + `\clewverified` underline are LaTeX renders I cannot validate in-container (no TeX). Auto-merge would otherwise ship them unvalidated. **@neurovista will host-validate the banner + underline on the real neurovista paper on Spartan; once the render is confirmed I mark ready → merge → 2.24.8.**

## Test plan
- [x] Python validated in-container: banner level resolves (and is rejected for non-citations checks); banner mode → exit 0 + artifact written; strict → exit 1 + no artifact; clean run removes stale banner; flattener injects after `\begin{document}` and is idempotent on reflatten. Local `scitex-dev audit` clean.
- [ ] CI green (Python).
- [ ] **Spartan host-validation (neurovista): red banner renders at top of page 1; `\clewverified` underline+link renders; no LaTeX errors on the real paper.**