### PR TITLE
chore(release): 2.24.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to SciTeX Writer will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.24.9] - 2026-07-06
+
+### Added
+- **`list-deps` command.** `scitex-writer list-deps --apt` prints the system
+  (apt) packages scitex-writer needs, so an environment can be provisioned from
+  a single authoritative list (#244).
+
+### Fixed
+- **`scitex-writer --version` prints its own version.** The flag was shadowed by
+  scitex-dev and reported the wrong package version; it now reports
+  scitex-writer's own version (user-facing regression fix, #243).
+- **Fail loud on a missing figure at compile time.** A referenced figure that is
+  absent now hard-fails the compile instead of silently producing an incomplete
+  PDF (#242).
+- **Stale-PDF freshness guard.** The compile step now fails loud when the output
+  PDF was not actually (re)created, so a stale PDF can never masquerade as a
+  fresh build (#241).
+- **`render_clew` resolves the git root correctly.** clew rendering now anchors
+  to the repository root regardless of the working directory (#240).
+
 ## [2.24.8] - 2026-07-06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.24.8"
+version = "2.24.9"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/scripts/python/check_figure_media.py
+++ b/scripts/python/check_figure_media.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/check_figure_media.py
+# Purpose: Pre-compile FIGURE-MEDIA gate. A manuscript declares a figure by
+#          dropping a caption `.tex` file under
+#            <doc>/contents/figures/caption_and_media/NN_Name.tex
+#          The compile pipeline resolves each declared figure to a rendered
+#          media asset (jpg/png/pdf/tif/svg/pptx/mmd/... same numeric prefix,
+#          incl. multi-panel figures composed from NN{a,b,...} panels). When a
+#          figure is DECLARED but NO media asset exists, the figure pipeline
+#          historically substituted a silent "Missing Figure" placeholder JPG
+#          (process_figures_modules/04_compilation.src:check_and_create_placeholders)
+#          and the compile SUCCEEDED -- a silent degradation the operator wants
+#          eliminated.
+#
+#          This gate scans every declared figure up front, reports ALL figures
+#          that have no media (name + expected media path), then exits non-zero
+#          so the caller (run_provenance_checks.sh -> compile_*.sh) BLOCKS the
+#          compile before the placeholder is ever created. It runs BEFORE
+#          process_figures.sh, so at error-level the placeholder code path is
+#          never reached; at warn/off the placeholder still fills in (the
+#          explicit draft opt-in).
+#
+#          DEFAULT depends on project type (mirrors check_citations /
+#          check_clew_verify): a *research* project (marked by
+#          .scitex/dev/config.yaml `project-type: research`) defaults to error
+#          -- a research manuscript must never ship a placeholder figure -- and
+#          a non-research project (the public template, whose example figures
+#          ship without media by design) defaults to warn.
+#
+#          Severity precedence (highest -> lowest), via the shared _severity
+#          resolver:
+#            1. --level {off,warn,error} CLI flag
+#            2. env SCITEX_WRITER_FIGURE_MEDIA
+#            3. project ./config.yaml key figure_media.level
+#            4. user ~/.scitex/writer/config.yaml key figure_media.level
+#            5. default: error for research projects, else warn
+#          Levels:
+#            off   -- skip the gate
+#            warn  -- report missing figures, exit 0 (does NOT block; the
+#                     downstream placeholder fills in for a draft compile)
+#            error -- report missing figures, exit 1 (caller blocks the compile)
+#
+# Usage:
+#   python check_figure_media.py [project_dir]
+#                                [--doc-type manuscript|supplementary|revision|all]
+#                                [--level off|warn|error]
+#
+# Self-contained: stdlib + optional PyYAML (config files only).
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
+
+# ANSI colors (match the sibling check_*.py standalones)
+GREEN = "\033[0;32m"
+YELLOW = "\033[1;33m"
+RED = "\033[0;31m"
+DIM = "\033[0;90m"
+BOLD = "\033[1m"
+NC = "\033[0m"
+
+PASS_COUNT = 0
+WARN_COUNT = 0
+FAIL_COUNT = 0
+
+_LEVELS = ("off", "warn", "error")
+
+_DOC_DIRS = {
+    "manuscript": "01_manuscript",
+    "supplementary": "02_supplementary",
+    "revision": "03_revision",
+}
+
+# Media assets a declared figure can resolve to. The figure pipeline converts
+# any of these (pptx/mmd/pdf/tif -> png -> jpg; panels -> composed jpg).
+_MEDIA_EXTS = {
+    ".jpg",
+    ".jpeg",
+    ".png",
+    ".pdf",
+    ".tif",
+    ".tiff",
+    ".svg",
+    ".eps",
+    ".gif",
+    ".pptx",
+    ".mmd",
+}
+
+# A declared MAIN figure caption stem: leading digits, optionally `_Name`.
+# A PANEL caption/media stem: leading digits + a single lowercase letter (NNa_).
+_MAIN_STEM_RE = re.compile(r"^\d+(?:_.*)?$")
+_PANEL_STEM_RE = re.compile(r"^\d+[a-z](?:_.*|$)")
+
+_MAX_LIST = 100
+
+
+def log_pass(msg):
+    global PASS_COUNT
+    print(f"  {GREEN}[PASS]{NC} {msg}")
+    PASS_COUNT += 1
+
+
+def log_warn(msg):
+    global WARN_COUNT
+    print(f"  {YELLOW}[WARN]{NC} {msg}")
+    WARN_COUNT += 1
+
+
+def log_fail(msg):
+    global FAIL_COUNT
+    print(f"  {RED}[FAIL]{NC} {msg}")
+    FAIL_COUNT += 1
+
+
+def log_detail(msg):
+    print(f"    {DIM}{msg}{NC}")
+
+
+def _is_research_project(project_dir):
+    """True iff .scitex/dev/config.yaml marks this a ``project-type: research``.
+
+    Mirrors check_citations / check_clew_verify so every gate shares one
+    research-mode signal. PyYAML optional; falls back to a textual marker scan.
+    """
+    cfg = Path(project_dir) / ".scitex" / "dev" / "config.yaml"
+    if not cfg.is_file():
+        return False
+    try:
+        text = cfg.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    try:
+        import yaml
+
+        data = yaml.safe_load(text) or {}
+        if isinstance(data, dict):
+            return str(data.get("project-type", "")).strip().lower() == "research"
+    except Exception:
+        pass
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("project-type:"):
+            return stripped.split(":", 1)[1].strip().strip("\"'").lower() == "research"
+    return False
+
+
+def _numeric_prefix(stem):
+    """The leading-digit run of a figure stem (e.g. '01_Foo' -> '01')."""
+    m = re.match(r"^(\d+)", stem)
+    return m.group(1) if m else ""
+
+
+def _declared_main_figures(media_dir):
+    """Return {stem: caption_path} for each DECLARED main figure caption.
+
+    A main figure caption is a ``.tex`` whose stem is leading digits optionally
+    followed by ``_Name`` (e.g. ``01.tex`` / ``01_Overview.tex``). Panel
+    captions (``01a_...tex``) are NOT independently declared figures -- they are
+    media sources for their parent figure -- so they are skipped.
+    """
+    figures = {}
+    for tex in sorted(media_dir.glob("*.tex")):
+        stem = tex.stem
+        if _PANEL_STEM_RE.match(stem):
+            continue
+        if not _MAIN_STEM_RE.match(stem):
+            continue
+        figures[stem] = tex
+    return figures
+
+
+def _has_media(media_dir, stem):
+    """True iff some rendered media asset exists for the figure ``stem``.
+
+    Matches (a) a same-stem asset (``01_Foo.png``), (b) a bare numeric-prefix
+    asset (``01.jpg``), and (c) any panel asset (``01a_left.png``) that composes
+    into the figure -- every asset whose stem begins with the figure's numeric
+    prefix followed by a ``_`` / lowercase-letter / end boundary. A broken
+    symlink counts as MISSING (``exists()`` follows the link), because the
+    pipeline could not render it either.
+    """
+    prefix = _numeric_prefix(stem)
+    if not prefix:
+        return False
+    # `01` must not match `010...`; require a non-digit boundary after prefix.
+    boundary = re.compile(rf"^{re.escape(prefix)}(?:[a-z]|_|$)")
+    for asset in media_dir.iterdir():
+        if asset.suffix.lower() not in _MEDIA_EXTS:
+            continue
+        if boundary.match(asset.stem) and asset.exists():
+            return True
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Pre-compile figure-media gate: FAIL when a figure is "
+        "declared (caption .tex) but has no rendered media asset -- catches the "
+        "silent 'Missing Figure' placeholder BEFORE it degrades the PDF. "
+        "Defaults to error for research projects, warn otherwise."
+    )
+    parser.add_argument("project_dir", nargs="?", default=".")
+    parser.add_argument(
+        "--doc-type",
+        choices=[*_DOC_DIRS, "all"],
+        default="all",
+        help="Which document(s) to scan (default: all present).",
+    )
+    parser.add_argument(
+        "--level",
+        choices=list(_LEVELS),
+        default=None,
+        help="Severity: off, warn, or error. Overrides env and config.",
+    )
+    args = parser.parse_args()
+
+    project_dir = Path(args.project_dir).resolve()
+    research = _is_research_project(project_dir)
+    default = "error" if research else "warn"
+    level = resolve_level(
+        "figure_media",
+        args.level,
+        project_dir,
+        default=default,
+        env_var="SCITEX_WRITER_FIGURE_MEDIA",
+    )
+    kind = "research" if research else "non-research"
+    print(f"\n{BOLD}=== Figure Media Gate (level={level}, {kind}) ==={NC}\n")
+
+    if level == "off":
+        print(
+            f"  {DIM}[INFO]{NC} figure-media gate is disabled (level=off). "
+            f"Set figure_media.level or --level to enable."
+        )
+        print(
+            f"\n{BOLD}Summary:{NC} {GREEN}0 passed{NC}, "
+            f"{YELLOW}0 warnings{NC}, {RED}0 errors{NC}"
+        )
+        return 0
+
+    report = log_fail if level == "error" else log_warn
+    doc_types = list(_DOC_DIRS) if args.doc_type == "all" else [args.doc_type]
+
+    any_dir = False
+    total = 0
+    missing = []
+    for doc_type in doc_types:
+        media_dir = (
+            project_dir
+            / _DOC_DIRS[doc_type]
+            / "contents"
+            / "figures"
+            / "caption_and_media"
+        )
+        if not media_dir.is_dir():
+            continue
+        any_dir = True
+        for stem, caption in sorted(_declared_main_figures(media_dir).items()):
+            total += 1
+            if not _has_media(media_dir, stem):
+                rel = caption.relative_to(project_dir)
+                expected = (
+                    media_dir.relative_to(project_dir)
+                    / f"{stem}.<jpg|png|pdf|tif|svg|pptx|mmd>"
+                )
+                missing.append((doc_type, str(rel), str(expected)))
+
+    if not any_dir:
+        log_pass("no figure caption_and_media directories found to check")
+    elif total == 0:
+        log_pass("no declared figures found to check")
+    elif not missing:
+        log_pass(f"all {total} declared figure(s) have rendered media")
+    else:
+        for doc_type, rel, expected in missing[:_MAX_LIST]:
+            report(
+                f"{doc_type}: {rel}: figure declared but NO media asset "
+                f"(expected {expected})"
+            )
+        if len(missing) > _MAX_LIST:
+            log_detail(f"... and {len(missing) - _MAX_LIST} more")
+        log_detail(
+            "fix: add the figure's rendered media (jpg/png/pdf/tif/svg/pptx/mmd, "
+            "or NN{a,b,...} panels) next to its caption .tex, or remove the "
+            "caption if the figure is not used."
+        )
+
+    print()
+    print(
+        f"{BOLD}Summary:{NC} {GREEN}{PASS_COUNT} passed{NC}, "
+        f"{YELLOW}{WARN_COUNT} warnings{NC}, {RED}{FAIL_COUNT} errors{NC}"
+    )
+    return 1 if FAIL_COUNT > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/python/render_clew.py
+++ b/scripts/python/render_clew.py
@@ -102,7 +102,13 @@ def _claim_value(claim):
     """The display string for a claim. clew stores it display-ready; try the
     known field names in order (`claim_value` is the clew 0.2.19 key)."""
     v = _first(
-        claim, "claim_value", "value", "display_value", "latex", "rendered_value", "text"
+        claim,
+        "claim_value",
+        "value",
+        "display_value",
+        "latex",
+        "rendered_value",
+        "text",
     )
     return "" if v is None else str(v)
 
@@ -138,7 +144,9 @@ def _resolve_palette(data):
     raw = data.get("palette") or data.get("display_palette") or {}
     if isinstance(raw, dict):
         for status, color in raw.items():
-            h = _hex(color if not isinstance(color, dict) else _first(color, "hex", "color"))
+            h = _hex(
+                color if not isinstance(color, dict) else _first(color, "hex", "color")
+            )
             key = _STATUS_SYNONYMS.get(str(status).lower(), str(status).lower())
             if h:
                 palette[key] = h
@@ -209,7 +217,9 @@ def render_clew_tex(data):
     total, verified, allverified = _aggregate(data, claims)
 
     lines = ["\\makeatletter", ""]
-    lines.append("%% --- palette (from clew claims.json; writer has \\providecolor fallbacks) ---")
+    lines.append(
+        "%% --- palette (from clew claims.json; writer has \\providecolor fallbacks) ---"
+    )
     for status, name in _STATUS_COLOR.items():
         lines.append(f"\\definecolor{{{name}}}{{HTML}}{{{palette[status]}}}")
     lines += ["", "%% --- aggregate ---"]
@@ -232,7 +242,9 @@ def render_clew_tex(data):
         verdict = _verdict(claim)
         # `display_color` is the frozen contract name (clew 0.4.0 emits it);
         # color/hex are accepted aliases. Fall back to the verdict palette.
-        color = _hex(_first(claim, "display_color", "color", "hex")) or palette.get(verdict)
+        color = _hex(_first(claim, "display_color", "color", "hex")) or palette.get(
+            verdict
+        )
         value = _claim_value(claim)
         lines.append(f"%% {claim.get('claim_id', cid)} [{verdict}]")
         lines.append(f"\\@namedef{{clew@val@{cid}}}{{{value}}}")
@@ -245,10 +257,40 @@ def render_clew_tex(data):
     return "\n".join(lines) + "\n"
 
 
+def _find_git_root(start):
+    """Nearest ancestor of ``start`` containing ``.git`` (a git root), or None.
+    Bounded walk so a pathological tree can't spin."""
+    cur = start
+    for _ in range(64):
+        if (cur / ".git").exists():
+            return cur
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+    return None
+
+
+def _resolve_claims_json(project_path):
+    r"""Locate .scitex/clew/runtime/claims.json the way clew resolves its OWN db:
+    at the GIT ROOT. This makes NESTED-writer projects work -- when scitex-writer
+    is vendored UNDER an outer repo (e.g. at ``.scitex/writer/``) whose
+    ``.scitex/clew`` at the git root is the real feed, clew writes the export at
+    the git root, so render_clew must READ it there too (not under the writer
+    subdir). Preference: git-root/.scitex/clew when that dir exists; else fall
+    back to project_path/.scitex/clew -- the flat/common case (project IS its own
+    git root) is unchanged, and a stray empty .scitex/clew under the writer
+    subdir is ignored in favor of the real git-root feed. (nested-writer bug
+    surfaced by paper-neurovista, 2026-07-04.)"""
+    root = _find_git_root(project_path)
+    if root is not None and (root / ".scitex" / "clew").is_dir():
+        return root / ".scitex" / "clew" / "runtime" / "claims.json"
+    return project_path / CLAIMS_JSON
+
+
 def main(argv):
     project_dir = argv[1] if len(argv) > 1 else "."
     project_path = Path(project_dir).resolve()
-    claims_json = project_path / CLAIMS_JSON
+    claims_json = _resolve_claims_json(project_path)
 
     if not claims_json.exists():
         return 0  # clew layer optional -- no-op
@@ -268,8 +310,7 @@ def main(argv):
         tex = render_clew_tex(data)
     except Exception as exc:  # malformed schema -- surface, don't ship stale
         print(
-            f"ERRO:     Failed to render clew_rendered.tex from {claims_json}: "
-            f"{exc}.",
+            f"ERRO:     Failed to render clew_rendered.tex from {claims_json}: {exc}.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/python/render_clew_toggles.py
+++ b/scripts/python/render_clew_toggles.py
@@ -65,10 +65,37 @@ _TRUTHY = ("1", "true", "yes", "on")
 _FALSY = ("0", "false", "no", "off")
 
 
+def _find_git_root(start):
+    """Nearest ancestor of ``start`` containing ``.git`` (a git root), or None."""
+    cur = Path(start)
+    for _ in range(64):
+        if (cur / ".git").exists():
+            return cur
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+    return None
+
+
+def _resolve_config_yaml(project_dir):
+    r"""Locate .scitex/writer/config.yaml at the GIT ROOT -- same walk render_clew.py
+    uses for the clew db -- so a NESTED-writer project (writer vendored under an
+    outer repo, e.g. at .scitex/writer/) reads the config at the outer git root
+    rather than a doubly-nested <writer>/.scitex/writer/config.yaml (which is
+    absent, leaving \clewpresmarkers OFF and marks plain). Preference: git-root
+    copy when present; else fall back to PROJECT_ROOT (flat case unchanged).
+    (nested-writer toggle bug surfaced by paper-neurovista, 2026-07-04.)"""
+    project_dir = Path(project_dir)
+    root = _find_git_root(project_dir)
+    if root is not None and (root / CONFIG_YAML).is_file():
+        return root / CONFIG_YAML
+    return project_dir / CONFIG_YAML
+
+
 def _read_config_value(project_dir):
     """Return the raw `clew_presentation` value from the project config, or None
     (PyYAML optional -- absent it, only env resolves)."""
-    cfg = Path(project_dir) / CONFIG_YAML
+    cfg = _resolve_config_yaml(project_dir)
     if not cfg.is_file():
         return None
     try:

--- a/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
+++ b/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
@@ -169,6 +169,28 @@ cleanup() {
         fi
     fi
 
+    # FRESHNESS GATE: a compile is a success only if THIS run actually
+    # (re)created the PDF. Every engine writes the PDF into LOG_DIR and the block
+    # above MOVES it to $pdf_file, setting fresh_pdf=true. If fresh_pdf is still
+    # false here, no PDF was produced this run -- so any $pdf_file present is
+    # STALE from a PREVIOUS compile. This happens when an engine returns exit 0
+    # without emitting output (e.g. a silent latexmk/tectonic no-op, or a
+    # container that failed to mount) yet an old PDF is still on disk. Reporting
+    # that stale PDF as success is a silent failure: the user believes they got a
+    # fresh PDF but it is the old one. Fail loud instead. (The 3-pass engine also
+    # guards this at the engine level via an mtime check; this is the central
+    # backstop that additionally covers latexmk / tectonic and the finalization
+    # point where the PDF is promoted.)
+    if [ "$fresh_pdf" != true ]; then
+        echo_error "    PDF was not (re)created this run: $pdf_file"
+        echo_error "      The build likely failed -- a stale PDF from a previous run is present."
+        echo_error "      Refusing to pass off a stale PDF as a fresh compile."
+        echo_error "      Inspect the real error in: ${LOG_DIR}/${pdf_basename%.pdf}.log"
+        # Remove the stale PDF so downstream gates never treat it as valid output.
+        [ -f "$pdf_file" ] && rm -f "$pdf_file"
+        return 1
+    fi
+
     if [ -f "$pdf_file" ]; then
         local size
         size=$(du -h "$pdf_file" | cut -f1)

--- a/scripts/shell/modules/process_figures_modules/04_compilation.src
+++ b/scripts/shell/modules/process_figures_modules/04_compilation.src
@@ -200,7 +200,14 @@ create_placeholder_jpg() {
     fi
 }
 
-# Check and create placeholders for missing figures
+# Check and create placeholders for missing figures.
+#
+# NOTE: a DECLARED-but-missing figure is caught FAIL-LOUD upstream by the
+# figure-media gate (scripts/python/check_figure_media.py, wired into
+# run_provenance_checks.sh) which aborts the compile BEFORE this runs. So at the
+# gate's default (error for research projects) this placeholder path is never
+# reached. It only fills in when the gate is warn/off -- the explicit draft
+# opt-in (e.g. the public template's example figures, which ship without media).
 check_and_create_placeholders() {
     echo_info "Checking for missing figures..."
 

--- a/scripts/shell/modules/run_provenance_checks.sh
+++ b/scripts/shell/modules/run_provenance_checks.sh
@@ -21,6 +21,12 @@
 # scholar stub (auto-generated placeholder), also error for research / warn
 # otherwise -- the compiler-owns half of the citation->clew verification
 # contract (a stub \cite can never reach a compiled research manuscript).
+# figure_media is the FIGURE-MEDIA GATE: it fails the build when a figure is
+# DECLARED (a caption .tex) but has NO rendered media asset, so the compile can
+# no longer silently substitute a "Missing Figure" placeholder. It runs BEFORE
+# process_figures.sh (which creates the placeholder), so at error-level the
+# placeholder path is never reached; defaults to error for research projects,
+# warn otherwise (the public template ships example captions without media).
 #
 # Returns the worst exit code across the checks (0 unless a check errored).
 
@@ -31,7 +37,7 @@ PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$THIS_DIR/../../.." && pwd)}"
 PY="${SCITEX_WRITER_PYTHON:-python3}"
 
 rc=0
-for chk in check_paper_symlink check_media_provenance check_caption_footnote check_clew_verify check_citations check_version_freshness; do
+for chk in check_paper_symlink check_media_provenance check_figure_media check_caption_footnote check_clew_verify check_citations check_version_freshness; do
     script="$THIS_DIR/../../python/${chk}.py"
     [ -f "$script" ] || continue
     "$PY" "$script" "$PROJECT_ROOT" || rc=$?

--- a/src/scitex_writer/_cli/__init__.py
+++ b/src/scitex_writer/_cli/__init__.py
@@ -34,8 +34,42 @@ of the package and are referenced from skills, READMEs, and external docs.
 
 from __future__ import annotations
 
-from . import commands  # noqa: F401 (registers all commands on main_group)
-from ._core import main, main_group
+import sys as _sys
+
+
+def _is_bare_version_invocation(argv: list[str]) -> bool:
+    """True iff ``argv`` is exactly a single ``--version`` / ``-V`` token."""
+    return argv in (["--version"], ["-V"])
+
+
+# Fast-path a bare ``--version`` / ``-V`` BEFORE importing ``.commands``.
+#
+# Root cause this guards against (fixes the CI regression that appeared once
+# scitex-dev 0.27.0 was installed): importing ``.commands`` eagerly pulls in
+# ``scitex_dev._cli._completion`` to attach shell-completion leaves, which
+# imports ``scitex_dev._cli`` — and *that* package's ``__init__`` has its own
+# module-level fast-path that, when ``sys.argv[1:]`` is a bare
+# ``--version``/``-V``, prints ``scitex-dev <ver>`` and ``raise
+# SystemExit(0)``. So without this guard, ``scitex-writer --version`` (and
+# ``python -m scitex_writer --version``) print scitex-dev's version and exit
+# before scitex-writer's own Click ``version_option`` (in ``._core``) ever
+# runs.
+#
+# We short-circuit here — before that import chain — so scitex-writer's own
+# version wins. The output matches Click's ``version_option`` format (and the
+# ``prog_name="scitex-writer"`` set in ``._core``), so behaviour is identical
+# to a normal Click ``--version`` dispatch. Deliberately narrow: any other
+# argv (a subcommand, ``--version --json``, ``--help``, ``-h``) falls through
+# to the real Click group unchanged.
+if _is_bare_version_invocation(_sys.argv[1:]):
+    from .. import __version__ as _pkg_version
+
+    print(f"scitex-writer, version {_pkg_version}")
+    raise SystemExit(0)
+
+
+from . import commands  # noqa: E402,F401 (registers all commands on main_group)
+from ._core import main, main_group  # noqa: E402
 
 # Backward-compat re-exports: before the monolith split every subcommand
 # group (``bib_group``, ``compile_group``, ...) lived directly in this

--- a/src/scitex_writer/_cli/commands/__init__.py
+++ b/src/scitex_writer/_cli/commands/__init__.py
@@ -24,6 +24,7 @@ from . import (  # noqa: F401
     bib,
     checks,
     compile,
+    deps,
     export,
     figures,
     gui,

--- a/src/scitex_writer/_cli/commands/deps.py
+++ b/src/scitex_writer/_cli/commands/deps.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_cli/commands/deps.py
+
+"""``list-deps`` command — scitex-writer's native (apt) system dependencies.
+
+scitex-writer is the single source of truth for its LaTeX-toolchain apt
+packages (``scitex_writer._core._system_deps``), declared to the ecosystem via
+the ``scitex_dev.system_deps`` entry-point. This command is the leaf-local
+view of that list: ``scitex-writer list-deps`` prints the apt packages (the
+fleet-wide aggregate across every leaf is a separate surface,
+``scitex-dev ecosystem system-deps``).
+
+Deliberately scitex_dev-free: it reads the local provider table
+(``APT_PACKAGES`` / ``_PACKAGES``) directly, so it never triggers the
+``scitex_dev`` import chain (and its historical import-time ``--version``
+fast-path).
+"""
+
+from __future__ import annotations
+
+import click
+
+from .._core import main_group
+from .._helpers import _emit_json
+
+# =========================================================================
+# list-deps  (flat verb-noun top-level command, per §1 — same house style
+# as compile-manuscript / check-limits / export-manuscript)
+# =========================================================================
+
+
+@main_group.command("list-deps")
+@click.option(
+    "--apt",
+    "as_apt",
+    is_flag=True,
+    default=False,
+    help="Emit the full `apt-get install ...` one-liner instead of one name per line.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit JSON (package/purpose/provider).",
+)
+def list_deps_cmd(as_apt, as_json):
+    """Print scitex-writer's required system (apt) packages — the LaTeX toolchain.
+
+    Default output is one apt package name per line (pipe/build friendly).
+    ``--apt`` prints the ready-to-paste ``apt-get install`` command; ``--json``
+    prints package/purpose/provider. These are the same packages scitex-writer
+    declares to ``scitex-dev ecosystem system-deps`` via the
+    ``scitex_dev.system_deps`` entry-point.
+
+    \b
+    Example:
+        $ scitex-writer list-deps
+        $ scitex-writer list-deps --apt
+        $ scitex-writer list-deps --json
+    """
+    from ..._core._system_deps import _PACKAGES, APT_PACKAGES
+
+    if as_json:
+        _emit_json(
+            [
+                {"package": pkg, "purpose": purpose, "provider": "scitex-writer"}
+                for pkg, purpose in _PACKAGES
+            ]
+        )
+        return 0
+    if as_apt:
+        click.echo(
+            "apt-get install -y --no-install-recommends " + " ".join(APT_PACKAGES)
+        )
+        return 0
+    click.echo("\n".join(APT_PACKAGES))
+    return 0
+
+
+# EOF

--- a/tests/scitex_writer/_cli/commands/test_deps.py
+++ b/tests/scitex_writer/_cli/commands/test_deps.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: src/scitex_writer/_cli/commands/deps.py
+
+"""Tests for the `scitex-writer deps` CLI command (real Click invocation)."""
+
+import importlib
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_writer._cli._core import main_group
+from scitex_writer._core._system_deps import APT_PACKAGES
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_module_exposes_list_deps_cmd():
+    # Arrange
+    name = "scitex_writer._cli.commands.deps"
+    # Act
+    module = importlib.import_module(name)
+    # Assert
+    assert hasattr(module, "list_deps_cmd")
+
+
+def test_deps_registered_on_main_group():
+    # Arrange
+    commands = main_group.commands
+    # Act
+    present = "list-deps" in commands
+    # Assert
+    assert present
+
+
+def test_deps_default_exits_zero(runner):
+    # Arrange
+    args = ["list-deps"]
+    # Act
+    result = runner.invoke(main_group, args)
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_deps_default_prints_one_package_per_line(runner):
+    # Arrange
+    args = ["list-deps"]
+    # Act
+    result = runner.invoke(main_group, args)
+    # Assert
+    assert result.output.splitlines() == APT_PACKAGES
+
+
+def test_deps_apt_exits_zero(runner):
+    # Arrange
+    args = ["list-deps", "--apt"]
+    # Act
+    result = runner.invoke(main_group, args)
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_deps_apt_starts_with_apt_get_install(runner):
+    # Arrange
+    args = ["list-deps", "--apt"]
+    # Act
+    result = runner.invoke(main_group, args)
+    # Assert
+    assert result.output.strip().startswith(
+        "apt-get install -y --no-install-recommends "
+    )
+
+
+def test_deps_apt_contains_every_package(runner):
+    # Arrange
+    args = ["list-deps", "--apt"]
+    # Act
+    result = runner.invoke(main_group, args)
+    # Assert
+    assert all(pkg in result.output for pkg in APT_PACKAGES)
+
+
+def test_deps_apt_has_core_latex(runner):
+    # Arrange
+    args = ["list-deps", "--apt"]
+    # Act
+    result = runner.invoke(main_group, args)
+    # Assert
+    assert "texlive-latex-base" in result.output
+
+
+def test_deps_apt_has_parallel(runner):
+    # Arrange
+    args = ["list-deps", "--apt"]
+    # Act
+    result = runner.invoke(main_group, args)
+    # Assert
+    assert "parallel" in result.output
+
+
+def test_deps_json_lists_packages_in_order(runner):
+    # Arrange
+    args = ["list-deps", "--json"]
+    # Act
+    result = runner.invoke(main_group, args)
+    payload = json.loads(result.output)
+    # Assert
+    assert [row["package"] for row in payload] == APT_PACKAGES
+
+
+def test_deps_json_tags_every_row_with_writer_provider(runner):
+    # Arrange
+    args = ["list-deps", "--json"]
+    # Act
+    result = runner.invoke(main_group, args)
+    payload = json.loads(result.output)
+    # Assert
+    assert all(row["provider"] == "scitex-writer" for row in payload)

--- a/tests/scripts/python/test_check_figure_media.py
+++ b/tests/scripts/python/test_check_figure_media.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: check_figure_media.py
+#
+# Reproduces the silent "Missing Figure" placeholder condition: a figure
+# declared by a caption .tex with NO rendered media asset must now FAIL LOUD
+# (gate names the figure and exits non-zero) instead of degrading to a
+# placeholder.
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from check_figure_media import resolve_level  # noqa: E402
+
+_SCRIPT = ROOT_DIR / "scripts" / "python" / "check_figure_media.py"
+
+_FIG_MEDIA = "01_manuscript/contents/figures/caption_and_media"
+
+
+# ============================================================================
+# helpers / fixtures
+# ============================================================================
+
+
+def _write(tmp_path, rel, content):
+    p = tmp_path / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _declare_figure(tmp_path, stem):
+    """Declare a figure: drop its caption .tex under the figure media dir."""
+    return _write(tmp_path, f"{_FIG_MEDIA}/{stem}.tex", f"\\textbf{{Figure}} {stem}.\n")
+
+
+def _add_media(tmp_path, name):
+    """Drop a (byte) media asset under the figure media dir."""
+    return _write(tmp_path, f"{_FIG_MEDIA}/{name}", "x")
+
+
+def _run(project, *extra):
+    env = dict(os.environ)
+    env.pop("SCITEX_WRITER_FIGURE_MEDIA", None)
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), str(project), *extra],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+@pytest.fixture
+def clean_env():
+    saved = {k: os.environ.get(k) for k in ("SCITEX_WRITER_FIGURE_MEDIA", "HOME")}
+    os.environ.pop("SCITEX_WRITER_FIGURE_MEDIA", None)
+    with tempfile.TemporaryDirectory() as home:
+        os.environ["HOME"] = home
+        yield home
+    for key, val in saved.items():
+        if val is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = val
+
+
+# ============================================================================
+# resolve_level
+# ============================================================================
+
+
+def test_resolve_level_defaults_to_error_for_research(tmp_path, clean_env):
+    """A research project defaults the figure-media gate to error."""
+    # Arrange
+    check = "figure_media"
+    # Act
+    level = resolve_level(
+        check,
+        None,
+        str(tmp_path),
+        default="error",
+        env_var="SCITEX_WRITER_FIGURE_MEDIA",
+    )
+    # Assert
+    assert level == "error"
+
+
+# ============================================================================
+# End-to-end (no LaTeX toolchain needed)
+# ============================================================================
+
+
+def test_declared_figure_without_media_errors(tmp_path, clean_env):
+    """A figure declared with no media asset blocks the compile (exit 1)."""
+    # Arrange
+    _declare_figure(tmp_path, "01_overview")
+    # Act
+    proc = _run(tmp_path, "--level", "error")
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_missing_figure_is_named_in_report(tmp_path, clean_env):
+    """The failure names the declared-but-missing figure caption."""
+    # Arrange
+    _declare_figure(tmp_path, "01_overview")
+    # Act
+    proc = _run(tmp_path, "--level", "error")
+    # Assert
+    assert "01_overview.tex" in proc.stdout
+
+
+def test_declared_figure_with_media_passes(tmp_path, clean_env):
+    """A figure whose media asset exists resolves cleanly (exit 0)."""
+    # Arrange
+    _declare_figure(tmp_path, "01_overview")
+    _add_media(tmp_path, "01_overview.jpg")
+    # Act
+    proc = _run(tmp_path, "--level", "error")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_figure_resolved_by_panels_passes(tmp_path, clean_env):
+    """A figure with only NN{a,b} panel media (no direct asset) resolves."""
+    # Arrange
+    _declare_figure(tmp_path, "02_panels")
+    _add_media(tmp_path, "02a_left.png")
+    _add_media(tmp_path, "02b_right.png")
+    # Act
+    proc = _run(tmp_path, "--level", "error")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_panel_caption_not_treated_as_declared_figure(tmp_path, clean_env):
+    """A panel caption (NNa_) is not itself a declared figure (exit 0)."""
+    # Arrange
+    _declare_figure(tmp_path, "03a_only_a_panel")
+    # Act
+    proc = _run(tmp_path, "--level", "error")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_reports_all_missing_figures_at_once(tmp_path, clean_env):
+    """One run surfaces every missing figure together, not one-at-a-time."""
+    # Arrange
+    _declare_figure(tmp_path, "01_overview")
+    _declare_figure(tmp_path, "02_results")
+    # Act
+    proc = _run(tmp_path, "--level", "error")
+    # Assert
+    assert "2 errors" in proc.stdout
+
+
+def test_off_level_skips(tmp_path, clean_env):
+    """--level off disables the gate even with a missing figure (exit 0)."""
+    # Arrange
+    _declare_figure(tmp_path, "01_overview")
+    # Act
+    proc = _run(tmp_path, "--level", "off")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_warn_level_does_not_block(tmp_path, clean_env):
+    """--level warn reports but exits 0 (the draft placeholder opt-in)."""
+    # Arrange
+    _declare_figure(tmp_path, "01_overview")
+    # Act
+    proc = _run(tmp_path, "--level", "warn")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_prefix_collision_does_not_false_pass(tmp_path, clean_env):
+    """Media for figure 10 must not satisfy figure 1 (prefix-boundary)."""
+    # Arrange
+    _declare_figure(tmp_path, "1_first")
+    _add_media(tmp_path, "10_tenth.jpg")
+    # Act
+    proc = _run(tmp_path, "--level", "error")
+    # Assert
+    assert proc.returncode == 1

--- a/tests/scripts/python/test_render_clew_gitroot.py
+++ b/tests/scripts/python/test_render_clew_gitroot.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: render_clew.py git-root .scitex/clew resolution (nested-writer).
+
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from render_clew import (  # noqa: E402
+    CLAIMS_JSON,
+    _resolve_claims_json,
+)
+
+
+class TestResolveClaimsJson:
+    def test_nested_writer_resolves_git_root_feed(self, tmp_path):
+        # Arrange: writer vendored under an outer git repo whose .scitex/clew is
+        # the real feed; a STRAY empty .scitex/clew sits under the writer subdir.
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".scitex" / "clew" / "runtime").mkdir(parents=True)
+        writer = tmp_path / ".scitex" / "writer"
+        (writer / ".scitex" / "clew" / "runtime").mkdir(parents=True)
+        # Act
+        resolved = _resolve_claims_json(writer)
+        # Assert
+        assert resolved == tmp_path / ".scitex" / "clew" / "runtime" / "claims.json"
+
+    def test_flat_project_resolves_its_own_clew(self, tmp_path):
+        # Arrange: project IS its own git root with .scitex/clew (common case).
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".scitex" / "clew" / "runtime").mkdir(parents=True)
+        # Act
+        resolved = _resolve_claims_json(tmp_path)
+        # Assert
+        assert resolved == tmp_path / ".scitex" / "clew" / "runtime" / "claims.json"
+
+    def test_no_git_root_falls_back_to_project_path(self, tmp_path):
+        # Arrange: no .git anywhere above the project.
+        project = tmp_path / "proj"
+        project.mkdir()
+        # Act
+        resolved = _resolve_claims_json(project)
+        # Assert
+        assert resolved == project / CLAIMS_JSON
+
+    def test_git_root_without_clew_falls_back_to_project_path(self, tmp_path):
+        # Arrange: a git root exists but never ran clew (no .scitex/clew there).
+        (tmp_path / ".git").mkdir()
+        project = tmp_path / "sub"
+        project.mkdir()
+        # Act
+        resolved = _resolve_claims_json(project)
+        # Assert
+        assert resolved == project / CLAIMS_JSON
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))
+
+# EOF

--- a/tests/scripts/python/test_render_clew_gitroot.py
+++ b/tests/scripts/python/test_render_clew_gitroot.py
@@ -12,6 +12,10 @@ from render_clew import (  # noqa: E402
     CLAIMS_JSON,
     _resolve_claims_json,
 )
+from render_clew_toggles import (  # noqa: E402
+    CONFIG_YAML,
+    _resolve_config_yaml,
+)
 
 
 class TestResolveClaimsJson:
@@ -54,6 +58,39 @@ class TestResolveClaimsJson:
         resolved = _resolve_claims_json(project)
         # Assert
         assert resolved == project / CLAIMS_JSON
+
+
+class TestResolveConfigYaml:
+    def test_nested_writer_resolves_git_root_config(self, tmp_path):
+        # Arrange: writer vendored under an outer git repo; config at the outer
+        # git root's .scitex/writer/, NOT doubly-nested under the writer subdir.
+        (tmp_path / ".git").mkdir()
+        writer = tmp_path / ".scitex" / "writer"
+        writer.mkdir(parents=True)
+        (writer / "config.yaml").write_text("clew_presentation: on\n")
+        # Act
+        resolved = _resolve_config_yaml(writer)
+        # Assert
+        assert resolved == tmp_path / CONFIG_YAML
+
+    def test_flat_project_resolves_its_own_config(self, tmp_path):
+        # Arrange
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".scitex" / "writer").mkdir(parents=True)
+        (tmp_path / CONFIG_YAML).write_text("clew_presentation: on\n")
+        # Act
+        resolved = _resolve_config_yaml(tmp_path)
+        # Assert
+        assert resolved == tmp_path / CONFIG_YAML
+
+    def test_no_git_root_falls_back_to_project_path(self, tmp_path):
+        # Arrange
+        project = tmp_path / "proj"
+        project.mkdir()
+        # Act
+        resolved = _resolve_config_yaml(project)
+        # Assert
+        assert resolved == project / CONFIG_YAML
 
 
 if __name__ == "__main__":

--- a/tests/scripts/shell/modules/test_compilation_compiled_tex_to_compiled_pdf.sh
+++ b/tests/scripts/shell/modules/test_compilation_compiled_tex_to_compiled_pdf.sh
@@ -86,6 +86,58 @@ test_pagecount_zero_when_no_log() {
     rm -rf "$tmp"
 }
 
+# FRESHNESS GATE regression: engine reports success (compile_result=0) but
+# produced NO fresh PDF in LOG_DIR this run, while a STALE PDF from a previous
+# compile still sits at the final location. cleanup() must FAIL LOUD (return 1)
+# instead of passing off the stale PDF as a successful compile.
+test_cleanup_fails_when_stale_pdf_and_no_fresh() {
+    local tmp
+    tmp="$(mktemp -d)"
+    export LOG_DIR="$tmp/logs"
+    mkdir -p "$LOG_DIR"
+    export SCITEX_WRITER_COMPILED_PDF="$tmp/manuscript.pdf"
+    printf 'STALE PDF from a previous run\n' >"$SCITEX_WRITER_COMPILED_PDF"
+    # No manuscript.pdf inside LOG_DIR -> nothing produced this run.
+    ( cleanup 0 ) >/dev/null 2>&1
+    local rc=$?
+    assert_eq "1" "$rc" "cleanup fails loud when success reported but no fresh PDF (stale present)"
+    rm -rf "$tmp"
+}
+
+# The stale PDF must be REMOVED so downstream gates never treat it as valid.
+test_cleanup_removes_stale_pdf_when_no_fresh() {
+    local tmp
+    tmp="$(mktemp -d)"
+    export LOG_DIR="$tmp/logs"
+    mkdir -p "$LOG_DIR"
+    export SCITEX_WRITER_COMPILED_PDF="$tmp/manuscript.pdf"
+    printf 'STALE PDF from a previous run\n' >"$SCITEX_WRITER_COMPILED_PDF"
+    ( cleanup 0 ) >/dev/null 2>&1
+    local present="yes"
+    [ -f "$SCITEX_WRITER_COMPILED_PDF" ] || present="no"
+    assert_eq "no" "$present" "cleanup removes the stale PDF when no fresh PDF was produced"
+    rm -rf "$tmp"
+}
+
+# Positive control: a PDF freshly produced in LOG_DIR this run is promoted and
+# cleanup() returns success (0).
+test_cleanup_succeeds_when_fresh_pdf_produced() {
+    local tmp
+    tmp="$(mktemp -d)"
+    export LOG_DIR="$tmp/logs"
+    mkdir -p "$LOG_DIR"
+    export SCITEX_WRITER_ROOT_DIR="$tmp"
+    export SCITEX_WRITER_DOC_TYPE="manuscript"
+    export SCITEX_WRITER_VERSIONS_DIR="$tmp/archive"
+    export SCITEX_WRITER_COMPILED_PDF="$tmp/manuscript.pdf"
+    # A PDF present in LOG_DIR == produced by THIS run.
+    printf 'FRESH PDF produced this run\n' >"$LOG_DIR/manuscript.pdf"
+    ( cleanup 0 ) >/dev/null 2>&1
+    local rc=$?
+    assert_eq "0" "$rc" "cleanup succeeds when a fresh PDF was produced in LOG_DIR this run"
+    rm -rf "$tmp"
+}
+
 # Run tests
 main() {
     echo "Testing: compilation_compiled_tex_to_compiled_pdf.sh"
@@ -102,6 +154,9 @@ main() {
     test_pagecount_from_log_single_page
     test_pagecount_zero_when_no_output_line
     test_pagecount_zero_when_no_log
+    test_cleanup_fails_when_stale_pdf_and_no_fresh
+    test_cleanup_removes_stale_pdf_when_no_fresh
+    test_cleanup_succeeds_when_fresh_pdf_produced
 
     echo "========================================"
     echo "Results: $TESTS_PASSED/$TESTS_RUN passed"


### PR DESCRIPTION
Promote develop to main for the 2.24.9 release. Bundles 5 merged PRs since 2.24.8: render_clew gitroot rescue, stale-PDF freshness guard, missing-figure fail-loud, the scitex-writer --version P1 fix, and the list-deps command. Version bumped to 2.24.9.