### PR TITLE
fix(cli): scitex-writer --version prints its own version (was shadowed by scitex-dev)

### DIFF
--- a/src/scitex_writer/_cli/__init__.py
+++ b/src/scitex_writer/_cli/__init__.py
@@ -34,8 +34,42 @@ of the package and are referenced from skills, READMEs, and external docs.
 
 from __future__ import annotations
 
-from . import commands  # noqa: F401 (registers all commands on main_group)
-from ._core import main, main_group
+import sys as _sys
+
+
+def _is_bare_version_invocation(argv: list[str]) -> bool:
+    """True iff ``argv`` is exactly a single ``--version`` / ``-V`` token."""
+    return argv in (["--version"], ["-V"])
+
+
+# Fast-path a bare ``--version`` / ``-V`` BEFORE importing ``.commands``.
+#
+# Root cause this guards against (fixes the CI regression that appeared once
+# scitex-dev 0.27.0 was installed): importing ``.commands`` eagerly pulls in
+# ``scitex_dev._cli._completion`` to attach shell-completion leaves, which
+# imports ``scitex_dev._cli`` — and *that* package's ``__init__`` has its own
+# module-level fast-path that, when ``sys.argv[1:]`` is a bare
+# ``--version``/``-V``, prints ``scitex-dev <ver>`` and ``raise
+# SystemExit(0)``. So without this guard, ``scitex-writer --version`` (and
+# ``python -m scitex_writer --version``) print scitex-dev's version and exit
+# before scitex-writer's own Click ``version_option`` (in ``._core``) ever
+# runs.
+#
+# We short-circuit here — before that import chain — so scitex-writer's own
+# version wins. The output matches Click's ``version_option`` format (and the
+# ``prog_name="scitex-writer"`` set in ``._core``), so behaviour is identical
+# to a normal Click ``--version`` dispatch. Deliberately narrow: any other
+# argv (a subcommand, ``--version --json``, ``--help``, ``-h``) falls through
+# to the real Click group unchanged.
+if _is_bare_version_invocation(_sys.argv[1:]):
+    from .. import __version__ as _pkg_version
+
+    print(f"scitex-writer, version {_pkg_version}")
+    raise SystemExit(0)
+
+
+from . import commands  # noqa: E402,F401 (registers all commands on main_group)
+from ._core import main, main_group  # noqa: E402
 
 # Backward-compat re-exports: before the monolith split every subcommand
 # group (``bib_group``, ``compile_group``, ...) lived directly in this


### PR DESCRIPTION
## P1 — unblocks develop CI (was red for every new PR, incl. #241, #242)

### Root cause
`scitex-dev 0.27.0` added a **module-level, import-time** fast-path in
`scitex_dev/_cli/__init__.py`:

```python
if _is_bare_version_invocation(_sys.argv[1:]):   # ['--version'] or ['-V']
    print(f"scitex-dev {_v}")
    raise SystemExit(0)
```

Its comment assumes "only the real scitex-dev console-script invocation sees
it" — but the check keys purely on `sys.argv`, so it fires for **any**
downstream package that imports `scitex_dev._cli` while argv is a bare
`--version`/`-V`.

scitex-writer's CLI imports `scitex_dev._cli._completion` (to attach shell
completion) at CLI-load time. So `scitex-writer --version` (and
`python -m scitex_writer --version`) imported `scitex_dev._cli`, whose
import-time fast-path fired first, printed `scitex-dev 0.27.0`, and
`raise SystemExit(0)` — **before** scitex-writer's own Click
`@click.version_option(..., prog_name="scitex-writer")` ever ran. Result:
`test_version_cli_flag` / `test_version_short_flag` failed on develop for
every fresh PR once 0.27.0 was installed in CI.

Note: this is *not* the "a second `--version` option shadows main_group's"
shape — `main_group.params` still has exactly one `--version` (scitex-writer's);
calling `main(['--version'])` directly always printed correctly. The hijack
happens at **import** time, before the Click group is ever invoked.

### Fix
Short-circuit a bare `--version`/`-V` at the top of
`scitex_writer/_cli/__init__.py`, **before** the `.commands` import chain that
pulls in `scitex_dev._cli`. scitex-writer prints its own version (Click's
`version_option` format, `prog_name="scitex-writer"`) and exits, so it wins
deterministically. The guard is deliberately narrow (`['--version']` /
`['-V']` only) — any other argv (subcommands, `--version --json`, `--help`)
falls through to the real Click group unchanged.

### Why scitex_dev subcommands still work
Only bare-version invocations are intercepted. For all other argv, the full
import chain runs as before, so `docs` / `skills` / shell-completion
subcommands mount and function normally (verified: `scitex-writer --help`
still lists the full command tree).

### Verification
Reproduced the bug with `scitex_dev` 0.26.1+ source on the path (simulating
CI's 0.27.0): before fix → `scitex-dev 0.26.1...`; after fix →
`scitex-writer, version 2.24.1`. `TestVersion` (both flags) passes under the
bug-reproducing environment.

### Follow-up (separate, upstream)
The true root cause is a library-level import-time side effect in
`scitex-dev`. scitex-dev should guard its fast-path so it only fires for its
own entry point (e.g. check `sys.argv[0]` basename), not for any importer.
Recommend a scitex-dev issue/PR so other downstream CLIs don't hit the same
shadowing.