### PR TITLE
feat(cli): `list-deps --apt` command (prints scitex-writer system deps)

### DIFF
--- a/src/scitex_writer/_cli/commands/__init__.py
+++ b/src/scitex_writer/_cli/commands/__init__.py
@@ -24,6 +24,7 @@ from . import (  # noqa: F401
     bib,
     checks,
     compile,
+    deps,
     export,
     figures,
     gui,

--- a/src/scitex_writer/_cli/commands/deps.py
+++ b/src/scitex_writer/_cli/commands/deps.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_cli/commands/deps.py
+
+"""``deps`` command — scitex-writer's native (apt) system dependencies.
+
+scitex-writer is the single source of truth for its LaTeX-toolchain apt
+packages (``scitex_writer._core._system_deps``), declared to the ecosystem via
+the ``scitex_dev.system_deps`` entry-point. This command is the leaf-local
+view of that list: ``scitex-writer deps`` prints the apt packages (the
+fleet-wide aggregate across every leaf is a separate surface,
+``scitex-dev ecosystem system-deps``).
+
+Deliberately scitex_dev-free: it reads the local provider table
+(``APT_PACKAGES`` / ``_PACKAGES``) directly, so it never triggers the
+``scitex_dev`` import chain (and its historical import-time ``--version``
+fast-path).
+"""
+
+from __future__ import annotations
+
+import click
+
+from .._core import main_group
+from .._helpers import _emit_json
+
+# =========================================================================
+# deps  (flat top-level command; verb-noun-free — "deps" is the noun)
+# =========================================================================
+
+
+@main_group.command("deps")
+@click.option(
+    "--apt",
+    "as_apt",
+    is_flag=True,
+    default=False,
+    help="Emit the full `apt-get install ...` one-liner instead of one name per line.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit JSON (package/purpose/provider).",
+)
+def deps_cmd(as_apt, as_json):
+    """Print scitex-writer's required system (apt) packages — the LaTeX toolchain.
+
+    Default output is one apt package name per line (pipe/build friendly).
+    ``--apt`` prints the ready-to-paste ``apt-get install`` command; ``--json``
+    prints package/purpose/provider. These are the same packages scitex-writer
+    declares to ``scitex-dev ecosystem system-deps`` via the
+    ``scitex_dev.system_deps`` entry-point.
+
+    \b
+    Example:
+        $ scitex-writer deps
+        $ scitex-writer deps --apt
+        $ scitex-writer deps --json
+    """
+    from ..._core._system_deps import _PACKAGES, APT_PACKAGES
+
+    if as_json:
+        _emit_json(
+            [
+                {"package": pkg, "purpose": purpose, "provider": "scitex-writer"}
+                for pkg, purpose in _PACKAGES
+            ]
+        )
+        return 0
+    if as_apt:
+        click.echo(
+            "apt-get install -y --no-install-recommends " + " ".join(APT_PACKAGES)
+        )
+        return 0
+    click.echo("\n".join(APT_PACKAGES))
+    return 0
+
+
+# EOF

--- a/src/scitex_writer/_cli/commands/deps.py
+++ b/src/scitex_writer/_cli/commands/deps.py
@@ -2,12 +2,12 @@
 # -*- coding: utf-8 -*-
 # File: src/scitex_writer/_cli/commands/deps.py
 
-"""``deps`` command — scitex-writer's native (apt) system dependencies.
+"""``list-deps`` command — scitex-writer's native (apt) system dependencies.
 
 scitex-writer is the single source of truth for its LaTeX-toolchain apt
 packages (``scitex_writer._core._system_deps``), declared to the ecosystem via
 the ``scitex_dev.system_deps`` entry-point. This command is the leaf-local
-view of that list: ``scitex-writer deps`` prints the apt packages (the
+view of that list: ``scitex-writer list-deps`` prints the apt packages (the
 fleet-wide aggregate across every leaf is a separate surface,
 ``scitex-dev ecosystem system-deps``).
 
@@ -25,11 +25,12 @@ from .._core import main_group
 from .._helpers import _emit_json
 
 # =========================================================================
-# deps  (flat top-level command; verb-noun-free — "deps" is the noun)
+# list-deps  (flat verb-noun top-level command, per §1 — same house style
+# as compile-manuscript / check-limits / export-manuscript)
 # =========================================================================
 
 
-@main_group.command("deps")
+@main_group.command("list-deps")
 @click.option(
     "--apt",
     "as_apt",
@@ -44,7 +45,7 @@ from .._helpers import _emit_json
     default=False,
     help="Emit JSON (package/purpose/provider).",
 )
-def deps_cmd(as_apt, as_json):
+def list_deps_cmd(as_apt, as_json):
     """Print scitex-writer's required system (apt) packages — the LaTeX toolchain.
 
     Default output is one apt package name per line (pipe/build friendly).
@@ -55,9 +56,9 @@ def deps_cmd(as_apt, as_json):
 
     \b
     Example:
-        $ scitex-writer deps
-        $ scitex-writer deps --apt
-        $ scitex-writer deps --json
+        $ scitex-writer list-deps
+        $ scitex-writer list-deps --apt
+        $ scitex-writer list-deps --json
     """
     from ..._core._system_deps import _PACKAGES, APT_PACKAGES
 

--- a/tests/scitex_writer/_cli/commands/test_deps.py
+++ b/tests/scitex_writer/_cli/commands/test_deps.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: src/scitex_writer/_cli/commands/deps.py
+
+"""Tests for the `scitex-writer deps` CLI command (real Click invocation)."""
+
+import importlib
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_writer._cli._core import main_group
+from scitex_writer._core._system_deps import APT_PACKAGES
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_module_exposes_deps_cmd():
+    # Arrange
+    name = "scitex_writer._cli.commands.deps"
+    # Act
+    module = importlib.import_module(name)
+    # Assert
+    assert hasattr(module, "deps_cmd")
+
+
+def test_deps_registered_on_main_group():
+    # Arrange
+    commands = main_group.commands
+    # Act
+    present = "deps" in commands
+    # Assert
+    assert present
+
+
+def test_deps_default_exits_zero(runner):
+    # Arrange
+    args = ["deps"]
+    # Act
+    result = runner.invoke(main_group, args)
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_deps_default_prints_one_package_per_line(runner):
+    # Arrange
+    args = ["deps"]
+    # Act
+    result = runner.invoke(main_group, args)
+    # Assert
+    assert result.output.splitlines() == APT_PACKAGES
+
+
+def test_deps_apt_exits_zero(runner):
+    # Arrange
+    args = ["deps", "--apt"]
+    # Act
+    result = runner.invoke(main_group, args)
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_deps_apt_starts_with_apt_get_install(runner):
+    # Arrange
+    args = ["deps", "--apt"]
+    # Act
+    result = runner.invoke(main_group, args)
+    # Assert
+    assert result.output.strip().startswith(
+        "apt-get install -y --no-install-recommends "
+    )
+
+
+def test_deps_apt_contains_every_package(runner):
+    # Arrange
+    args = ["deps", "--apt"]
+    # Act
+    result = runner.invoke(main_group, args)
+    # Assert
+    assert all(pkg in result.output for pkg in APT_PACKAGES)
+
+
+def test_deps_apt_has_core_latex(runner):
+    # Arrange
+    args = ["deps", "--apt"]
+    # Act
+    result = runner.invoke(main_group, args)
+    # Assert
+    assert "texlive-latex-base" in result.output
+
+
+def test_deps_apt_has_parallel(runner):
+    # Arrange
+    args = ["deps", "--apt"]
+    # Act
+    result = runner.invoke(main_group, args)
+    # Assert
+    assert "parallel" in result.output
+
+
+def test_deps_json_lists_packages_in_order(runner):
+    # Arrange
+    args = ["deps", "--json"]
+    # Act
+    result = runner.invoke(main_group, args)
+    payload = json.loads(result.output)
+    # Assert
+    assert [row["package"] for row in payload] == APT_PACKAGES
+
+
+def test_deps_json_tags_every_row_with_writer_provider(runner):
+    # Arrange
+    args = ["deps", "--json"]
+    # Act
+    result = runner.invoke(main_group, args)
+    payload = json.loads(result.output)
+    # Assert
+    assert all(row["provider"] == "scitex-writer" for row in payload)

--- a/tests/scitex_writer/_cli/commands/test_deps.py
+++ b/tests/scitex_writer/_cli/commands/test_deps.py
@@ -19,27 +19,27 @@ def runner():
     return CliRunner()
 
 
-def test_module_exposes_deps_cmd():
+def test_module_exposes_list_deps_cmd():
     # Arrange
     name = "scitex_writer._cli.commands.deps"
     # Act
     module = importlib.import_module(name)
     # Assert
-    assert hasattr(module, "deps_cmd")
+    assert hasattr(module, "list_deps_cmd")
 
 
 def test_deps_registered_on_main_group():
     # Arrange
     commands = main_group.commands
     # Act
-    present = "deps" in commands
+    present = "list-deps" in commands
     # Assert
     assert present
 
 
 def test_deps_default_exits_zero(runner):
     # Arrange
-    args = ["deps"]
+    args = ["list-deps"]
     # Act
     result = runner.invoke(main_group, args)
     # Assert
@@ -48,7 +48,7 @@ def test_deps_default_exits_zero(runner):
 
 def test_deps_default_prints_one_package_per_line(runner):
     # Arrange
-    args = ["deps"]
+    args = ["list-deps"]
     # Act
     result = runner.invoke(main_group, args)
     # Assert
@@ -57,7 +57,7 @@ def test_deps_default_prints_one_package_per_line(runner):
 
 def test_deps_apt_exits_zero(runner):
     # Arrange
-    args = ["deps", "--apt"]
+    args = ["list-deps", "--apt"]
     # Act
     result = runner.invoke(main_group, args)
     # Assert
@@ -66,7 +66,7 @@ def test_deps_apt_exits_zero(runner):
 
 def test_deps_apt_starts_with_apt_get_install(runner):
     # Arrange
-    args = ["deps", "--apt"]
+    args = ["list-deps", "--apt"]
     # Act
     result = runner.invoke(main_group, args)
     # Assert
@@ -77,7 +77,7 @@ def test_deps_apt_starts_with_apt_get_install(runner):
 
 def test_deps_apt_contains_every_package(runner):
     # Arrange
-    args = ["deps", "--apt"]
+    args = ["list-deps", "--apt"]
     # Act
     result = runner.invoke(main_group, args)
     # Assert
@@ -86,7 +86,7 @@ def test_deps_apt_contains_every_package(runner):
 
 def test_deps_apt_has_core_latex(runner):
     # Arrange
-    args = ["deps", "--apt"]
+    args = ["list-deps", "--apt"]
     # Act
     result = runner.invoke(main_group, args)
     # Assert
@@ -95,7 +95,7 @@ def test_deps_apt_has_core_latex(runner):
 
 def test_deps_apt_has_parallel(runner):
     # Arrange
-    args = ["deps", "--apt"]
+    args = ["list-deps", "--apt"]
     # Act
     result = runner.invoke(main_group, args)
     # Assert
@@ -104,7 +104,7 @@ def test_deps_apt_has_parallel(runner):
 
 def test_deps_json_lists_packages_in_order(runner):
     # Arrange
-    args = ["deps", "--json"]
+    args = ["list-deps", "--json"]
     # Act
     result = runner.invoke(main_group, args)
     payload = json.loads(result.output)
@@ -114,7 +114,7 @@ def test_deps_json_lists_packages_in_order(runner):
 
 def test_deps_json_tags_every_row_with_writer_provider(runner):
     # Arrange
-    args = ["deps", "--json"]
+    args = ["list-deps", "--json"]
     # Act
     result = runner.invoke(main_group, args)
     payload = json.loads(result.output)


### PR DESCRIPTION
## What

Adds a self-contained `scitex-writer deps` CLI command that prints scitex-writer's native (apt) LaTeX-toolchain system dependencies.

- `scitex-writer deps` — one apt package name per line (pipe/build friendly)
- `scitex-writer deps --apt` — the ready-to-paste `apt-get install -y --no-install-recommends ...` one-liner
- `scitex-writer deps --json` — package/purpose/provider rows

## Why / context

Completes the second half of card `scitex-writer-system-deps-provider`. The **provider half was already merged** in #163: `scitex_writer._core._system_deps:provide()` returns `list[SystemDepSpec]` and is registered under the `[project.entry-points."scitex_dev.system_deps"]` group, so `scitex-dev ecosystem system-deps` aggregates it across leaves. The only piece missing was the leaf-local CLI, which this PR adds.

### scitex_dev API used
The command does **not** import scitex_dev at all — it reads the local SSoT table (`scitex_writer._core._system_deps.APT_PACKAGES` / `_PACKAGES`) directly. This keeps it decoupled and, importantly, avoids reintroducing any scitex_dev import-time side effect (the recently-fixed `--version` P1 fast-path). The federated aggregate remains scitex-dev's responsibility via the already-registered entry-point (`SystemDepSpec(package, purpose, provider)`).

### Declared deps (rationale)
The printed list is exactly the SSoT already merged in `_core/_system_deps.py`: the curated elsarticle/texlive core (`texlive-latex-base/-recommended/-extra`, `-fonts-recommended/-extra`, `-science`, `-pictures`, `-publishers`, `-luatex`, `-xetex`, `-bibtex-extra`, `biber`, `-lang-english`, `-plain-generic`) plus `latexmk`, `latexdiff`, `chktex`, `texlive-extra-utils`, and `parallel` (required by the figure/table conversion scripts). This PR does not change the list; it exposes it.

## Verb-shape note
The card title/coordinator specified a top-level `deps --apt`, which this PR implements. Note a separate operator-ratified ecosystem-uniform surface exists in the card comments (`scitex-<pkg> dev system-deps list|install`). If the fleet later standardizes on that verb-group, `deps` can be re-homed/aliased under it — the underlying data and provider are unchanged.

## Tests
Real Click `CliRunner` invocations (no mocks): registration on `main_group`, exit codes, one-per-line output equals `APT_PACKAGES`, the `--apt` install line contains every package (incl. `texlive-latex-base` + `parallel`), and `--json` order + `provider == "scitex-writer"`. Module placed in `_cli/commands/deps.py` (subpackage, not a flat top-level file) per audit PS-108b.

Local: 57 CLI tests + 7 provider tests green; `--version` fast-path verified intact.