### PR TITLE
fix(figures): fail loud on declared-but-missing figure media (no silent placeholder)

### DIFF
--- a/scripts/python/check_figure_media.py
+++ b/scripts/python/check_figure_media.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/check_figure_media.py
+# Purpose: Pre-compile FIGURE-MEDIA gate. A manuscript declares a figure by
+#          dropping a caption `.tex` file under
+#            <doc>/contents/figures/caption_and_media/NN_Name.tex
+#          The compile pipeline resolves each declared figure to a rendered
+#          media asset (jpg/png/pdf/tif/svg/pptx/mmd/... same numeric prefix,
+#          incl. multi-panel figures composed from NN{a,b,...} panels). When a
+#          figure is DECLARED but NO media asset exists, the figure pipeline
+#          historically substituted a silent "Missing Figure" placeholder JPG
+#          (process_figures_modules/04_compilation.src:check_and_create_placeholders)
+#          and the compile SUCCEEDED -- a silent degradation the operator wants
+#          eliminated.
+#
+#          This gate scans every declared figure up front, reports ALL figures
+#          that have no media (name + expected media path), then exits non-zero
+#          so the caller (run_provenance_checks.sh -> compile_*.sh) BLOCKS the
+#          compile before the placeholder is ever created. It runs BEFORE
+#          process_figures.sh, so at error-level the placeholder code path is
+#          never reached; at warn/off the placeholder still fills in (the
+#          explicit draft opt-in).
+#
+#          DEFAULT depends on project type (mirrors check_citations /
+#          check_clew_verify): a *research* project (marked by
+#          .scitex/dev/config.yaml `project-type: research`) defaults to error
+#          -- a research manuscript must never ship a placeholder figure -- and
+#          a non-research project (the public template, whose example figures
+#          ship without media by design) defaults to warn.
+#
+#          Severity precedence (highest -> lowest), via the shared _severity
+#          resolver:
+#            1. --level {off,warn,error} CLI flag
+#            2. env SCITEX_WRITER_FIGURE_MEDIA
+#            3. project ./config.yaml key figure_media.level
+#            4. user ~/.scitex/writer/config.yaml key figure_media.level
+#            5. default: error for research projects, else warn
+#          Levels:
+#            off   -- skip the gate
+#            warn  -- report missing figures, exit 0 (does NOT block; the
+#                     downstream placeholder fills in for a draft compile)
+#            error -- report missing figures, exit 1 (caller blocks the compile)
+#
+# Usage:
+#   python check_figure_media.py [project_dir]
+#                                [--doc-type manuscript|supplementary|revision|all]
+#                                [--level off|warn|error]
+#
+# Self-contained: stdlib + optional PyYAML (config files only).
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
+
+# ANSI colors (match the sibling check_*.py standalones)
+GREEN = "\033[0;32m"
+YELLOW = "\033[1;33m"
+RED = "\033[0;31m"
+DIM = "\033[0;90m"
+BOLD = "\033[1m"
+NC = "\033[0m"
+
+PASS_COUNT = 0
+WARN_COUNT = 0
+FAIL_COUNT = 0
+
+_LEVELS = ("off", "warn", "error")
+
+_DOC_DIRS = {
+    "manuscript": "01_manuscript",
+    "supplementary": "02_supplementary",
+    "revision": "03_revision",
+}
+
+# Media assets a declared figure can resolve to. The figure pipeline converts
+# any of these (pptx/mmd/pdf/tif -> png -> jpg; panels -> composed jpg).
+_MEDIA_EXTS = {
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".pdf",
+    ".tif",
+    ".tiff",
+    ".svg",
+    ".eps",
+    ".gif",
+    ".pptx",
+    ".mmd",
+}
+
+# A declared MAIN figure caption stem: leading digits, optionally `_Name`.
+# A PANEL caption/media stem: leading digits + a single lowercase letter (NNa_).
+_MAIN_STEM_RE = re.compile(r"^\d+(?:_.*)?$")
+_PANEL_STEM_RE = re.compile(r"^\d+[a-z](?:_.*|$)")
+
+_MAX_LIST = 100
+
+
+def log_pass(msg):
+    global PASS_COUNT
+    print(f"  {GREEN}[PASS]{NC} {msg}")
+    PASS_COUNT += 1
+
+
+def log_warn(msg):
+    global WARN_COUNT
+    print(f"  {YELLOW}[WARN]{NC} {msg}")
+    WARN_COUNT += 1
+
+
+def log_fail(msg):
+    global FAIL_COUNT
+    print(f"  {RED}[FAIL]{NC} {msg}")
+    FAIL_COUNT += 1
+
+
+def log_detail(msg):
+    print(f"    {DIM}{msg}{NC}")
+
+
+def _is_research_project(project_dir):
+    """True iff .scitex/dev/config.yaml marks this a ``project-type: research``.
+
+    Mirrors check_citations / check_clew_verify so every gate shares one
+    research-mode signal. PyYAML optional; falls back to a textual marker scan.
+    """
+    cfg = Path(project_dir) / ".scitex" / "dev" / "config.yaml"
+    if not cfg.is_file():
+        return False
+    try:
+        text = cfg.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    try:
+        import yaml
+
+        data = yaml.safe_load(text) or {}
+        if isinstance(data, dict):
+            return str(data.get("project-type", "")).strip().lower() == "research"
+    except Exception:
+        pass
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("project-type:"):
+            return stripped.split(":", 1)[1].strip().strip("\"'").lower() == "research"
+    return False
+
+
+def _numeric_prefix(stem):
+    """The leading-digit run of a figure stem (e.g. '01_Foo' -> '01')."""
+    m = re.match(r"^(\d+)", stem)
+    return m.group(1) if m else ""
+
+
+def _declared_main_figures(media_dir):
+    """Return {stem: caption_path} for each DECLARED main figure caption.
+
+    A main figure caption is a ``.tex`` whose stem is leading digits optionally
+    followed by ``_Name`` (e.g. ``01.tex`` / ``01_Overview.tex``). Panel
+    captions (``01a_...tex``) are NOT independently declared figures -- they are
+    media sources for their parent figure -- so they are skipped.
+    """
+    figures = {}
+    for tex in sorted(media_dir.glob("*.tex")):
+        stem = tex.stem
+        if _PANEL_STEM_RE.match(stem):
+            continue
+        if not _MAIN_STEM_RE.match(stem):
+            continue
+        figures[stem] = tex
+    return figures
+
+
+def _has_media(media_dir, stem):
+    """True iff some rendered media asset exists for the figure ``stem``.
+
+    Matches (a) a same-stem asset (``01_Foo.png``), (b) a bare numeric-prefix
+    asset (``01.jpg``), and (c) any panel asset (``01a_left.png``) that composes
+    into the figure -- every asset whose stem begins with the figure's numeric
+    prefix followed by a ``_`` / lowercase-letter / end boundary. A broken
+    symlink counts as MISSING (``exists()`` follows the link), because the
+    pipeline could not render it either.
+    """
+    prefix = _numeric_prefix(stem)
+    if not prefix:
+        return False
+    # `01` must not match `010...`; require a non-digit boundary after prefix.
+    boundary = re.compile(rf"^{re.escape(prefix)}(?:[a-z]|_|$)")
+    for asset in media_dir.iterdir():
+        if asset.suffix.lower() not in _MEDIA_EXTS:
+            continue
+        if boundary.match(asset.stem) and asset.exists():
+            return True
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Pre-compile figure-media gate: FAIL when a figure is "
+        "declared (caption .tex) but has no rendered media asset -- catches the "
+        "silent 'Missing Figure' placeholder BEFORE it degrades the PDF. "
+        "Defaults to error for research projects, warn otherwise."
+    )
+    parser.add_argument("project_dir", nargs="?", default=".")
+    parser.add_argument(
+        "--doc-type",
+        choices=[*_DOC_DIRS, "all"],
+        default="all",
+        help="Which document(s) to scan (default: all present).",
+    )
+    parser.add_argument(
+        "--level",
+        choices=list(_LEVELS),
+        default=None,
+        help="Severity: off, warn, or error. Overrides env and config.",
+    )
+    args = parser.parse_args()
+
+    project_dir = Path(args.project_dir).resolve()
+    research = _is_research_project(project_dir)
+    default = "error" if research else "warn"
+    level = resolve_level(
+        "figure_media",
+        args.level,
+        project_dir,
+        default=default,
+        env_var="SCITEX_WRITER_FIGURE_MEDIA",
+    )
+    kind = "research" if research else "non-research"
+    print(f"\n{BOLD}=== Figure Media Gate (level={level}, {kind}) ==={NC}\n")
+
+    if level == "off":
+        print(
+            f"  {DIM}[INFO]{NC} figure-media gate is disabled (level=off). "
+            f"Set figure_media.level or --level to enable."
+        )
+        print(
+            f"\n{BOLD}Summary:{NC} {GREEN}0 passed{NC}, "
+            f"{YELLOW}0 warnings{NC}, {RED}0 errors{NC}"
+        )
+        return 0
+
+    report = log_fail if level == "error" else log_warn
+    doc_types = list(_DOC_DIRS) if args.doc_type == "all" else [args.doc_type]
+
+    any_dir = False
+    total = 0
+    missing = []
+    for doc_type in doc_types:
+        media_dir = (
+            project_dir
+            / _DOC_DIRS[doc_type]
+            / "contents"
+            / "figures"
+            / "caption_and_media"
+        )
+        if not media_dir.is_dir():
+            continue
+        any_dir = True
+        for stem, caption in sorted(_declared_main_figures(media_dir).items()):
+            total += 1
+            if not _has_media(media_dir, stem):
+                rel = caption.relative_to(project_dir)
+                expected = (
+                    media_dir.relative_to(project_dir)
+                    / f"{stem}.<jpg|png|pdf|tif|svg|pptx|mmd>"
+                )
+                missing.append((doc_type, str(rel), str(expected)))
+
+    if not any_dir:
+        log_pass("no figure caption_and_media directories found to check")
+    elif total == 0:
+        log_pass("no declared figures found to check")
+    elif not missing:
+        log_pass(f"all {total} declared figure(s) have rendered media")
+    else:
+        for doc_type, rel, expected in missing[:_MAX_LIST]:
+            report(
+                f"{doc_type}: {rel}: figure declared but NO media asset "
+                f"(expected {expected})"
+            )
+        if len(missing) > _MAX_LIST:
+            log_detail(f"... and {len(missing) - _MAX_LIST} more")
+        log_detail(
+            "fix: add the figure's rendered media (jpg/png/pdf/tif/svg/pptx/mmd, "
+            "or NN{a,b,...} panels) next to its caption .tex, or remove the "
+            "caption if the figure is not used."
+        )
+
+    print()
+    print(
+        f"{BOLD}Summary:{NC} {GREEN}{PASS_COUNT} passed{NC}, "
+        f"{YELLOW}{WARN_COUNT} warnings{NC}, {RED}{FAIL_COUNT} errors{NC}"
+    )
+    return 1 if FAIL_COUNT > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shell/modules/process_figures_modules/04_compilation.src
+++ b/scripts/shell/modules/process_figures_modules/04_compilation.src
@@ -200,7 +200,14 @@ create_placeholder_jpg() {
     fi
 }
 
-# Check and create placeholders for missing figures
+# Check and create placeholders for missing figures.
+#
+# NOTE: a DECLARED-but-missing figure is caught FAIL-LOUD upstream by the
+# figure-media gate (scripts/python/check_figure_media.py, wired into
+# run_provenance_checks.sh) which aborts the compile BEFORE this runs. So at the
+# gate's default (error for research projects) this placeholder path is never
+# reached. It only fills in when the gate is warn/off -- the explicit draft
+# opt-in (e.g. the public template's example figures, which ship without media).
 check_and_create_placeholders() {
     echo_info "Checking for missing figures..."
 

--- a/scripts/shell/modules/run_provenance_checks.sh
+++ b/scripts/shell/modules/run_provenance_checks.sh
@@ -21,6 +21,12 @@
 # scholar stub (auto-generated placeholder), also error for research / warn
 # otherwise -- the compiler-owns half of the citation->clew verification
 # contract (a stub \cite can never reach a compiled research manuscript).
+# figure_media is the FIGURE-MEDIA GATE: it fails the build when a figure is
+# DECLARED (a caption .tex) but has NO rendered media asset, so the compile can
+# no longer silently substitute a "Missing Figure" placeholder. It runs BEFORE
+# process_figures.sh (which creates the placeholder), so at error-level the
+# placeholder path is never reached; defaults to error for research projects,
+# warn otherwise (the public template ships example captions without media).
 #
 # Returns the worst exit code across the checks (0 unless a check errored).
 
@@ -31,7 +37,7 @@ PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$THIS_DIR/../../.." && pwd)}"
 PY="${SCITEX_WRITER_PYTHON:-python3}"
 
 rc=0
-for chk in check_paper_symlink check_media_provenance check_caption_footnote check_clew_verify check_citations check_version_freshness; do
+for chk in check_paper_symlink check_media_provenance check_figure_media check_caption_footnote check_clew_verify check_citations check_version_freshness; do
     script="$THIS_DIR/../../python/${chk}.py"
     [ -f "$script" ] || continue
     "$PY" "$script" "$PROJECT_ROOT" || rc=$?

--- a/tests/scripts/python/test_check_figure_media.py
+++ b/tests/scripts/python/test_check_figure_media.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: check_figure_media.py
+#
+# Reproduces the silent "Missing Figure" placeholder condition: a figure
+# declared by a caption .tex with NO rendered media asset must now FAIL LOUD
+# (gate names the figure and exits non-zero) instead of degrading to a
+# placeholder.
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from check_figure_media import resolve_level  # noqa: E402
+
+_SCRIPT = ROOT_DIR / "scripts" / "python" / "check_figure_media.py"
+
+_FIG_MEDIA = "01_manuscript/contents/figures/caption_and_media"
+
+
+# ============================================================================
+# helpers / fixtures
+# ============================================================================
+
+
+def _write(tmp_path, rel, content):
+    p = tmp_path / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _declare_figure(tmp_path, stem):
+    """Declare a figure: drop its caption .tex under the figure media dir."""
+    return _write(tmp_path, f"{_FIG_MEDIA}/{stem}.tex", f"\\textbf{{Figure}} {stem}.\n")
+
+
+def _add_media(tmp_path, name):
+    """Drop a (byte) media asset under the figure media dir."""
+    return _write(tmp_path, f"{_FIG_MEDIA}/{name}", "x")
+
+
+def _run(project, *extra):
+    env = dict(os.environ)
+    env.pop("SCITEX_WRITER_FIGURE_MEDIA", None)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), str(project), *extra],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+@pytest.fixture
+def clean_env():
+    saved = {k: os.environ.get(k) for k in ("SCITEX_WRITER_FIGURE_MEDIA", "HOME")}
+    os.environ.pop("SCITEX_WRITER_FIGURE_MEDIA", None)
+    with tempfile.TemporaryDirectory() as home:
+        os.environ["HOME"] = home
+        yield home
+    for key, val in saved.items():
+        if val is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = val
+
+
+# ============================================================================
+# resolve_level
+# ============================================================================
+
+
+def test_resolve_level_defaults_to_error_for_research(tmp_path, clean_env):
+    """A research project defaults the figure-media gate to error."""
+    # Arrange
+    check = "figure_media"
+    # Act
+    level = resolve_level(
+        check,
+        None,
+        str(tmp_path),
+        default="error",
+        env_var="SCITEX_WRITER_FIGURE_MEDIA",
+    )
+    # Assert
+    assert level == "error"
+
+
+# ============================================================================
+# End-to-end (no LaTeX toolchain needed)
+# ============================================================================
+
+
+def test_declared_figure_without_media_errors(tmp_path, clean_env):
+    """A figure declared with no media asset blocks the compile (exit 1)."""
+    # Arrange
+    _declare_figure(tmp_path, "01_overview")
+    # Act
+    proc = _run(tmp_path, "--level", "error")
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_missing_figure_is_named_in_report(tmp_path, clean_env):
+    """The failure names the declared-but-missing figure caption."""
+    # Arrange
+    _declare_figure(tmp_path, "01_overview")
+    # Act
+    proc = _run(tmp_path, "--level", "error")
+    # Assert
+    assert "01_overview.tex" in proc.stdout
+
+
+def test_declared_figure_with_media_passes(tmp_path, clean_env):
+    """A figure whose media asset exists resolves cleanly (exit 0)."""
+    # Arrange
+    _declare_figure(tmp_path, "01_overview")
+    _add_media(tmp_path, "01_overview.jpg")
+    # Act
+    proc = _run(tmp_path, "--level", "error")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_figure_resolved_by_panels_passes(tmp_path, clean_env):
+    """A figure with only NN{a,b} panel media (no direct asset) resolves."""
+    # Arrange
+    _declare_figure(tmp_path, "02_panels")
+    _add_media(tmp_path, "02a_left.png")
+    _add_media(tmp_path, "02b_right.png")
+    # Act
+    proc = _run(tmp_path, "--level", "error")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_panel_caption_not_treated_as_declared_figure(tmp_path, clean_env):
+    """A panel caption (NNa_) is not itself a declared figure (exit 0)."""
+    # Arrange
+    _declare_figure(tmp_path, "03a_only_a_panel")
+    # Act
+    proc = _run(tmp_path, "--level", "error")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_reports_all_missing_figures_at_once(tmp_path, clean_env):
+    """One run surfaces every missing figure together, not one-at-a-time."""
+    # Arrange
+    _declare_figure(tmp_path, "01_overview")
+    _declare_figure(tmp_path, "02_results")
+    # Act
+    proc = _run(tmp_path, "--level", "error")
+    # Assert
+    assert "2 errors" in proc.stdout
+
+
+def test_off_level_skips(tmp_path, clean_env):
+    """--level off disables the gate even with a missing figure (exit 0)."""
+    # Arrange
+    _declare_figure(tmp_path, "01_overview")
+    # Act
+    proc = _run(tmp_path, "--level", "off")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_warn_level_does_not_block(tmp_path, clean_env):
+    """--level warn reports but exits 0 (the draft placeholder opt-in)."""
+    # Arrange
+    _declare_figure(tmp_path, "01_overview")
+    # Act
+    proc = _run(tmp_path, "--level", "warn")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_prefix_collision_does_not_false_pass(tmp_path, clean_env):
+    """Media for figure 10 must not satisfy figure 1 (prefix-boundary)."""
+    # Arrange
+    _declare_figure(tmp_path, "1_first")
+    _add_media(tmp_path, "10_tenth.jpg")
+    # Act
+    proc = _run(tmp_path, "--level", "error")
+    # Assert
+    assert proc.returncode == 1


### PR DESCRIPTION
## Root cause

When a manuscript declared a figure (a caption `.tex` under
`<doc>/contents/figures/caption_and_media/NN_Name.tex`) but had **no rendered
media asset**, the figure pipeline silently substituted a "Missing Figure"
placeholder JPG and the compile **succeeded**. The emit site is
`check_and_create_placeholders()` in
`scripts/shell/modules/process_figures_modules/04_compilation.src` (calls
`create_placeholder_jpg` -> ImageMagick `-annotate "Missing Figure\n<name>"`).
A declared-but-missing figure therefore degraded silently instead of failing.

## Fail-loud fix

New **pre-compile FIGURE-MEDIA gate**: `scripts/python/check_figure_media.py`.
It scans every declared main figure caption and verifies a rendered media asset
exists (same-stem, bare-numeric, or `NN{a,b,...}` panel media — covering
composed/tiled figures). On any miss it reports **ALL** missing figures at once
(name + expected media path) and exits non-zero.

- Mirrors the established gate pattern (`check_ref_integrity` /
  `check_citations` / `check_clew_verify`): shared `_severity.resolve_level`,
  `off | warn | error`, precedence CLI `--level` > env
  `SCITEX_WRITER_FIGURE_MEDIA` > project/user `config.yaml` `figure_media.level`.
- **Override / level knob**: defaults to `error` for research projects
  (`.scitex/dev/config.yaml project-type: research`) and `warn` otherwise — so
  the public template (whose example figures ship without media by design) is
  not broken, while a real research manuscript fails loud. Set
  `figure_media.level` / `--level` / the env var to override.
- Wired into `run_provenance_checks.sh`, which runs **before**
  `process_figures.sh`, so at `error` level the compile aborts before the
  placeholder is ever created. At `warn`/`off` the placeholder still fills in —
  the explicit draft opt-in — and the emit site is documented as such.

## Test

`tests/scripts/python/test_check_figure_media.py` (10 tests, all green):
declared-figure-without-media -> exit 1 with the figure named; media present /
panel-composed / panel-caption -> pass; reports-all-at-once; off/warn do not
block; prefix-boundary (figure 10's media must not satisfy figure 1).

Verified against the real template project: gate warns (exit 0), template
compile unaffected.