### PR TITLE
feat(compile): list exact undefined \ref/\cite keys in the post-compile gate

### DIFF
--- a/scripts/python/check_compile_artifacts.py
+++ b/scripts/python/check_compile_artifacts.py
@@ -19,9 +19,12 @@
 #              when absent the image check is skipped with a warning. The
 #              compute env that actually compiles has poppler (e.g. Spartan via
 #              `module load texlive`); a bare laptop/container may not.
-#            SECONDARY (log scan): missing-graphics / "File `..' not found" /
-#              "There were undefined references" / "Citation `..' undefined" in
-#              the LaTeX .log. The intentional scitex self-citation NUDGE
+#            SECONDARY (log scan): missing-graphics / "File `..' not found" in
+#              the LaTeX .log; and UNDEFINED cross-references / citations -- it
+#              LISTS the exact unresolved \ref / \cite keys (the ?? / [?] that
+#              render in the PDF), e.g. "undefined reference(s): tab:2_scorecard,
+#              tab:3_clinical", falling back to the aggregate "There were
+#              undefined references". The intentional scitex self-citation NUDGE
 #              ("SciTeX Writer citation not found") is NOT a trigger.
 #
 #          Severity precedence (highest -> lowest):
@@ -65,14 +68,24 @@ FAIL_COUNT = 0
 
 _LEVELS = ("off", "warn", "error")
 
-# Secondary log-scan deficiency patterns. The scitex self-citation nudge is a
-# stdout print (not in the .log) AND intentional -- never a trigger.
-_LOG_PATTERNS = (
+# Secondary log-scan: missing-file/graphic patterns. The scitex self-citation
+# nudge is a stdout print (not in the .log) AND intentional -- never a trigger.
+_FILE_PATTERNS = (
     (re.compile(r"File [`'][^']+' not found"), "missing file/graphic"),
     (re.compile(r"!\s*LaTeX Error: File [`'][^']+' not found"), "missing input file"),
-    (re.compile(r"There were undefined references"), "undefined references"),
-    (re.compile(r"Citation [`'][^']+' (?:on page .*)?undefined"), "undefined citation"),
 )
+
+# Undefined cross-reference / citation warnings. LaTeX emits one line PER
+# unresolved key, e.g. "LaTeX Warning: Reference `tab:foo' on page 3 undefined
+# on input line 42." -- capturing the key lets the gate LIST exactly which
+# \ref/\cite are unresolved (the ?? / [?] that must never ship) instead of a
+# bare "undefined references". The aggregate line is the catch-all fallback.
+_UNDEF_REF_RE = re.compile(r"Reference [`']([^']+)'[^\n]*?undefined")
+_UNDEF_CITE_RE = re.compile(r"Citation [`']([^']+)'[^\n]*?undefined")
+_UNDEF_AGG_RE = re.compile(r"There were undefined references")
+
+# Cap names listed in one report line.
+_MAX_NAMES = 25
 
 
 def log_pass(msg):
@@ -139,6 +152,36 @@ def count_pdf_images(pdf_path):
     return len(rows)
 
 
+def _dedupe(names):
+    """Order-preserving de-dup (LaTeX repeats a warning per page)."""
+    seen = set()
+    out = []
+    for n in names:
+        if n not in seen:
+            seen.add(n)
+            out.append(n)
+    return out
+
+
+def extract_undefined(text):
+    """Return (undefined_refs, undefined_cites) key names from a LaTeX log.
+
+    Each is an order-preserving, de-duplicated list of the keys LaTeX reported
+    as undefined (the ?? / [?] that render in the PDF).
+    """
+    return (
+        _dedupe(_UNDEF_REF_RE.findall(text)),
+        _dedupe(_UNDEF_CITE_RE.findall(text)),
+    )
+
+
+def _fmt_names(names):
+    """Comma-join names, capped at _MAX_NAMES with a '(+N more)' suffix."""
+    shown = ", ".join(names[:_MAX_NAMES])
+    extra = len(names) - _MAX_NAMES
+    return shown + (f" (+{extra} more)" if extra > 0 else "")
+
+
 def _scan_log(log_path, report):
     """Secondary: scan the LaTeX log for deficiency signals (not the self-cite
     nudge). ``report`` is log_fail or log_warn per resolved level."""
@@ -148,9 +191,19 @@ def _scan_log(log_path, report):
         text = Path(log_path).read_text(encoding="utf-8", errors="replace")
     except OSError:
         return
-    for pattern, label in _LOG_PATTERNS:
+    for pattern, label in _FILE_PATTERNS:
         if pattern.search(text):
             report(f"log: {label}")
+    # Undefined \ref / \cite -- list the exact keys (?? / [?] in the PDF).
+    refs, cites = extract_undefined(text)
+    if refs:
+        report(f"{len(refs)} undefined reference(s) [?? in PDF]: {_fmt_names(refs)}")
+    if cites:
+        report(f"{len(cites)} undefined citation(s) [[?] in PDF]: {_fmt_names(cites)}")
+    # Aggregate fallback: catch "There were undefined references" even if the
+    # per-key warnings were absent (e.g. a truncated / hint-only log).
+    if not refs and not cites and _UNDEF_AGG_RE.search(text):
+        report("log: there were undefined references (unresolved \\ref/\\cite)")
 
 
 def main():

--- a/tests/scripts/python/test_check_compile_artifacts.py
+++ b/tests/scripts/python/test_check_compile_artifacts.py
@@ -20,6 +20,7 @@ sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
 from check_compile_artifacts import (  # noqa: E402
     count_includegraphics,
     count_pdf_images,
+    extract_undefined,
 )
 
 _SCRIPT = ROOT_DIR / "scripts" / "python" / "check_compile_artifacts.py"
@@ -226,3 +227,65 @@ def test_log_scan_ignores_scitex_citation_nudge(tmp_path):
                 "--log", str(tmp_path / "c.log"), rows=0)
     # Assert
     assert proc.returncode == 0
+
+
+# ============================================================================
+# extract_undefined  (list the exact ?? / [?] keys from the log)
+# ============================================================================
+
+
+def test_extract_undefined_returns_reference_keys():
+    # Arrange
+    log = "LaTeX Warning: Reference `tab:foo' on page 3 undefined on input line 42.\n"
+    # Act
+    refs, cites = extract_undefined(log)
+    # Assert
+    assert refs == ["tab:foo"]
+
+
+def test_extract_undefined_returns_citation_keys():
+    # Arrange
+    log = "LaTeX Warning: Citation `Kuhlmann2018' on page 2 undefined on input line 9.\n"
+    # Act
+    refs, cites = extract_undefined(log)
+    # Assert
+    assert cites == ["Kuhlmann2018"]
+
+
+def test_extract_undefined_dedupes_repeated_keys():
+    # Arrange: LaTeX repeats the same warning once per page.
+    log = (
+        "LaTeX Warning: Reference `tab:x' on page 1 undefined on input line 5.\n"
+        "LaTeX Warning: Reference `tab:x' on page 2 undefined on input line 6.\n"
+    )
+    # Act
+    refs, cites = extract_undefined(log)
+    # Assert
+    assert refs == ["tab:x"]
+
+
+def test_extract_undefined_empty_when_clean():
+    # Arrange
+    log = "This is a clean log with no undefined warnings.\n"
+    # Act
+    refs, cites = extract_undefined(log)
+    # Assert
+    assert (refs == []) and (cites == [])
+
+
+def test_undefined_reference_log_fails_and_lists_the_key(tmp_path):
+    # Arrange: 0 figures (primary check passes) + a log with an undefined \ref.
+    _write(tmp_path, "compiled.tex", _TEX_0)
+    _write(tmp_path, "out.pdf", "%PDF-1.5\n")
+    _write(
+        tmp_path,
+        "c.log",
+        "LaTeX Warning: Reference `tab:2_scorecard' on page 3 undefined on input line 42.\n"
+        "LaTeX Warning: There were undefined references.\n",
+    )
+    # Act
+    proc = _run(tmp_path, "--compiled-tex", str(tmp_path / "compiled.tex"),
+                "--pdf", str(tmp_path / "out.pdf"),
+                "--log", str(tmp_path / "c.log"), rows=0)
+    # Assert
+    assert (proc.returncode == 1) and ("tab:2_scorecard" in proc.stdout)


### PR DESCRIPTION
## Summary
The operator's 事案 gate — fail loud when a compile ENDS with `??` / `[?]` — **already exists** in `check_compile_artifacts.py` (post-compile verification at compile_manuscript.sh:408): it FAILs (default error) on "There were undefined references" / "Citation `X' undefined". This PR makes that failure **actionable**: it now extracts and LISTS the exact unresolved keys instead of a bare label.

- New `extract_undefined(log_text) -> (refs, cites)` — order-preserving, de-duplicated key names parsed from `LaTeX Warning: Reference/Citation \`X' ... undefined`.
- `_scan_log` now reports e.g. `1 undefined reference(s) [?? in PDF]: tab:2_scorecard` and `2 undefined citation(s) [[?] in PDF]: Kuhlmann2018, Freestone2015`, with the aggregate "There were undefined references" as a fallback for truncated logs.
- Feeds the 2.24.8 red banner (#223) with the specific keys.

Pure-Python log parsing — fully CI-validatable, no host toolchain needed.

Context (neurovista incident): a `??`/`[?]` ships only if the compile dies BEFORE this post-compile stage (e.g. the wordcount `\read` emergency-stop — fixed in #224) or runs a stale vendored engine. This gate + #224 + re-vendoring 2.24.7 closes it.

## Test plan
- [x] `extract_undefined`: reference keys, citation keys, de-dup of per-page repeats, empty on clean log.
- [x] CLI: an undefined-`\ref` log → exit 1 and the specific key (`tab:2_scorecard`) appears in output. Validated in-container; local `scitex-dev audit` clean.
- [ ] CI green.