### PR TITLE
fix(render_clew): resolve .scitex/clew + config at git root (nested-writer feed) — rescued from stranded #232

### DIFF
--- a/scripts/python/render_clew.py
+++ b/scripts/python/render_clew.py
@@ -102,7 +102,13 @@ def _claim_value(claim):
     """The display string for a claim. clew stores it display-ready; try the
     known field names in order (`claim_value` is the clew 0.2.19 key)."""
     v = _first(
-        claim, "claim_value", "value", "display_value", "latex", "rendered_value", "text"
+        claim,
+        "claim_value",
+        "value",
+        "display_value",
+        "latex",
+        "rendered_value",
+        "text",
     )
     return "" if v is None else str(v)
 
@@ -138,7 +144,9 @@ def _resolve_palette(data):
     raw = data.get("palette") or data.get("display_palette") or {}
     if isinstance(raw, dict):
         for status, color in raw.items():
-            h = _hex(color if not isinstance(color, dict) else _first(color, "hex", "color"))
+            h = _hex(
+                color if not isinstance(color, dict) else _first(color, "hex", "color")
+            )
             key = _STATUS_SYNONYMS.get(str(status).lower(), str(status).lower())
             if h:
                 palette[key] = h
@@ -209,7 +217,9 @@ def render_clew_tex(data):
     total, verified, allverified = _aggregate(data, claims)
 
     lines = ["\\makeatletter", ""]
-    lines.append("%% --- palette (from clew claims.json; writer has \\providecolor fallbacks) ---")
+    lines.append(
+        "%% --- palette (from clew claims.json; writer has \\providecolor fallbacks) ---"
+    )
     for status, name in _STATUS_COLOR.items():
         lines.append(f"\\definecolor{{{name}}}{{HTML}}{{{palette[status]}}}")
     lines += ["", "%% --- aggregate ---"]
@@ -232,7 +242,9 @@ def render_clew_tex(data):
         verdict = _verdict(claim)
         # `display_color` is the frozen contract name (clew 0.4.0 emits it);
         # color/hex are accepted aliases. Fall back to the verdict palette.
-        color = _hex(_first(claim, "display_color", "color", "hex")) or palette.get(verdict)
+        color = _hex(_first(claim, "display_color", "color", "hex")) or palette.get(
+            verdict
+        )
         value = _claim_value(claim)
         lines.append(f"%% {claim.get('claim_id', cid)} [{verdict}]")
         lines.append(f"\\@namedef{{clew@val@{cid}}}{{{value}}}")
@@ -245,10 +257,40 @@ def render_clew_tex(data):
     return "\n".join(lines) + "\n"
 
 
+def _find_git_root(start):
+    """Nearest ancestor of ``start`` containing ``.git`` (a git root), or None.
+    Bounded walk so a pathological tree can't spin."""
+    cur = start
+    for _ in range(64):
+        if (cur / ".git").exists():
+            return cur
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+    return None
+
+
+def _resolve_claims_json(project_path):
+    r"""Locate .scitex/clew/runtime/claims.json the way clew resolves its OWN db:
+    at the GIT ROOT. This makes NESTED-writer projects work -- when scitex-writer
+    is vendored UNDER an outer repo (e.g. at ``.scitex/writer/``) whose
+    ``.scitex/clew`` at the git root is the real feed, clew writes the export at
+    the git root, so render_clew must READ it there too (not under the writer
+    subdir). Preference: git-root/.scitex/clew when that dir exists; else fall
+    back to project_path/.scitex/clew -- the flat/common case (project IS its own
+    git root) is unchanged, and a stray empty .scitex/clew under the writer
+    subdir is ignored in favor of the real git-root feed. (nested-writer bug
+    surfaced by paper-neurovista, 2026-07-04.)"""
+    root = _find_git_root(project_path)
+    if root is not None and (root / ".scitex" / "clew").is_dir():
+        return root / ".scitex" / "clew" / "runtime" / "claims.json"
+    return project_path / CLAIMS_JSON
+
+
 def main(argv):
     project_dir = argv[1] if len(argv) > 1 else "."
     project_path = Path(project_dir).resolve()
-    claims_json = project_path / CLAIMS_JSON
+    claims_json = _resolve_claims_json(project_path)
 
     if not claims_json.exists():
         return 0  # clew layer optional -- no-op
@@ -268,8 +310,7 @@ def main(argv):
         tex = render_clew_tex(data)
     except Exception as exc:  # malformed schema -- surface, don't ship stale
         print(
-            f"ERRO:     Failed to render clew_rendered.tex from {claims_json}: "
-            f"{exc}.",
+            f"ERRO:     Failed to render clew_rendered.tex from {claims_json}: {exc}.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/python/render_clew_toggles.py
+++ b/scripts/python/render_clew_toggles.py
@@ -65,10 +65,37 @@ _TRUTHY = ("1", "true", "yes", "on")
 _FALSY = ("0", "false", "no", "off")
 
 
+def _find_git_root(start):
+    """Nearest ancestor of ``start`` containing ``.git`` (a git root), or None."""
+    cur = Path(start)
+    for _ in range(64):
+        if (cur / ".git").exists():
+            return cur
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+    return None
+
+
+def _resolve_config_yaml(project_dir):
+    r"""Locate .scitex/writer/config.yaml at the GIT ROOT -- same walk render_clew.py
+    uses for the clew db -- so a NESTED-writer project (writer vendored under an
+    outer repo, e.g. at .scitex/writer/) reads the config at the outer git root
+    rather than a doubly-nested <writer>/.scitex/writer/config.yaml (which is
+    absent, leaving \clewpresmarkers OFF and marks plain). Preference: git-root
+    copy when present; else fall back to PROJECT_ROOT (flat case unchanged).
+    (nested-writer toggle bug surfaced by paper-neurovista, 2026-07-04.)"""
+    project_dir = Path(project_dir)
+    root = _find_git_root(project_dir)
+    if root is not None and (root / CONFIG_YAML).is_file():
+        return root / CONFIG_YAML
+    return project_dir / CONFIG_YAML
+
+
 def _read_config_value(project_dir):
     """Return the raw `clew_presentation` value from the project config, or None
     (PyYAML optional -- absent it, only env resolves)."""
-    cfg = Path(project_dir) / CONFIG_YAML
+    cfg = _resolve_config_yaml(project_dir)
     if not cfg.is_file():
         return None
     try:

--- a/tests/scripts/python/test_render_clew_gitroot.py
+++ b/tests/scripts/python/test_render_clew_gitroot.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: render_clew.py git-root .scitex/clew resolution (nested-writer).
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from render_clew import (  # noqa: E402
+    CLAIMS_JSON,
+    _resolve_claims_json,
+)
+
+
+class TestResolveClaimsJson:
+    def test_nested_writer_resolves_git_root_feed(self, tmp_path):
+        # Arrange: writer vendored under an outer git repo whose .scitex/clew is
+        # the real feed; a STRAY empty .scitex/clew sits under the writer subdir.
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".scitex" / "clew" / "runtime").mkdir(parents=True)
+        writer = tmp_path / ".scitex" / "writer"
+        (writer / ".scitex" / "clew" / "runtime").mkdir(parents=True)
+        # Act
+        resolved = _resolve_claims_json(writer)
+        # Assert
+        assert resolved == tmp_path / ".scitex" / "clew" / "runtime" / "claims.json"
+
+    def test_flat_project_resolves_its_own_clew(self, tmp_path):
+        # Arrange: project IS its own git root with .scitex/clew (common case).
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".scitex" / "clew" / "runtime").mkdir(parents=True)
+        # Act
+        resolved = _resolve_claims_json(tmp_path)
+        # Assert
+        assert resolved == tmp_path / ".scitex" / "clew" / "runtime" / "claims.json"
+
+    def test_no_git_root_falls_back_to_project_path(self, tmp_path):
+        # Arrange: no .git anywhere above the project.
+        project = tmp_path / "proj"
+        project.mkdir()
+        # Act
+        resolved = _resolve_claims_json(project)
+        # Assert
+        assert resolved == project / CLAIMS_JSON
+
+    def test_git_root_without_clew_falls_back_to_project_path(self, tmp_path):
+        # Arrange: a git root exists but never ran clew (no .scitex/clew there).
+        (tmp_path / ".git").mkdir()
+        project = tmp_path / "sub"
+        project.mkdir()
+        # Act
+        resolved = _resolve_claims_json(project)
+        # Assert
+        assert resolved == project / CLAIMS_JSON
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))
+
+# EOF

--- a/tests/scripts/python/test_render_clew_gitroot.py
+++ b/tests/scripts/python/test_render_clew_gitroot.py
@@ -12,6 +12,10 @@ from render_clew import (  # noqa: E402
     CLAIMS_JSON,
     _resolve_claims_json,
 )
+from render_clew_toggles import (  # noqa: E402
+    CONFIG_YAML,
+    _resolve_config_yaml,
+)
 
 
 class TestResolveClaimsJson:
@@ -54,6 +58,39 @@ class TestResolveClaimsJson:
         resolved = _resolve_claims_json(project)
         # Assert
         assert resolved == project / CLAIMS_JSON
+
+
+class TestResolveConfigYaml:
+    def test_nested_writer_resolves_git_root_config(self, tmp_path):
+        # Arrange: writer vendored under an outer git repo; config at the outer
+        # git root's .scitex/writer/, NOT doubly-nested under the writer subdir.
+        (tmp_path / ".git").mkdir()
+        writer = tmp_path / ".scitex" / "writer"
+        writer.mkdir(parents=True)
+        (writer / "config.yaml").write_text("clew_presentation: on\n")
+        # Act
+        resolved = _resolve_config_yaml(writer)
+        # Assert
+        assert resolved == tmp_path / CONFIG_YAML
+
+    def test_flat_project_resolves_its_own_config(self, tmp_path):
+        # Arrange
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".scitex" / "writer").mkdir(parents=True)
+        (tmp_path / CONFIG_YAML).write_text("clew_presentation: on\n")
+        # Act
+        resolved = _resolve_config_yaml(tmp_path)
+        # Assert
+        assert resolved == tmp_path / CONFIG_YAML
+
+    def test_no_git_root_falls_back_to_project_path(self, tmp_path):
+        # Arrange
+        project = tmp_path / "proj"
+        project.mkdir()
+        # Act
+        resolved = _resolve_config_yaml(project)
+        # Assert
+        assert resolved == project / CONFIG_YAML
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Makes `render_clew.py` (clew feed) and `render_clew_toggles.py` (config.yaml)
resolve `.scitex/clew` and `.scitex/writer/config.yaml` at the **git root**
rather than the cwd/PROJECT_ROOT, so a **nested writer** (scitex-writer
vendored under an outer repo, e.g. at `.scitex/writer/`) finds the outer
repo's real clew feed and config instead of a missing/stray-empty path.

Two additive changes, both a bounded `_find_git_root` walk + a resolver:

- `render_clew.py`: `_resolve_claims_json` prefers `git-root/.scitex/clew`
  when that dir exists, else falls back to `PROJECT_ROOT/.scitex/clew`
  (flat/common case unchanged). Fixes `\clew@total{0}` -> real count, so
  `\clewmark`/`\clewval` render verdict-colored again.
- `render_clew_toggles.py`: `_resolve_config_yaml` uses the same git-root
  walk for `config.yaml`, so `\clewpresmarkers` turns ON in the nested
  layout without needing `SCITEX_WRITER_CLEW_PRESENTATION=on`.

Reported by paper-neurovista (2026-07-04).

## Why this PR (rescued from stranded #232)

The same fix already exists as PR #232, but #232's base branch is
`feat/showcase-fullset` — a dead side-branch (behind develop, no PR
merging it anywhere), so the fix can never reach develop that way. This
PR cherry-picks the two source-fix commits (`a5f74ab`, `6347cb7`) fresh
onto develop. The third original commit (`1a91c00`, monkeypatch removal
in the clew-version tests) was **already landed on develop** by a later
PR, so it cherry-picked empty and was skipped.

**Recommend closing #232 once this lands.**

## Merge notes

- The two source files also picked up the newer develop features
  (#236 legend_first, #237 stray-table suppression) — the git-root
  resolution is layered ON TOP of them, nothing dropped.

## Tests

`test_render_clew_gitroot.py` (7 AAA cases: nested / flat / no-git /
git-root-without-clew for both feed and toggle) + the existing clew
suites all green:

```
53 passed in 1.66s
```

The gitroot tests use real tmp-dir fixtures (no mocks/monkeypatch,
PA-306 compliant).
