### PR TITLE
fix(compile): fail loud when output PDF was not (re)created (stale-PDF freshness guard)

### DIFF
--- a/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
+++ b/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
@@ -169,6 +169,28 @@ cleanup() {
         fi
     fi
 
+    # FRESHNESS GATE: a compile is a success only if THIS run actually
+    # (re)created the PDF. Every engine writes the PDF into LOG_DIR and the block
+    # above MOVES it to $pdf_file, setting fresh_pdf=true. If fresh_pdf is still
+    # false here, no PDF was produced this run -- so any $pdf_file present is
+    # STALE from a PREVIOUS compile. This happens when an engine returns exit 0
+    # without emitting output (e.g. a silent latexmk/tectonic no-op, or a
+    # container that failed to mount) yet an old PDF is still on disk. Reporting
+    # that stale PDF as success is a silent failure: the user believes they got a
+    # fresh PDF but it is the old one. Fail loud instead. (The 3-pass engine also
+    # guards this at the engine level via an mtime check; this is the central
+    # backstop that additionally covers latexmk / tectonic and the finalization
+    # point where the PDF is promoted.)
+    if [ "$fresh_pdf" != true ]; then
+        echo_error "    PDF was not (re)created this run: $pdf_file"
+        echo_error "      The build likely failed -- a stale PDF from a previous run is present."
+        echo_error "      Refusing to pass off a stale PDF as a fresh compile."
+        echo_error "      Inspect the real error in: ${LOG_DIR}/${pdf_basename%.pdf}.log"
+        # Remove the stale PDF so downstream gates never treat it as valid output.
+        [ -f "$pdf_file" ] && rm -f "$pdf_file"
+        return 1
+    fi
+
     if [ -f "$pdf_file" ]; then
         local size
         size=$(du -h "$pdf_file" | cut -f1)

--- a/tests/scripts/shell/modules/test_compilation_compiled_tex_to_compiled_pdf.sh
+++ b/tests/scripts/shell/modules/test_compilation_compiled_tex_to_compiled_pdf.sh
@@ -86,6 +86,58 @@ test_pagecount_zero_when_no_log() {
     rm -rf "$tmp"
 }
 
+# FRESHNESS GATE regression: engine reports success (compile_result=0) but
+# produced NO fresh PDF in LOG_DIR this run, while a STALE PDF from a previous
+# compile still sits at the final location. cleanup() must FAIL LOUD (return 1)
+# instead of passing off the stale PDF as a successful compile.
+test_cleanup_fails_when_stale_pdf_and_no_fresh() {
+    local tmp
+    tmp="$(mktemp -d)"
+    export LOG_DIR="$tmp/logs"
+    mkdir -p "$LOG_DIR"
+    export SCITEX_WRITER_COMPILED_PDF="$tmp/manuscript.pdf"
+    printf 'STALE PDF from a previous run\n' >"$SCITEX_WRITER_COMPILED_PDF"
+    # No manuscript.pdf inside LOG_DIR -> nothing produced this run.
+    ( cleanup 0 ) >/dev/null 2>&1
+    local rc=$?
+    assert_eq "1" "$rc" "cleanup fails loud when success reported but no fresh PDF (stale present)"
+    rm -rf "$tmp"
+}
+
+# The stale PDF must be REMOVED so downstream gates never treat it as valid.
+test_cleanup_removes_stale_pdf_when_no_fresh() {
+    local tmp
+    tmp="$(mktemp -d)"
+    export LOG_DIR="$tmp/logs"
+    mkdir -p "$LOG_DIR"
+    export SCITEX_WRITER_COMPILED_PDF="$tmp/manuscript.pdf"
+    printf 'STALE PDF from a previous run\n' >"$SCITEX_WRITER_COMPILED_PDF"
+    ( cleanup 0 ) >/dev/null 2>&1
+    local present="yes"
+    [ -f "$SCITEX_WRITER_COMPILED_PDF" ] || present="no"
+    assert_eq "no" "$present" "cleanup removes the stale PDF when no fresh PDF was produced"
+    rm -rf "$tmp"
+}
+
+# Positive control: a PDF freshly produced in LOG_DIR this run is promoted and
+# cleanup() returns success (0).
+test_cleanup_succeeds_when_fresh_pdf_produced() {
+    local tmp
+    tmp="$(mktemp -d)"
+    export LOG_DIR="$tmp/logs"
+    mkdir -p "$LOG_DIR"
+    export SCITEX_WRITER_ROOT_DIR="$tmp"
+    export SCITEX_WRITER_DOC_TYPE="manuscript"
+    export SCITEX_WRITER_VERSIONS_DIR="$tmp/archive"
+    export SCITEX_WRITER_COMPILED_PDF="$tmp/manuscript.pdf"
+    # A PDF present in LOG_DIR == produced by THIS run.
+    printf 'FRESH PDF produced this run\n' >"$LOG_DIR/manuscript.pdf"
+    ( cleanup 0 ) >/dev/null 2>&1
+    local rc=$?
+    assert_eq "0" "$rc" "cleanup succeeds when a fresh PDF was produced in LOG_DIR this run"
+    rm -rf "$tmp"
+}
+
 # Run tests
 main() {
     echo "Testing: compilation_compiled_tex_to_compiled_pdf.sh"
@@ -102,6 +154,9 @@ main() {
     test_pagecount_from_log_single_page
     test_pagecount_zero_when_no_output_line
     test_pagecount_zero_when_no_log
+    test_cleanup_fails_when_stale_pdf_and_no_fresh
+    test_cleanup_removes_stale_pdf_when_no_fresh
+    test_cleanup_succeeds_when_fresh_pdf_produced
 
     echo "========================================"
     echo "Results: $TESTS_PASSED/$TESTS_RUN passed"


### PR DESCRIPTION
## Root cause

`cleanup()` in `scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh` decided compile success on `[ -f "$pdf_file" ]` alone. When an engine returned exit 0 without actually emitting output this run — a silent `latexmk`/`tectonic` no-op, or a container that failed to mount — but a PDF from a **previous** compile was still on disk, the **stale** PDF passed as a successful compile. That is a silent failure: the user believes they got a fresh PDF, but it is the old one.

The 3-pass engine already guards this at the engine level via an mtime check, but `latexmk`/`tectonic` do not, and the central finalization point (where the PDF is promoted from `LOG_DIR` to its final location) had no guard.

## Freshness signal chosen

Per-run production, not wall-clock mtime. Every engine writes the PDF into `LOG_DIR`; `cleanup()` **moves** it out to the final location and sets `fresh_pdf=true`. Because the move removes the PDF from `LOG_DIR`, its presence there unambiguously means *this run* created it. If `fresh_pdf` is still `false` at finalization, no PDF was produced this run — so any PDF present at the final location is stale.

## Fail-loud behavior

Central freshness gate added at the finalization point (covers all engines):
- If `fresh_pdf != true`: error with the PDF path, state the build likely failed and a stale PDF from a previous run is present, point at the LaTeX log for the real error, **remove the stale PDF** (so downstream gates never treat it as valid output), and `return 1`.
- The promotion path (non-zero engine exit but a valid fresh PDF with pages>0) is unaffected — it sets `fresh_pdf=true` before falling through.

This is complementary to, not a duplicate of, the post-compile verification gate (`check_compile_artifacts.py`), which checks figure embedding / log deficiency and would happily pass a stale-but-figure-complete PDF.

## Test

Extends `tests/scripts/shell/modules/test_compilation_compiled_tex_to_compiled_pdf.sh`:
- stale PDF present + no fresh PDF in `LOG_DIR` ⇒ `cleanup` returns 1 (fail loud)
- same condition ⇒ the stale PDF is removed
- positive control: a fresh PDF in `LOG_DIR` ⇒ `cleanup` returns 0

Local run: 7/7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)