### PR TITLE
fix(wordcount): never emit empty count -> siunitx no longer fatal (neurovista)

### DIFF
--- a/00_shared/latex_styles/formatting.tex
+++ b/00_shared/latex_styles/formatting.tex
@@ -60,9 +60,19 @@
 %% --- Word count ---
 \newread\wordcount
 \newcommand\readwordcount[1]{%
-\openin\wordcount=#1
+\openin\wordcount=#1\relax
+% Guard: a missing OR empty count file must NEVER reach \num as an empty
+% argument -- siunitx then errors "Invalid number", which is FATAL and fails
+% every latexmk pass (so citations render as [?]). \ifeof is true for both a
+% missing file and a 0-byte file; the post-read \ifx catches a blank line.
+% Default to 0 in all those cases. (neurovista incident 2026-07-04.)
+\ifeof\wordcount
+\def\thewordcount{0}%
+\else
 \read\wordcount to \thewordcount
+\fi
 \closein\wordcount
+\ifx\thewordcount\empty\def\thewordcount{0}\fi
 \begingroup\sisetup{round-mode=none,group-separator={,},group-minimum-digits=4}\num{\thewordcount}\endgroup%
 }
 

--- a/scripts/shell/modules/count_words.sh
+++ b/scripts/shell/modules/count_words.sh
@@ -86,7 +86,16 @@ _count_words() {
         return 1
     fi
 
-    eval "$TEXCOUNT_CMD \"$input_file\" -inc -1 -sum 2> >(grep -v 'gocryptfs not found' >&2)" >"$output_file"
+    # NEVER write an empty/non-numeric count file: an empty file makes the
+    # manuscript's \readwordcount emit \num{} -> siunitx "Invalid number" ->
+    # EVERY latexmk pass fails -> citations render as [?] (neurovista incident
+    # 2026-07-04). So capture texcount, extract the first integer, and default
+    # to 0 when texcount printed nothing (empty section / warning-only output /
+    # texcount hiccup). Fail-safe, never fatal.
+    local _raw _count
+    _raw=$(eval "$TEXCOUNT_CMD \"$input_file\" -inc -1 -sum 2> >(grep -v 'gocryptfs not found' >&2)")
+    _count=$(printf '%s' "$_raw" | grep -oE '[0-9]+' | head -1)
+    echo "${_count:-0}" >"$output_file"
 }
 
 count_tables() {


### PR DESCRIPTION
## Incident
neurovista (real paper, branch feat/restructure-to-5-figs) — the word-count step wrote **empty** `contents/*_count.txt` files. The manuscript's `\readwordcount` then fed `\num{}` to siunitx → **"Invalid number"**, which is fatal and failed **every** latexmk pass → all citations rendered as `[?]`. neurovista had to hand-populate the counts to compile.

## Fix (two fail-safes)
1. **`count_words.sh::_count_words`** — capture `texcount` output, extract the first integer, default to `0` when texcount printed nothing (empty section / warning-only output / hiccup). Never writes an empty file. (Root cause: it previously redirected raw texcount stdout with no validation.)
2. **`formatting.tex::\readwordcount`** — `\ifeof` guard (missing OR 0-byte file → 0) + post-read `\ifx`-empty fallback, so even a stray empty count file can never reach `\num` as an empty argument.

Belt-and-suspenders: the step stops producing empties, and the macro tolerates any that slip through. Fail-safe, never fatal. `bash -n` clean; digit-extract/default logic verified (empty→0, "File(s) total: 342"→342). LaTeX macro not runnable in-container → CI/host compile is the gate.