### PR TITLE
feat(clew): page-1 legend toggle (legend_first) + env/config wiring

### DIFF
--- a/00_shared/latex_styles/clew_presentation.tex
+++ b/00_shared/latex_styles/clew_presentation.tex
@@ -54,6 +54,10 @@
 \newif\ifclewpreslegend
 \newif\ifclewpresattest      % "Provenance checked by SciTeX Clew." line
 \newif\ifclewpresexplainer   % renderable clew explainer section
+\newif\ifclewpreslegendfirst % opt-in: emit \clewLegend at the TOP of page 1
+                             % (config key legend_first). Independent of
+                             % \ifclewpreslegend (end-of-doc) and NOT in the
+                             % master set, so master-on won't double-render it.
 
 %% --- verdict palette ---
 %% scitex-clew OWNS the palette (what to render). It emits \definecolor{clewX}
@@ -273,10 +277,16 @@
       \end{minipage}}\par\medskip
   \fi}
 
-%% Auto-placement: badge at top; legend, signature + attestation at the end.
+%% Auto-placement: badge (+ opt-in legend_first) at top; legend, signature +
+%% attestation at the end.
 %% Manual macros (\clewVerifiedBadge, \clewExplainer, ...) stay available for
 %% explicit placement.
-\AtBeginDocument{\ifclewpresbadge\par\noindent\clewVerifiedBadge\par\fi}
+%% legend_first reuses \clewLegend UNCHANGED, auto-placed at page-1 top (before
+%% the badge). Opt-in and NOT in the master set, so it never double-renders with
+%% the end-of-doc \ifclewpreslegend.
+\AtBeginDocument{%
+  \ifclewpreslegendfirst\clewLegend\fi
+  \ifclewpresbadge\par\noindent\clewVerifiedBadge\par\fi}
 \AtEndDocument{%
   \ifclewpreslegend\clewLegend\fi
   \ifclewpressignature\clewSignature\fi

--- a/demo/clew_demo.tex
+++ b/demo/clew_demo.tex
@@ -28,6 +28,10 @@
 \clewpresexplainertrue
 %% \clewpreslegendtrue  % standalone legend; omitted here — the explainer
 %%                       % section below already embeds the legend key.
+%% \clewpreslegendfirsttrue  % opt-in: auto-emit \clewLegend at the TOP of
+%%                           % page 1 (config key legend_first). Independent of
+%%                           % \clewpreslegend (end-of-doc) and excluded from the
+%%                           % master set, so it never double-renders.
 
 \begin{document}
 

--- a/scripts/python/render_clew_toggles.py
+++ b/scripts/python/render_clew_toggles.py
@@ -36,10 +36,30 @@ OUTPUT_TEX = "00_shared/clew_presentation_toggles.tex"
 ENV_VAR = "SCITEX_WRITER_CLEW_PRESENTATION"
 
 # The \newif toggles defined in clew_presentation.tex (do NOT emit one whose
-# \newif is undefined -- e.g. a future legend_first -- or LaTeX errors).
-_KNOWN = ("markers", "badge", "legend", "explainer", "signature", "attest")
-# The co-author-facing "full set" a master ON enables.
+# \newif is undefined or LaTeX errors).
+_KNOWN = (
+    "markers",
+    "badge",
+    "legend",
+    "explainer",
+    "signature",
+    "attest",
+    "legend_first",
+)
+# The co-author-facing "full set" a master ON enables. `legend_first` is
+# DELIBERATELY excluded: master-on already enables end-of-doc `legend`, so
+# adding `legend_first` too would render the legend twice (page-1 top AND
+# end-of-doc). It is opt-in ONLY (a mapping key or the env master cannot turn
+# it on) so an author enables it knowingly.
 _MASTER_SET = ("markers", "badge", "legend", "explainer", "signature")
+
+
+# Config key -> LaTeX \newif stem. A \newif control sequence cannot contain an
+# underscore, so `legend_first` maps to `\clewpreslegendfirst`. Keys without an
+# underscore map to themselves.
+def _macro_stem(name):
+    return name.replace("_", "")
+
 
 _TRUTHY = ("1", "true", "yes", "on")
 _FALSY = ("0", "false", "no", "off")
@@ -104,18 +124,14 @@ def resolve_toggles(config_value, env_value):
         for key, val in config_value.items():
             name = str(key).strip().lower()
             if name not in _KNOWN:
-                continue  # ignore unknown/future keys (e.g. legend_first)
+                continue  # ignore unknown/future keys (no defined \newif)
             b = _scalar_bool(val)
             if b is None:
-                raise ValueError(
-                    f"clew_presentation.{name}={val!r} is not true/false"
-                )
+                raise ValueError(f"clew_presentation.{name}={val!r} is not true/false")
             toggles[name] = b
         return toggles
 
-    raise ValueError(
-        f"clew_presentation={config_value!r} must be on/off or a mapping"
-    )
+    raise ValueError(f"clew_presentation={config_value!r} must be on/off or a mapping")
 
 
 def render_toggles_tex(toggles):
@@ -129,7 +145,7 @@ def render_toggles_tex(toggles):
     ]
     for name in _KNOWN:
         if toggles.get(name):
-            lines.append(f"\\clewpres{name}true")
+            lines.append(f"\\clewpres{_macro_stem(name)}true")
     return "\n".join(lines) + "\n"
 
 

--- a/src/scitex_writer/_skills/scitex-writer/20_env-vars.md
+++ b/src/scitex_writer/_skills/scitex-writer/20_env-vars.md
@@ -47,6 +47,23 @@ exits non-zero.
 | `SCITEX_WRITER_REF_INTEGRITY` | Severity for the pre-compile reference-integrity gate (`off`/`warn`/`error`). Default `error`. | `error` | enum |
 | `SCITEX_WRITER_CLEW_VERIFY` | Severity for the pre-compile clew provenance gate — re-verifies every clew-registered claim against its bound source (`off`/`warn`/`error`). Default `error` for **research** projects (`.scitex/dev/config.yaml` `project-type: research`), `off` otherwise. NO_CLAIMS and a missing `clew` CLI warn (never block) unless `clew_verify.require_claims` is set. `clew_verify.strict` / `--strict` forwards `--strict` to clew; `clew_verify.require_claims` / `--require-claims` makes NO_CLAIMS + missing-clew hard-fail at the resolved level (ADR-0021). | `error` (research) / `off` | enum |
 | `SCITEX_WRITER_CLEW_BIN` | Path to the `clew` executable used by the provenance gate. Defaults to `clew` on `PATH`. | `clew` | path |
+| `SCITEX_WRITER_CLEW_PRESENTATION` | Master ON/OFF switch for the page-1 clew *presentation* layer (marks/badge/legend/explainer/signature), resolved pre-compile by `render_clew_toggles.py`. `on`/`true`/`yes` enables the full co-author-facing set; `off` disables all. Overrides the project `.scitex/writer/config.yaml` `clew_presentation` key (which may instead be a per-toggle mapping — see below). Default off. | `off` | enum |
+
+> **`clew_presentation` toggle set** (config-mapping keys under
+> `.scitex/writer/config.yaml` `clew_presentation:`, each `true`/`false`,
+> absent = off). The env master `SCITEX_WRITER_CLEW_PRESENTATION=on` enables
+> the **master set** (`markers`, `badge`, `legend`, `explainer`, `signature`);
+> `attest` and `legend_first` are **opt-in only** (never enabled by master-on).
+>
+> | key | effect |
+> |---|---|
+> | `markers` | verdict-colored wavy underlines on `\clewval`/`\clewmark`/`\clewcite`/`\clewfig` |
+> | `badge` | "Clew Verified" stamp auto-placed at page-1 top |
+> | `legend` | status-color key auto-placed at end-of-doc |
+> | `explainer` | "How to read provenance marks" box (author-placed via `\clewExplainer`) |
+> | `signature` | "Compiled by SciTeX Writer." colophon at end-of-doc |
+> | `attest` | "Provenance audited by SciTeX Clew" line at end-of-doc (opt-in) |
+> | `legend_first` | auto-emit the status-color key at the **top of page 1** (opt-in; independent of `legend`, excluded from the master set so it never double-renders) |
 | `SCITEX_WRITER_COMPILE_ARTIFACTS` | Severity for the POST-compile verification gate (`off`/`warn`/`error`). Default `error`. Fails loud when the compiled `.tex` references `\includegraphics` (N>0) but the PDF embeds 0 images (silent figure miss), plus secondary log deficiency signals. PDF embedding check needs poppler (`pdfimages`); skipped-with-warning when absent. | `error` | enum |
 | `SCITEX_WRITER_VERSION_FRESHNESS` | Severity for the pre-compile version-freshness gate (`off`/`warn`/`error`). Default `error`. Fails loud when the vendored engine (stamped in `00_shared/.scitex-writer-vendored-version` by `update-project`) is behind the installed scitex-writer — re-vendor with `scitex-writer update-project`. Absent stamp or no installed pkg → warn (never blocks). | `error` | enum |
 

--- a/tests/scripts/python/test_render_clew_toggles.py
+++ b/tests/scripts/python/test_render_clew_toggles.py
@@ -28,8 +28,11 @@ class TestResolveToggles:
         toggles = resolve_toggles(config_value, None)
         # Assert: master set on, attest off.
         assert (
-            toggles["markers"] and toggles["badge"] and toggles["legend"]
-            and toggles["explainer"] and toggles["signature"]
+            toggles["markers"]
+            and toggles["badge"]
+            and toggles["legend"]
+            and toggles["explainer"]
+            and toggles["signature"]
             and not toggles["attest"]
         )
 
@@ -67,11 +70,36 @@ class TestResolveToggles:
 
     def test_unknown_mapping_key_is_ignored(self):
         # Arrange: a future toggle whose \newif is not defined yet.
-        config_value = {"legend_first": True, "markers": True}
+        config_value = {"future_toggle": True, "markers": True}
         # Act
         toggles = resolve_toggles(config_value, None)
         # Assert
-        assert ("legend_first" not in toggles) and toggles["markers"]
+        assert ("future_toggle" not in toggles) and toggles["markers"]
+
+    def test_legend_first_mapping_key_enables_only_itself(self):
+        # Arrange: opt-in page-1 legend via the mapping key.
+        config_value = {"legend_first": True}
+        # Act
+        toggles = resolve_toggles(config_value, None)
+        # Assert
+        assert toggles["legend_first"] and not toggles["legend"]
+
+    def test_legend_first_env_master_on_does_not_enable_it(self):
+        # Arrange: master ON enables the full set but NOT legend_first
+        # (excluded from _MASTER_SET to avoid a double-rendered legend).
+        config_value = None
+        # Act
+        toggles = resolve_toggles(config_value, "on")
+        # Assert
+        assert not toggles["legend_first"]
+
+    def test_legend_first_defaults_off(self):
+        # Arrange
+        config_value = None
+        # Act
+        toggles = resolve_toggles(config_value, None)
+        # Assert
+        assert not toggles["legend_first"]
 
     def test_malformed_scalar_raises(self):
         # Arrange
@@ -86,19 +114,43 @@ class TestResolveToggles:
 class TestRenderTogglesTex:
     def test_emits_true_line_only_for_enabled_toggles(self):
         # Arrange
-        toggles = {"markers": True, "badge": False, "legend": True,
-                   "explainer": False, "signature": False, "attest": False}
+        toggles = {
+            "markers": True,
+            "badge": False,
+            "legend": True,
+            "explainer": False,
+            "signature": False,
+            "attest": False,
+        }
         # Act
         tex = render_toggles_tex(toggles)
         # Assert
         assert ("\\clewpresmarkerstrue" in tex) and ("\\clewpresbadgetrue" not in tex)
+
+    def test_legend_first_emits_underscoreless_newif_macro(self):
+        # Arrange: the config key has an underscore; the \newif control
+        # sequence must not (LaTeX forbids '_' in a control sequence).
+        toggles = {
+            "markers": False,
+            "badge": False,
+            "legend": False,
+            "explainer": False,
+            "signature": False,
+            "attest": False,
+            "legend_first": True,
+        }
+        # Act
+        tex = render_toggles_tex(toggles)
+        # Assert
+        assert "\\clewpreslegendfirsttrue" in tex
 
 
 class TestCli:
     def _run(self, project_dir):
         return subprocess.run(
             [sys.executable, str(_SCRIPT), str(project_dir)],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
             env={"PATH": __import__("os").environ["PATH"]},
         )
 


### PR DESCRIPTION
## Page-1 clew legend toggle (`legend_first`)

Adds a new **opt-in, default-OFF** toggle `legend_first` that auto-emits the
**existing** `\clewLegend` key (the "what each mark means" status-color legend)
at the **top of page 1**, instead of only at end-of-document. Gated by
env/config exactly like the other `clewpres*` toggles, so it cannot affect any
existing compile unless explicitly enabled.

Implements scitex-todo card `writer-clew-legend-page1-float-and-env-toggles`.

### What shipped
- **`00_shared/latex_styles/clew_presentation.tex`** — new
  `\newif\ifclewpreslegendfirst`; emit `\clewLegend` at page-1 top inside the
  existing `\AtBeginDocument` block (the same mechanism the clew *badge* uses).
  Reuses the `\clewLegend` macro **unchanged**.
- **`scripts/python/render_clew_toggles.py`** — add `"legend_first"` to
  `_KNOWN` only (**not** `_MASTER_SET`). Adds a config-key → `\newif`-stem map
  that strips underscores, because a LaTeX control sequence cannot contain `_`
  (`legend_first` → `\clewpreslegendfirst`).
- **`tests/scripts/python/test_render_clew_toggles.py`** — legend_first emitted
  via config mapping; NOT emitted under master-on; off by default; underscoreless
  macro name; retarget the former unknown-key test to a genuinely unknown key.
  **15 passed** locally.
- **`demo/clew_demo.tex`** — commented demonstration line.
- **`src/scitex_writer/_skills/scitex-writer/20_env-vars.md`** — document the
  previously-undocumented `SCITEX_WRITER_CLEW_PRESENTATION` master switch and the
  full `clew_presentation` toggle set including `legend_first` (closes a doc gap
  in the same card).

### Design decisions (resolved from existing code conventions — please sanity-check)
1. **Placement** = top-of-page-1 via the existing `\AtBeginDocument` block (NOT a
   true float, NOT a margin note). The pre-baked name `legend_first`
   ("legend, first thing") confirms this intent.
2. **Toggle name** = exactly `legend_first` (already referenced as a future key).
3. **Opt-in only** — deliberately excluded from `_MASTER_SET`, so master-on does
   not enable it (would otherwise double-render: page-1 top AND end-of-doc).
4. **Independent** of the existing end-of-doc `legend` toggle; an author may
   enable either/both knowingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
