### PR TITLE
fix(render_clew): resolve .scitex/clew at the git root (nested-writer feed)

### DIFF
--- a/scripts/python/render_clew.py
+++ b/scripts/python/render_clew.py
@@ -102,7 +102,13 @@ def _claim_value(claim):
     """The display string for a claim. clew stores it display-ready; try the
     known field names in order (`claim_value` is the clew 0.2.19 key)."""
     v = _first(
-        claim, "claim_value", "value", "display_value", "latex", "rendered_value", "text"
+        claim,
+        "claim_value",
+        "value",
+        "display_value",
+        "latex",
+        "rendered_value",
+        "text",
     )
     return "" if v is None else str(v)
 
@@ -138,7 +144,9 @@ def _resolve_palette(data):
     raw = data.get("palette") or data.get("display_palette") or {}
     if isinstance(raw, dict):
         for status, color in raw.items():
-            h = _hex(color if not isinstance(color, dict) else _first(color, "hex", "color"))
+            h = _hex(
+                color if not isinstance(color, dict) else _first(color, "hex", "color")
+            )
             key = _STATUS_SYNONYMS.get(str(status).lower(), str(status).lower())
             if h:
                 palette[key] = h
@@ -209,7 +217,9 @@ def render_clew_tex(data):
     total, verified, allverified = _aggregate(data, claims)
 
     lines = ["\\makeatletter", ""]
-    lines.append("%% --- palette (from clew claims.json; writer has \\providecolor fallbacks) ---")
+    lines.append(
+        "%% --- palette (from clew claims.json; writer has \\providecolor fallbacks) ---"
+    )
     for status, name in _STATUS_COLOR.items():
         lines.append(f"\\definecolor{{{name}}}{{HTML}}{{{palette[status]}}}")
     lines += ["", "%% --- aggregate ---"]
@@ -232,7 +242,9 @@ def render_clew_tex(data):
         verdict = _verdict(claim)
         # `display_color` is the frozen contract name (clew 0.4.0 emits it);
         # color/hex are accepted aliases. Fall back to the verdict palette.
-        color = _hex(_first(claim, "display_color", "color", "hex")) or palette.get(verdict)
+        color = _hex(_first(claim, "display_color", "color", "hex")) or palette.get(
+            verdict
+        )
         value = _claim_value(claim)
         lines.append(f"%% {claim.get('claim_id', cid)} [{verdict}]")
         lines.append(f"\\@namedef{{clew@val@{cid}}}{{{value}}}")
@@ -245,10 +257,40 @@ def render_clew_tex(data):
     return "\n".join(lines) + "\n"
 
 
+def _find_git_root(start):
+    """Nearest ancestor of ``start`` containing ``.git`` (a git root), or None.
+    Bounded walk so a pathological tree can't spin."""
+    cur = start
+    for _ in range(64):
+        if (cur / ".git").exists():
+            return cur
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+    return None
+
+
+def _resolve_claims_json(project_path):
+    r"""Locate .scitex/clew/runtime/claims.json the way clew resolves its OWN db:
+    at the GIT ROOT. This makes NESTED-writer projects work -- when scitex-writer
+    is vendored UNDER an outer repo (e.g. at ``.scitex/writer/``) whose
+    ``.scitex/clew`` at the git root is the real feed, clew writes the export at
+    the git root, so render_clew must READ it there too (not under the writer
+    subdir). Preference: git-root/.scitex/clew when that dir exists; else fall
+    back to project_path/.scitex/clew -- the flat/common case (project IS its own
+    git root) is unchanged, and a stray empty .scitex/clew under the writer
+    subdir is ignored in favor of the real git-root feed. (nested-writer bug
+    surfaced by paper-neurovista, 2026-07-04.)"""
+    root = _find_git_root(project_path)
+    if root is not None and (root / ".scitex" / "clew").is_dir():
+        return root / ".scitex" / "clew" / "runtime" / "claims.json"
+    return project_path / CLAIMS_JSON
+
+
 def main(argv):
     project_dir = argv[1] if len(argv) > 1 else "."
     project_path = Path(project_dir).resolve()
-    claims_json = project_path / CLAIMS_JSON
+    claims_json = _resolve_claims_json(project_path)
 
     if not claims_json.exists():
         return 0  # clew layer optional -- no-op
@@ -268,8 +310,7 @@ def main(argv):
         tex = render_clew_tex(data)
     except Exception as exc:  # malformed schema -- surface, don't ship stale
         print(
-            f"ERRO:     Failed to render clew_rendered.tex from {claims_json}: "
-            f"{exc}.",
+            f"ERRO:     Failed to render clew_rendered.tex from {claims_json}: {exc}.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/python/render_clew_toggles.py
+++ b/scripts/python/render_clew_toggles.py
@@ -45,10 +45,37 @@ _TRUTHY = ("1", "true", "yes", "on")
 _FALSY = ("0", "false", "no", "off")
 
 
+def _find_git_root(start):
+    """Nearest ancestor of ``start`` containing ``.git`` (a git root), or None."""
+    cur = Path(start)
+    for _ in range(64):
+        if (cur / ".git").exists():
+            return cur
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+    return None
+
+
+def _resolve_config_yaml(project_dir):
+    r"""Locate .scitex/writer/config.yaml at the GIT ROOT -- same walk render_clew.py
+    uses for the clew db -- so a NESTED-writer project (writer vendored under an
+    outer repo, e.g. at .scitex/writer/) reads the config at the outer git root
+    rather than a doubly-nested <writer>/.scitex/writer/config.yaml (which is
+    absent, leaving \clewpresmarkers OFF and marks plain). Preference: git-root
+    copy when present; else fall back to PROJECT_ROOT (flat case unchanged).
+    (nested-writer toggle bug surfaced by paper-neurovista, 2026-07-04.)"""
+    project_dir = Path(project_dir)
+    root = _find_git_root(project_dir)
+    if root is not None and (root / CONFIG_YAML).is_file():
+        return root / CONFIG_YAML
+    return project_dir / CONFIG_YAML
+
+
 def _read_config_value(project_dir):
     """Return the raw `clew_presentation` value from the project config, or None
     (PyYAML optional -- absent it, only env resolves)."""
-    cfg = Path(project_dir) / CONFIG_YAML
+    cfg = _resolve_config_yaml(project_dir)
     if not cfg.is_file():
         return None
     try:
@@ -107,15 +134,11 @@ def resolve_toggles(config_value, env_value):
                 continue  # ignore unknown/future keys (e.g. legend_first)
             b = _scalar_bool(val)
             if b is None:
-                raise ValueError(
-                    f"clew_presentation.{name}={val!r} is not true/false"
-                )
+                raise ValueError(f"clew_presentation.{name}={val!r} is not true/false")
             toggles[name] = b
         return toggles
 
-    raise ValueError(
-        f"clew_presentation={config_value!r} must be on/off or a mapping"
-    )
+    raise ValueError(f"clew_presentation={config_value!r} must be on/off or a mapping")
 
 
 def render_toggles_tex(toggles):

--- a/tests/scripts/python/test_render_clew.py
+++ b/tests/scripts/python/test_render_clew.py
@@ -6,6 +6,8 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
 
@@ -13,6 +15,30 @@ from render_clew import (  # noqa: E402
     render_clew_tex,
     sanitize_id,
 )
+
+_CLEW_VERSION_VAR = "SCITEX_WRITER_CLEW_VERSION"
+
+
+@pytest.fixture
+def clew_version_env():
+    """Set/clear ``SCITEX_WRITER_CLEW_VERSION``; restore on teardown.
+
+    A real env mutation with cleanup, no monkeypatch fixture — mirrors
+    the pattern in tests/scitex_writer/test__branding.py's
+    ``reload_branding`` fixture.
+    """
+    saved = os.environ.get(_CLEW_VERSION_VAR)
+
+    def _set(value: str | None) -> None:
+        if value is None:
+            os.environ.pop(_CLEW_VERSION_VAR, None)
+        else:
+            os.environ[_CLEW_VERSION_VAR] = value
+
+    try:
+        yield _set
+    finally:
+        _set(saved)
 
 
 class TestSanitizeId:
@@ -43,10 +69,18 @@ class TestRenderClewTex:
         },
         "attestation": {"verified_count": 2, "unverified_count": 1},
         "claims": [
-            {"claim_id": "results_repro", "status": "verified",
-             "color": "#2E7D32", "value": "13/15 reproduce; p=0.0037"},
-            {"claim_id": "table1_events", "status": "unverified",
-             "color": "C62828", "value": "Table 1 events"},
+            {
+                "claim_id": "results_repro",
+                "status": "verified",
+                "color": "#2E7D32",
+                "value": "13/15 reproduce; p=0.0037",
+            },
+            {
+                "claim_id": "table1_events",
+                "status": "unverified",
+                "color": "C62828",
+                "value": "Table 1 events",
+            },
         ],
     }
 
@@ -55,7 +89,9 @@ class TestRenderClewTex:
         # Act
         tex = render_clew_tex(self._DATA)
         # Assert
-        assert tex.startswith("\\makeatletter") and tex.rstrip().endswith("\\makeatother")
+        assert tex.startswith("\\makeatletter") and tex.rstrip().endswith(
+            "\\makeatother"
+        )
 
     def test_defines_the_four_palette_colors(self):
         # Arrange
@@ -121,9 +157,15 @@ class TestRenderClewTex:
 
     def test_value_emitted_verbatim_without_reescaping(self):
         # Arrange: clew provides display-ready LaTeX; must not be double-escaped.
-        data = {"claims": [
-            {"claim_id": "c", "status": "verified", "value": "AUC $\\times$ 0.58, clinical\\_only"}
-        ]}
+        data = {
+            "claims": [
+                {
+                    "claim_id": "c",
+                    "status": "verified",
+                    "value": "AUC $\\times$ 0.58, clinical\\_only",
+                }
+            ]
+        }
         # Act
         tex = render_clew_tex(data)
         # Assert
@@ -171,11 +213,13 @@ class TestClew0219Schema:
 
     def test_aggregate_computed_without_attestation_block(self):
         # Arrange: 2 registered (unverified) + 1 verified, no attestation.
-        data = {"claims": [
-            dict(self._CLAIM, claim_id="a"),
-            dict(self._CLAIM, claim_id="b"),
-            dict(self._CLAIM, claim_id="c", verified_at="2026-07-01T00:00:00Z"),
-        ]}
+        data = {
+            "claims": [
+                dict(self._CLAIM, claim_id="a"),
+                dict(self._CLAIM, claim_id="b"),
+                dict(self._CLAIM, claim_id="c", verified_at="2026-07-01T00:00:00Z"),
+            ]
+        }
         # Act
         tex = render_clew_tex(data)
         # Assert
@@ -197,10 +241,16 @@ class TestCitationAndFigureClaims:
 
     def test_verified_citation_emits_green_hex_by_bibkey(self):
         # Arrange
-        data = {"claims": [{
-            "claim_id": "Kuhlmann2018", "claim_type": "citation",
-            "status": "verified", "verified_at": "2026-07-01T00:00:00Z",
-        }]}
+        data = {
+            "claims": [
+                {
+                    "claim_id": "Kuhlmann2018",
+                    "claim_type": "citation",
+                    "status": "verified",
+                    "verified_at": "2026-07-01T00:00:00Z",
+                }
+            ]
+        }
         # Act
         tex = render_clew_tex(data)
         # Assert
@@ -208,10 +258,16 @@ class TestCitationAndFigureClaims:
 
     def test_unverified_citation_emits_red_hex_by_bibkey(self):
         # Arrange
-        data = {"claims": [{
-            "claim_id": "Freestone2015", "claim_type": "citation",
-            "status": "registered", "verified_at": None,
-        }]}
+        data = {
+            "claims": [
+                {
+                    "claim_id": "Freestone2015",
+                    "claim_type": "citation",
+                    "status": "registered",
+                    "verified_at": None,
+                }
+            ]
+        }
         # Act
         tex = render_clew_tex(data)
         # Assert
@@ -219,10 +275,16 @@ class TestCitationAndFigureClaims:
 
     def test_figure_claim_keyed_by_sanitized_save_path(self):
         # Arrange
-        data = {"claims": [{
-            "claim_id": "figures/01_main.jpg", "claim_type": "figure",
-            "status": "registered", "verified_at": None,
-        }]}
+        data = {
+            "claims": [
+                {
+                    "claim_id": "figures/01_main.jpg",
+                    "claim_type": "figure",
+                    "status": "registered",
+                    "verified_at": None,
+                }
+            ]
+        }
         # Act
         tex = render_clew_tex(data)
         # Assert
@@ -230,10 +292,16 @@ class TestCitationAndFigureClaims:
 
     def test_v15_failed_status_maps_to_red_bucket(self):
         # Arrange: unified schema 1.5 renamed the red state unverified->failed.
-        data = {"claims": [{
-            "claim_id": "Stub2023", "claim_type": "citation",
-            "status": "failed", "claim_value": "",
-        }]}
+        data = {
+            "claims": [
+                {
+                    "claim_id": "Stub2023",
+                    "claim_type": "citation",
+                    "status": "failed",
+                    "claim_value": "",
+                }
+            ]
+        }
         # Act
         tex = render_clew_tex(data)
         # Assert
@@ -244,10 +312,20 @@ class TestCitationAndFigureClaims:
     def test_v15_palette_failed_key_lands_on_red_color(self):
         # Arrange: 1.5 palette keys the red state "failed" (cf222e).
         data = {
-            "palette": {"verified": "2da44e", "suspect": "d29922",
-                        "failed": "cf222e", "exception": "8250df"},
-            "claims": [{"claim_id": "c", "claim_type": "value",
-                        "status": "failed", "claim_value": "x"}],
+            "palette": {
+                "verified": "2da44e",
+                "suspect": "d29922",
+                "failed": "cf222e",
+                "exception": "8250df",
+            },
+            "claims": [
+                {
+                    "claim_id": "c",
+                    "claim_type": "value",
+                    "status": "failed",
+                    "claim_value": "x",
+                }
+            ],
         }
         # Act
         tex = render_clew_tex(data)
@@ -257,8 +335,10 @@ class TestCitationAndFigureClaims:
     def test_v15_nested_attestation_counts_shape(self):
         # Arrange: 1.5 attestation nests counts {total, verified, ...}.
         data = {
-            "attestation": {"badge_state": "partial",
-                            "counts": {"total": 5, "verified": 2}},
+            "attestation": {
+                "badge_state": "partial",
+                "counts": {"total": 5, "verified": 2},
+            },
             "claims": [],
         }
         # Act
@@ -268,10 +348,17 @@ class TestCitationAndFigureClaims:
 
     def test_display_color_field_is_honored_over_palette(self):
         # Arrange: clew 0.4.0 emits per-entry `display_color` (frozen name).
-        data = {"claims": [{
-            "claim_id": "c", "claim_type": "value", "status": "verified",
-            "claim_value": "x", "display_color": "#123ABC",
-        }]}
+        data = {
+            "claims": [
+                {
+                    "claim_id": "c",
+                    "claim_type": "value",
+                    "status": "verified",
+                    "claim_value": "x",
+                    "display_color": "#123ABC",
+                }
+            ]
+        }
         # Act
         tex = render_clew_tex(data)
         # Assert
@@ -279,8 +366,16 @@ class TestCitationAndFigureClaims:
 
     def test_v16_unsourced_status_folds_to_amber_suspect(self):
         # Arrange: clew 1.6 adds an `unsourced` state; writer folds it to suspect.
-        data = {"claims": [{"claim_id": "u", "claim_type": "value",
-                            "status": "unsourced", "claim_value": "x"}]}
+        data = {
+            "claims": [
+                {
+                    "claim_id": "u",
+                    "claim_type": "value",
+                    "status": "unsourced",
+                    "claim_value": "x",
+                }
+            ]
+        }
         # Act
         tex = render_clew_tex(data)
         # Assert
@@ -289,9 +384,13 @@ class TestCitationAndFigureClaims:
     def test_v16_unsourced_palette_key_preserves_suspect_color(self):
         # Arrange: clew 1.6 palette carries BOTH suspect and unsourced hexes.
         data = {
-            "palette": {"verified": "2da44e", "suspect": "d29922",
-                        "unsourced": "b26a00", "failed": "cf222e",
-                        "exception": "8250df"},
+            "palette": {
+                "verified": "2da44e",
+                "suspect": "d29922",
+                "unsourced": "b26a00",
+                "failed": "cf222e",
+                "exception": "8250df",
+            },
             "claims": [],
         }
         # Act
@@ -305,52 +404,55 @@ class TestClewVersion:
     provenance attestation -- from the export's own stamp, else the CLI version
     captured into SCITEX_WRITER_CLEW_VERSION by render_clew.sh."""
 
-    def test_version_from_export_stamp_is_emitted(self, monkeypatch):
+    def test_version_from_export_stamp_is_emitted(self, clew_version_env):
         # Arrange
-        monkeypatch.delenv("SCITEX_WRITER_CLEW_VERSION", raising=False)
+        clew_version_env(None)
         data = {"clew_version": "0.8.0", "claims": []}
         # Act
         tex = render_clew_tex(data)
         # Assert
         assert "\\def\\clew@version{0.8.0}" in tex
 
-    def test_version_from_env_when_export_has_no_stamp(self, monkeypatch):
+    def test_version_from_env_when_export_has_no_stamp(self, clew_version_env):
         # Arrange
-        monkeypatch.setenv("SCITEX_WRITER_CLEW_VERSION", "0.9.1")
+        clew_version_env("0.9.1")
         # Act
         tex = render_clew_tex({"claims": []})
         # Assert
         assert "\\def\\clew@version{0.9.1}" in tex
 
-    def test_version_from_attestation_version_field(self, monkeypatch):
+    def test_version_from_attestation_version_field(self, clew_version_env):
         # Arrange: clew stamps the producing tool version at attestation.version.
-        monkeypatch.delenv("SCITEX_WRITER_CLEW_VERSION", raising=False)
-        data = {"attestation": {"version": "0.8.1", "counts": {"total": 0, "verified": 0}}, "claims": []}
+        clew_version_env(None)
+        data = {
+            "attestation": {"version": "0.8.1", "counts": {"total": 0, "verified": 0}},
+            "claims": [],
+        }
         # Act
         tex = render_clew_tex(data)
         # Assert
         assert "\\def\\clew@version{0.8.1}" in tex
 
-    def test_no_version_macro_when_source_unknown(self, monkeypatch):
+    def test_no_version_macro_when_source_unknown(self, clew_version_env):
         # Arrange
-        monkeypatch.delenv("SCITEX_WRITER_CLEW_VERSION", raising=False)
+        clew_version_env(None)
         # Act
         tex = render_clew_tex({"claims": []})
         # Assert
         assert "\\def\\clew@version" not in tex
 
-    def test_version_sanitized_to_latex_safe_token(self, monkeypatch):
+    def test_version_sanitized_to_latex_safe_token(self, clew_version_env):
         # Arrange
-        monkeypatch.delenv("SCITEX_WRITER_CLEW_VERSION", raising=False)
+        clew_version_env(None)
         data = {"clew_version": "0.8.0\\evil{}", "claims": []}
         # Act
         tex = render_clew_tex(data)
         # Assert
         assert "\\def\\clew@version{0.8.0evil}" in tex
 
-    def test_bare_schema_version_is_not_used_as_tool_version(self, monkeypatch):
+    def test_bare_schema_version_is_not_used_as_tool_version(self, clew_version_env):
         # Arrange: top-level `version` is the SCHEMA version, not the tool version.
-        monkeypatch.delenv("SCITEX_WRITER_CLEW_VERSION", raising=False)
+        clew_version_env(None)
         data = {"version": "1.6", "claims": []}
         # Act
         tex = render_clew_tex(data)

--- a/tests/scripts/python/test_render_clew_gitroot.py
+++ b/tests/scripts/python/test_render_clew_gitroot.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: render_clew.py git-root .scitex/clew resolution (nested-writer).
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from render_clew import (  # noqa: E402
+    CLAIMS_JSON,
+    _resolve_claims_json,
+)
+
+
+class TestResolveClaimsJson:
+    def test_nested_writer_resolves_git_root_feed(self, tmp_path):
+        # Arrange: writer vendored under an outer git repo whose .scitex/clew is
+        # the real feed; a STRAY empty .scitex/clew sits under the writer subdir.
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".scitex" / "clew" / "runtime").mkdir(parents=True)
+        writer = tmp_path / ".scitex" / "writer"
+        (writer / ".scitex" / "clew" / "runtime").mkdir(parents=True)
+        # Act
+        resolved = _resolve_claims_json(writer)
+        # Assert
+        assert resolved == tmp_path / ".scitex" / "clew" / "runtime" / "claims.json"
+
+    def test_flat_project_resolves_its_own_clew(self, tmp_path):
+        # Arrange: project IS its own git root with .scitex/clew (common case).
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".scitex" / "clew" / "runtime").mkdir(parents=True)
+        # Act
+        resolved = _resolve_claims_json(tmp_path)
+        # Assert
+        assert resolved == tmp_path / ".scitex" / "clew" / "runtime" / "claims.json"
+
+    def test_no_git_root_falls_back_to_project_path(self, tmp_path):
+        # Arrange: no .git anywhere above the project.
+        project = tmp_path / "proj"
+        project.mkdir()
+        # Act
+        resolved = _resolve_claims_json(project)
+        # Assert
+        assert resolved == project / CLAIMS_JSON
+
+    def test_git_root_without_clew_falls_back_to_project_path(self, tmp_path):
+        # Arrange: a git root exists but never ran clew (no .scitex/clew there).
+        (tmp_path / ".git").mkdir()
+        project = tmp_path / "sub"
+        project.mkdir()
+        # Act
+        resolved = _resolve_claims_json(project)
+        # Assert
+        assert resolved == project / CLAIMS_JSON
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))
+
+# EOF

--- a/tests/scripts/python/test_render_clew_gitroot.py
+++ b/tests/scripts/python/test_render_clew_gitroot.py
@@ -12,6 +12,10 @@ from render_clew import (  # noqa: E402
     CLAIMS_JSON,
     _resolve_claims_json,
 )
+from render_clew_toggles import (  # noqa: E402
+    CONFIG_YAML,
+    _resolve_config_yaml,
+)
 
 
 class TestResolveClaimsJson:
@@ -54,6 +58,39 @@ class TestResolveClaimsJson:
         resolved = _resolve_claims_json(project)
         # Assert
         assert resolved == project / CLAIMS_JSON
+
+
+class TestResolveConfigYaml:
+    def test_nested_writer_resolves_git_root_config(self, tmp_path):
+        # Arrange: writer vendored under an outer git repo; config at the outer
+        # git root's .scitex/writer/, NOT doubly-nested under the writer subdir.
+        (tmp_path / ".git").mkdir()
+        writer = tmp_path / ".scitex" / "writer"
+        writer.mkdir(parents=True)
+        (writer / "config.yaml").write_text("clew_presentation: on\n")
+        # Act
+        resolved = _resolve_config_yaml(writer)
+        # Assert
+        assert resolved == tmp_path / CONFIG_YAML
+
+    def test_flat_project_resolves_its_own_config(self, tmp_path):
+        # Arrange
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".scitex" / "writer").mkdir(parents=True)
+        (tmp_path / CONFIG_YAML).write_text("clew_presentation: on\n")
+        # Act
+        resolved = _resolve_config_yaml(tmp_path)
+        # Assert
+        assert resolved == tmp_path / CONFIG_YAML
+
+    def test_no_git_root_falls_back_to_project_path(self, tmp_path):
+        # Arrange
+        project = tmp_path / "proj"
+        project.mkdir()
+        # Act
+        resolved = _resolve_config_yaml(project)
+        # Assert
+        assert resolved == project / CONFIG_YAML
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Bug (paper-neurovista, real paper)
In a **nested-writer** project (scitex-writer vendored under an outer repo — e.g. at `.scitex/writer/`), `render_clew.py` read the clew feed at `PROJECT_ROOT/.scitex/clew`, but **clew writes its db at the git root**. So render_clew read a missing/stray-empty path → emitted `\clew@total{0}` → every `\clewmark`/`\clewval` rendered **plain** instead of verdict-colored, even with a populated 83-claim feed.

## Fix
`_resolve_claims_json` walks up from PROJECT_ROOT to the nearest `.git` and reads that git root's `.scitex/clew/runtime/claims.json` — matching how clew resolves its own db. Preference: git-root `.scitex/clew` when it exists; else fall back to `PROJECT_ROOT/.scitex/clew`. So:
- **flat/common case** (project IS its own git root) — unchanged;
- **nested-writer** — resolves the real git-root feed, no bridge symlink needed;
- a **stray empty** `.scitex/clew` under the writer subdir is ignored in favor of the real git-root feed.

## Verification (local, sac-scitex)
Reproduced the nested layout — real 83-claim feed at the git root + a stray empty feed under the writer subdir — and `\clew@total` flips **0 → 83** with the per-claim blocks emitted; flat case unchanged. 4 AAA tests (nested / flat / no-git / git-root-without-clew) pass; py_compile clean.

Parser itself was already correct (1.6-unified) — this is purely feed-path resolution. Backward compatible. Base: feat/showcase-fullset (#226). No change to `test_render_clew.py` (its pre-existing monkeypatch tests are untouched).