### PR TITLE
fix(compile): enforce hard compile-timeout ceiling by default (fail-fast)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,15 @@
+# Claude Code Telegrammer
+export CCT_AGENT_ID="scitex-writer"
+# no bot yet: export CCT_BOT_TOKEN="$CCT_BOT_TOKEN_SCITEX_WRITER"
+export CCT_STATE_DIR="$CCT_STATE_DIR"
+export CCT_ALLOWED_USERS="$CCT_ALLOWED_USERS"
+
+# SciTeX Writer
+export SCITEX_WRITER_DARK_MODE=true
+
+# Spartan texlive
+_NV_TEXLIVE_BIN=/apps/easybuild-2022/easybuild/software/Compiler/GCCcore/11.3.0/texlive/20230313/bin/x86_64-linux
+[ -d "$_NV_TEXLIVE_BIN" ] && export PATH="$_NV_TEXLIVE_BIN:$PATH"
+
+# SciTeX Todo
+export SCITEX_TODO_AGENT="scitex-writer"

--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,6 @@
 # Claude Code Telegrammer
 export CCT_AGENT_ID="scitex-writer"
-# no bot yet: export CCT_BOT_TOKEN="$CCT_BOT_TOKEN_SCITEX_WRITER"
+export CCT_BOT_TOKEN="$CCT_BOT_TOKEN_SCITEX_WRITER"
 export CCT_ALLOWED_USERS="8379369979"
 
 # SciTeX Writer

--- a/.envrc
+++ b/.envrc
@@ -1,8 +1,7 @@
 # Claude Code Telegrammer
 export CCT_AGENT_ID="scitex-writer"
 # no bot yet: export CCT_BOT_TOKEN="$CCT_BOT_TOKEN_SCITEX_WRITER"
-export CCT_STATE_DIR="$CCT_STATE_DIR"
-export CCT_ALLOWED_USERS="$CCT_ALLOWED_USERS"
+export CCT_ALLOWED_USERS="8379369979"
 
 # SciTeX Writer
 export SCITEX_WRITER_DARK_MODE=true
@@ -12,4 +11,4 @@ _NV_TEXLIVE_BIN=/apps/easybuild-2022/easybuild/software/Compiler/GCCcore/11.3.0/
 [ -d "$_NV_TEXLIVE_BIN" ] && export PATH="$_NV_TEXLIVE_BIN:$PATH"
 
 # SciTeX Todo
-export SCITEX_TODO_AGENT="scitex-writer"
+export SCITEX_TODO_AGENT_ID="scitex-writer"

--- a/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
+++ b/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
@@ -52,6 +52,20 @@ log_info "Running $0 ..."
 compiled_tex_to_pdf() {
     log_info "    Converting $SCITEX_WRITER_COMPILED_TEX to PDF..."
 
+    # Fail-fast ceiling: enforce a hard compile timeout by DEFAULT so a wedged
+    # LaTeX/bibtex run (e.g. a terminal prompt -interaction=nonstopmode cannot
+    # answer) NEVER hangs silently. Every engine already honors
+    # SCITEX_WRITER_COMPILE_TIMEOUT via a `timeout` prefix + exit-124 check;
+    # setting it here at the single dispatch point makes the ceiling opt-OUT
+    # rather than opt-in (previously only diff-compile set it). Diff-compile's
+    # own (shorter) value is preserved -- `:=` defaults only when UNSET. Opt out
+    # with 0/off/none/false (mapped to empty so the engines skip the prefix).
+    : "${SCITEX_WRITER_COMPILE_TIMEOUT:=${SCITEX_WRITER_COMPILE_TIMEOUT_DEFAULT:-300}}"
+    case "${SCITEX_WRITER_COMPILE_TIMEOUT}" in
+    0 | off | none | false | disabled) SCITEX_WRITER_COMPILE_TIMEOUT="" ;;
+    esac
+    export SCITEX_WRITER_COMPILE_TIMEOUT
+
     local tex_file="$SCITEX_WRITER_COMPILED_TEX"
     local engine="${SCITEX_WRITER_SELECTED_ENGINE:-3pass}"
 


### PR DESCRIPTION
## What
Default `SCITEX_WRITER_COMPILE_TIMEOUT` to **300s** at the single dispatch point (`compiled_tex_to_pdf`), making the compile-timeout ceiling **opt-OUT** instead of opt-in.

## Why
All 3 engines (3pass/latexmk/tectonic) already honor `SCITEX_WRITER_COMPILE_TIMEOUT` via a `timeout` prefix + exit-124 check — but it was only ever set by diff-compile. A normal compile had **no ceiling**, so a wedged LaTeX/bibtex run (a terminal prompt `-interaction=nonstopmode` can't answer) would hang forever with no PDF and no error.

Surfaced by paper-scitex-clew (their ~2h hang was a container mispath, not this engine — but the missing default ceiling was a real writer-side gap). `-interaction=nonstopmode` is already present in all engines; this is the complementary defense-in-depth.

## Behavior
- unset → **300s** ceiling applied
- diff-compile's own shorter value → **preserved** (`:=` defaults only when unset)
- `0`/`off`/`none`/`false`/`disabled` → **opt out** (empty → engines skip the prefix)
- override via `SCITEX_WRITER_COMPILE_TIMEOUT` or `SCITEX_WRITER_COMPILE_TIMEOUT_DEFAULT`

Constitution: fail-fast, fail-loud, no silent hang. Card: writer-compile-default-timeout.