### PR TITLE
feat(engine): register the 6 missing checks.py MCP tools (slice 3)

### DIFF
--- a/src/scitex_writer/_mcp/tools/checks.py
+++ b/src/scitex_writer/_mcp/tools/checks.py
@@ -4,15 +4,45 @@
 # Purpose: MCP tool registrations for pre-compilation project checks.
 #   - writer_checks_references (issue #45)
 #   - writer_checks_float_order (issue #44)
+#   - writer_checks_limits
+#   - writer_checks_overflow
+#   - writer_checks_paper_symlink
+#   - writer_checks_media_provenance
+#   - writer_checks_caption_footnote
+#   - writer_checks_ref_integrity
 
-"""Pre-compilation check MCP tools."""
+"""Pre-compilation check MCP tools.
 
-from typing import Literal
+Thin ``@mcp.tool()`` wrappers over ``_mcp.handlers`` -- same handlers backing
+the ``scitex_writer.checks`` Python API (see ``checks.py``), so the Python,
+MCP, and (where one still exists) shell-script interfaces share one
+implementation.
+"""
+
+from typing import Literal, Optional
 
 from fastmcp import FastMCP
 
 from ..handlers import (
+    check_caption_footnote as _check_caption_footnote,
+)
+from ..handlers import (
     check_float_order as _check_float_order,
+)
+from ..handlers import (
+    check_limits as _check_limits,
+)
+from ..handlers import (
+    check_media_provenance as _check_media_provenance,
+)
+from ..handlers import (
+    check_overflow as _check_overflow,
+)
+from ..handlers import (
+    check_paper_symlink as _check_paper_symlink,
+)
+from ..handlers import (
+    check_ref_integrity as _check_ref_integrity,
 )
 from ..handlers import (
     check_references as _check_references,
@@ -53,6 +83,113 @@ def register_tools(mcp: FastMCP) -> None:
         most one of ``fix`` / ``dry_run`` may be set.
         """
         return _check_float_order(project_dir, doc_type, fix, dry_run)
+
+    @mcp.tool()
+    def writer_checks_limits(
+        project_dir: str,
+        doc_type: Literal["manuscript", "supplementary", "revision"] = "manuscript",
+        strict: bool = False,
+    ) -> dict:
+        """Validate per-section word limits + the reference cap (``limits:`` block).
+
+        Fast pre-compile check: reads ``config/config_<doc_type>.yaml`` and
+        compares its ``limits:`` block against ``texcount`` word counts plus
+        unique ``\\cite`` keys. Over-limit is a warning by default;
+        ``strict=True`` (or ``limits.strict`` / ``SCITEX_WRITER_LINT_STRICT=1``)
+        promotes breaches to errors with a non-zero exit code.
+        """
+        return _check_limits(project_dir, doc_type, strict)
+
+    @mcp.tool()
+    def writer_checks_overflow(
+        project_dir: str,
+        doc_type: Literal["manuscript", "supplementary", "revision"] = "manuscript",
+        strict: bool = False,
+        max_pt: Optional[float] = None,
+    ) -> dict:
+        """Detect off-page content (wide tables/figures, over-tall pages).
+
+        Parses the ``.log`` from the last compile for ``Overfull \\hbox``
+        (too wide) and ``Overfull \\vbox`` (too tall) boxes. Boxes
+        overflowing by <= ``max_pt`` (default 5pt) are cosmetic and
+        ignored; larger ones are warnings, or errors under ``strict=True``
+        (or ``overflow.strict`` / ``SCITEX_WRITER_LINT_STRICT=1``). Runs
+        AFTER compile -- it reads the log -- unlike the pre-compile
+        ``writer_checks_limits``.
+        """
+        return _check_overflow(project_dir, doc_type, strict, max_pt)
+
+    @mcp.tool()
+    def writer_checks_paper_symlink(
+        project_dir: str,
+        level: Optional[Literal["off", "warn", "error", "repair"]] = None,
+        force_after_backup: bool = False,
+    ) -> dict:
+        """Detect / repair drift in the ``paper`` -> ``.scitex/writer`` symlink.
+
+        A PRIVATE convention -- never enforced by default (``warn`` when
+        nothing is configured). ``level="repair"`` actively fixes the safe
+        cases (create/repoint the symlink; convert a non-diverged real
+        ``paper/`` dir after backing it up). Diverged content is NEVER
+        deleted or overwritten; ``force_after_backup=True`` still moves
+        ``paper/`` to a timestamped backup before symlinking.
+        """
+        return _check_paper_symlink(project_dir, level, force_after_backup)
+
+    @mcp.tool()
+    def writer_checks_media_provenance(
+        project_dir: str,
+        doc_type: Literal["manuscript", "supplementary", "revision", "all"] = "all",
+        level: Optional[Literal["off", "warn", "error"]] = None,
+        require_under_scripts: bool = False,
+    ) -> dict:
+        """Verify manuscript media are symlinks chained to the producing code.
+
+        Rendered artifacts under
+        ``<doc>/contents/figures/caption_and_media/`` (image/pdf/tif/svg)
+        and ``<doc>/contents/tables/caption_and_media/`` (``.csv``) should
+        be symlinks, not loose committed copies. A PRIVATE convention --
+        disabled (``off``) by default. ``require_under_scripts=True`` also
+        requires each symlink to resolve under the project ``scripts/``
+        dir.
+        """
+        return _check_media_provenance(
+            project_dir, doc_type, level, require_under_scripts
+        )
+
+    @mcp.tool()
+    def writer_checks_caption_footnote(
+        project_dir: str,
+        doc_type: Literal["manuscript", "supplementary", "revision", "all"] = "all",
+        level: Optional[Literal["off", "warn", "error"]] = None,
+    ) -> dict:
+        """Lint: flag ``\\footnote``/``\\footnotetext`` inside a ``\\caption{}``.
+
+        ``\\footnote`` in a caption is a fatal LaTeX pattern; the blessed
+        alternative is ``\\footnotemark`` in-caption with ``\\footnotetext``
+        after the float. ``error`` (the default) reports and blocks;
+        ``warn`` reports without blocking; ``off`` disables the check.
+        """
+        return _check_caption_footnote(project_dir, doc_type, level)
+
+    @mcp.tool()
+    def writer_checks_ref_integrity(
+        project_dir: str,
+        doc_type: Literal["manuscript", "supplementary", "revision", "all"] = "all",
+        level: Optional[Literal["off", "warn", "error"]] = None,
+    ) -> dict:
+        """Pre-compile reference-integrity gate over all four reference classes.
+
+        Validates, reporting ALL problems at once (file:line): figure
+        ``\\ref`` resolution, table ``\\ref`` resolution, every ``\\cite``
+        key existing in the merged bibliography, and ``supple-``
+        cross-document xrefs against the supplement's ``.aux`` (a missing
+        supplement ``.aux`` is reported explicitly as "not compiled", not
+        as undefined refs). ``error`` (the default) exits non-zero so the
+        compile stage blocks; ``warn`` reports without blocking; ``off``
+        disables the gate.
+        """
+        return _check_ref_integrity(project_dir, doc_type, level)
 
 
 # EOF

--- a/tests/scitex_writer/_mcp/tools/test_checks_mcp_tools.py
+++ b/tests/scitex_writer/_mcp/tools/test_checks_mcp_tools.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_writer/_mcp/tools/test_checks_mcp_tools.py
+# Test file for: src/scitex_writer/_mcp/tools/checks.py
+#
+# Named distinctly from ``test_checks.py`` (which already exists at
+# tests/scitex_writer/test_checks.py, testing the Python API layer) --
+# neither tests/scitex_writer/ nor tests/scitex_writer/_mcp/tools/ has an
+# __init__.py, so pytest's rootdir import mode would otherwise collide on
+# the bare "test_checks" module name.
+
+"""Tests for the MCP tool registrations in ``scitex_writer._mcp.tools.checks``.
+
+Registers the tools on a real ``FastMCP`` instance and inspects the real
+``Tool`` objects (name, docstring, parameter schema) -- no mocked
+collaborators. Mirrors the existing coverage style for
+``writer_checks_references`` / ``writer_checks_float_order`` in
+``tests/scripts/python/test_scitex_writer_mcp.py`` (name-registration
+checks against the real FastMCP instance).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastmcp import FastMCP
+
+from scitex_writer._mcp.tools import checks as checks_tools
+
+
+def _get_tools(mcp: FastMCP) -> dict:
+    """Return {tool_name: Tool} across FastMCP versions."""
+    try:
+        return asyncio.run(mcp.get_tools())  # FastMCP >= 2.3
+    except AttributeError:
+        tools = asyncio.run(mcp._list_tools())  # FastMCP 2.0-2.2
+        return {t.name: t for t in tools}
+
+
+@pytest.fixture
+def registered_tools():
+    """Real FastMCP instance with the checks tools registered; {name: Tool}."""
+    server = FastMCP(name="test-checks")
+    checks_tools.register_tools(server)
+    return _get_tools(server)
+
+
+def test_all_eight_check_tools_are_registered(registered_tools):
+    # Arrange
+    # Act
+    names = set(registered_tools)
+    # Assert
+    assert names == {
+        "writer_checks_references",
+        "writer_checks_float_order",
+        "writer_checks_limits",
+        "writer_checks_overflow",
+        "writer_checks_paper_symlink",
+        "writer_checks_media_provenance",
+        "writer_checks_caption_footnote",
+        "writer_checks_ref_integrity",
+    }
+
+
+def test_writer_checks_limits_is_registered(registered_tools):
+    # Arrange
+    # Act
+    # Assert
+    assert "writer_checks_limits" in registered_tools
+
+
+def test_writer_checks_overflow_is_registered(registered_tools):
+    # Arrange
+    # Act
+    # Assert
+    assert "writer_checks_overflow" in registered_tools
+
+
+def test_writer_checks_paper_symlink_is_registered(registered_tools):
+    # Arrange
+    # Act
+    # Assert
+    assert "writer_checks_paper_symlink" in registered_tools
+
+
+def test_writer_checks_media_provenance_is_registered(registered_tools):
+    # Arrange
+    # Act
+    # Assert
+    assert "writer_checks_media_provenance" in registered_tools
+
+
+def test_writer_checks_caption_footnote_is_registered(registered_tools):
+    # Arrange
+    # Act
+    # Assert
+    assert "writer_checks_caption_footnote" in registered_tools
+
+
+def test_writer_checks_ref_integrity_is_registered(registered_tools):
+    # Arrange
+    # Act
+    # Assert
+    assert "writer_checks_ref_integrity" in registered_tools
+
+
+def test_writer_checks_limits_fn_is_callable(registered_tools):
+    # Arrange
+    # Act
+    # Assert
+    assert callable(registered_tools["writer_checks_limits"].fn)
+
+
+def test_writer_checks_overflow_fn_is_callable(registered_tools):
+    # Arrange
+    # Act
+    # Assert
+    assert callable(registered_tools["writer_checks_overflow"].fn)
+
+
+def test_writer_checks_paper_symlink_fn_is_callable(registered_tools):
+    # Arrange
+    # Act
+    # Assert
+    assert callable(registered_tools["writer_checks_paper_symlink"].fn)
+
+
+def test_writer_checks_media_provenance_fn_is_callable(registered_tools):
+    # Arrange
+    # Act
+    # Assert
+    assert callable(registered_tools["writer_checks_media_provenance"].fn)
+
+
+def test_writer_checks_caption_footnote_fn_is_callable(registered_tools):
+    # Arrange
+    # Act
+    # Assert
+    assert callable(registered_tools["writer_checks_caption_footnote"].fn)
+
+
+def test_writer_checks_ref_integrity_fn_is_callable(registered_tools):
+    # Arrange
+    # Act
+    # Assert
+    assert callable(registered_tools["writer_checks_ref_integrity"].fn)
+
+
+def test_writer_checks_limits_docstring_mentions_limits(registered_tools):
+    # Arrange
+    # Act
+    doc = registered_tools["writer_checks_limits"].fn.__doc__ or ""
+    # Assert
+    assert "limit" in doc.lower()
+
+
+def test_writer_checks_overflow_docstring_mentions_overflow(registered_tools):
+    # Arrange
+    # Act
+    doc = registered_tools["writer_checks_overflow"].fn.__doc__ or ""
+    # Assert
+    assert "overflow" in doc.lower() or "hbox" in doc.lower()
+
+
+def test_writer_checks_paper_symlink_docstring_mentions_symlink(registered_tools):
+    # Arrange
+    # Act
+    doc = registered_tools["writer_checks_paper_symlink"].fn.__doc__ or ""
+    # Assert
+    assert "symlink" in doc.lower()
+
+
+def test_writer_checks_media_provenance_docstring_mentions_provenance(
+    registered_tools,
+):
+    # Arrange
+    # Act
+    doc = registered_tools["writer_checks_media_provenance"].fn.__doc__ or ""
+    # Assert
+    assert "symlink" in doc.lower()
+
+
+def test_writer_checks_caption_footnote_docstring_mentions_footnote(
+    registered_tools,
+):
+    # Arrange
+    # Act
+    doc = registered_tools["writer_checks_caption_footnote"].fn.__doc__ or ""
+    # Assert
+    assert "footnote" in doc.lower()
+
+
+def test_writer_checks_ref_integrity_docstring_mentions_reference_integrity(
+    registered_tools,
+):
+    # Arrange
+    # Act
+    doc = registered_tools["writer_checks_ref_integrity"].fn.__doc__ or ""
+    # Assert
+    assert "reference-integrity" in doc.lower()
+
+
+def test_writer_checks_limits_calls_the_real_check_limits_handler(registered_tools):
+    """Wiring check: the tool's closure calls the same object the module
+    imports as ``_check_limits`` -- verified by giving it a nonexistent
+    project dir (a real, deterministic error path -- no mocking) and
+    checking the real handler's "script not found" contract fires.
+    """
+    # Arrange
+    tool = registered_tools["writer_checks_limits"]
+    # Act
+    out = tool.fn("/nonexistent/scitex-writer-mcp-tools-test-project")
+    # Assert
+    assert out["success"] is False
+
+
+def test_writer_checks_overflow_reports_missing_script_for_bad_project(
+    registered_tools,
+):
+    # Arrange
+    tool = registered_tools["writer_checks_overflow"]
+    # Act
+    out = tool.fn("/nonexistent/scitex-writer-mcp-tools-test-project")
+    # Assert
+    assert out["success"] is False
+
+
+def test_writer_checks_paper_symlink_reports_missing_script_for_bad_project(
+    registered_tools,
+):
+    # Arrange
+    tool = registered_tools["writer_checks_paper_symlink"]
+    # Act
+    out = tool.fn("/nonexistent/scitex-writer-mcp-tools-test-project")
+    # Assert
+    assert out["success"] is False
+
+
+def test_writer_checks_media_provenance_reports_missing_script_for_bad_project(
+    registered_tools,
+):
+    # Arrange
+    tool = registered_tools["writer_checks_media_provenance"]
+    # Act
+    out = tool.fn("/nonexistent/scitex-writer-mcp-tools-test-project")
+    # Assert
+    assert out["success"] is False
+
+
+def test_writer_checks_caption_footnote_reports_missing_script_for_bad_project(
+    registered_tools,
+):
+    # Arrange
+    tool = registered_tools["writer_checks_caption_footnote"]
+    # Act
+    out = tool.fn("/nonexistent/scitex-writer-mcp-tools-test-project")
+    # Assert
+    assert out["success"] is False
+
+
+def test_writer_checks_ref_integrity_reports_missing_script_for_bad_project(
+    registered_tools,
+):
+    # Arrange
+    tool = registered_tools["writer_checks_ref_integrity"]
+    # Act
+    out = tool.fn("/nonexistent/scitex-writer-mcp-tools-test-project")
+    # Assert
+    assert out["success"] is False
+
+
+# EOF


### PR DESCRIPTION
## Summary

- `scitex_writer.checks` already exposes eight Python-API functions (`references`, `float_order`, `limits`, `overflow`, `paper_symlink`, `media_provenance`, `caption_footnote`, `ref_integrity`), each backed by a working `_mcp.handlers.check_*` handler — but `_mcp/tools/checks.py` only registered MCP tools for two of them (`references`, `float_order`).
- This turned out to be the actual remaining gap in this slice series: there is no `check_ref_integrity.sh` to port — `scripts/python/check_ref_integrity.py`, the Python API, and the handler were already fully wired. What was missing was just the MCP tool wrapper for six already-implemented checks.
- Adds `writer_checks_limits`, `writer_checks_overflow`, `writer_checks_paper_symlink`, `writer_checks_media_provenance`, `writer_checks_caption_footnote`, and `writer_checks_ref_integrity` as thin `@mcp.tool()` wrappers, mirroring the existing `writer_checks_references` / `writer_checks_float_order` pattern exactly.
- No new top-level module added, so this does not touch the PS-108b flat-file-count cap at `src/scitex_writer/` root.

## Test plan

- [x] New `tests/scitex_writer/_mcp/tools/test_checks_mcp_tools.py` — real FastMCP registration + real `Tool.fn` invocation (no mocked collaborators), covering registration, docstring content, and the real "script not found" error path for a nonexistent project dir.
- [x] Full local suite green: 1025 passed, 15 skipped, 0 failed.
- [x] `tests/develop/test_audit.py::test_audit_all_clean` green (flat-file count unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)