### PR TITLE
feat(footer): opt-in visible "Compiled by scitex-writer v<version>" page footer

### DIFF
--- a/00_shared/latex_styles/signature_footer.tex
+++ b/00_shared/latex_styles/signature_footer.tex
@@ -1,0 +1,34 @@
+%% -*- coding: utf-8 -*-
+%% File: 00_shared/latex_styles/signature_footer.tex
+%% Description: OPT-IN visible on-page footer advertising scitex-writer.
+%%
+%% Injected at compile time by scripts/python/compile_tex_structure.py ONLY when
+%% the SCITEX_WRITER_SIGNATURE_FOOTER feature flag resolves ON (default OFF), so
+%% default compiles are byte-for-byte visually unchanged. This is DISTINCT from
+%% the invisible PDF pdfcreator metadata (00_shared/scitex_writer_version.tex),
+%% which is always emitted -- this adds a VISIBLE page footer.
+%%
+%% The __SCITEX_WRITER_VERSION__ token is substituted with the resolved writer
+%% version before this block is inlined (see _signature_footer.py).
+%%
+%% Rendering: an absolute bottom-centre overlay stamped on EVERY shipped page
+%% via \AtBeginShipout (from atbegshi, always available -- hyperref loads it in
+%% packages.tex) + a TikZ overlay node anchored to the physical page (tikz is
+%% loaded in packages.tex). This is deliberately pagestyle-agnostic: it does
+%% NOT touch \pagestyle, fancyhdr, or the elsarticle \ps@pprintTitle footer, so
+%% existing page numbers / journal headers are preserved. The "current page"
+%% reference settles after the usual 2 compile passes (the default multi-pass
+%% build does this; a single-pass draft may misposition on the first run).
+
+\AtBeginShipout{%
+  \AtBeginShipoutUpperLeft{%
+    \begin{tikzpicture}[remember picture, overlay]%
+      \node[anchor=south, yshift=4pt,
+            font=\ttfamily\scriptsize, text=gray]
+        at (current page.south)
+        {Compiled by scitex-writer v__SCITEX_WRITER_VERSION__};%
+    \end{tikzpicture}%
+  }%
+}
+
+%%%% EOF

--- a/scripts/python/_severity.py
+++ b/scripts/python/_severity.py
@@ -107,7 +107,7 @@ def _warn_invalid_level(raw, check, source):
     valid = "/".join(_valid_levels(check))
     sys.stderr.write(
         f"[WARN] {source}: {check}.level must be one of {valid}; got {raw!r} "
-        f"-- ignoring (using default). Quote string values, e.g. level: \"off\".\n"
+        f'-- ignoring (using default). Quote string values, e.g. level: "off".\n'
     )
 
 
@@ -116,11 +116,14 @@ def env_truthy(name):
     return os.environ.get(name, "").strip().lower() in _TRUTHY
 
 
-def _read_config_level(config_path, check):
-    """Read ``<check>.level`` from a YAML config, or None.
+def _load_config_data(config_path):
+    """Load a YAML config file into a mapping, or None.
 
-    A missing file/key is None (not an error). PyYAML is optional -- absent it,
-    config files are silently skipped so CLI + env still resolve.
+    Shared loader for every config tier in the precedence ladder (severity
+    levels AND boolean feature toggles). A missing file, absent PyYAML, an
+    unreadable/invalid YAML, or a non-mapping document all degrade to None (the
+    tier is skipped) rather than raising -- so CLI + env still resolve when a
+    config file is broken or PyYAML is not installed.
     """
     if not config_path.exists():
         return None
@@ -132,12 +135,53 @@ def _read_config_level(config_path, check):
         data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
     except Exception:
         return None
-    if not isinstance(data, dict):
+    return data if isinstance(data, dict) else None
+
+
+def _read_config_level(config_path, check):
+    """Read ``<check>.level`` from a YAML config, or None.
+
+    A missing file/key is None (not an error). PyYAML is optional -- absent it,
+    config files are silently skipped so CLI + env still resolve.
+    """
+    data = _load_config_data(config_path)
+    if data is None:
         return None
     block = data.get(check)
     if not isinstance(block, dict):
         return None
     return _coerce_config_level(block.get("level"), check, str(config_path))
+
+
+def read_config_bool(config_path, key):
+    """Read a top-level boolean feature-toggle ``key`` from a YAML config.
+
+    Companion to ``_read_config_level`` for boolean feature FLAGS (on/off
+    toggles) rather than severity LEVELS: it reuses the exact same optional-
+    PyYAML load + YAML-1.1 bool coercion (a bare ``on``/``yes``/``true`` ->
+    True, ``off``/``no``/``false`` -> False). Returns the resolved bool, or
+    None when the key is absent / the file is missing / the value is not
+    boolean -- so the caller falls through to the next precedence tier.
+
+    Public so feature-flag resolvers (e.g. the visible signature footer) can
+    reuse the project ./config.yaml -> user ~/.scitex/writer/config.yaml
+    machinery instead of reinventing it.
+    """
+    data = _load_config_data(config_path)
+    if data is None:
+        return None
+    raw = data.get(key)
+    if isinstance(raw, bool):
+        return raw
+    # Accept the string spellings too (a hand-written value that arrived quoted,
+    # e.g. ``signature_footer: "true"``); anything else is treated as unset.
+    if isinstance(raw, str):
+        low = raw.strip().lower()
+        if low in ("1", "true", "yes", "on"):
+            return True
+        if low in ("0", "false", "no", "off"):
+            return False
+    return None
 
 
 def resolve_level(
@@ -174,9 +218,7 @@ def resolve_level(
         or _read_config_level(Path(project_dir) / "config.yaml", check)
         # Path.home() is resolved at call time (not import) so a changed $HOME
         # is honored -- matches the sibling check_*.py resolvers.
-        or _read_config_level(
-            Path.home() / ".scitex" / "writer" / "config.yaml", check
-        )
+        or _read_config_level(Path.home() / ".scitex" / "writer" / "config.yaml", check)
         or _norm(default, check)
         or "error"
     )
@@ -191,6 +233,12 @@ def resolve_level(
     return level
 
 
-__all__ = ["resolve_level", "env_truthy", "LEVELS", "LINT_STRICT_ENV"]
+__all__ = [
+    "resolve_level",
+    "read_config_bool",
+    "env_truthy",
+    "LEVELS",
+    "LINT_STRICT_ENV",
+]
 
 # EOF

--- a/scripts/python/_signature_footer.py
+++ b/scripts/python/_signature_footer.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/_signature_footer.py
+# Purpose: Resolve + render the OPT-IN, DEFAULT-OFF, VISIBLE on-page footer
+#          "Compiled by scitex-writer v<version>". This is DISTINCT from the
+#          invisible PDF metadata signature (pdfcreator={Compiled by
+#          scitex-writer vX}, emitted via 00_shared/scitex_writer_version.tex,
+#          which is always present) -- this module adds a visible page footer
+#          the operator can enable to advertise SciTeX across their papers.
+#
+#          Feature TOGGLE (boolean on/off), NOT a severity level. Precedence
+#          ladder (first decisive tier wins), mirroring _resolve_dark_mode and
+#          the _severity resolver:
+#            1. CLI flag                                   (opt-in; forces ON)
+#            2. env SCITEX_WRITER_SIGNATURE_FOOTER         (set & non-empty)
+#            3. project ./config.yaml   signature_footer:  <bool>
+#            4. user ~/.scitex/writer/config.yaml  signature_footer: <bool>
+#            5. default OFF
+#          The project/user config tiers reuse the shared config-reading
+#          machinery in _severity.read_config_bool (same optional-PyYAML load +
+#          YAML-bool coercion + path resolution) rather than reinventing it.
+#
+# Self-contained: stdlib + optional PyYAML (via _severity). No public-API
+# change to the compile flow beyond the flattener wiring.
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import read_config_bool  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# SINGLE SOURCE OF TRUTH for the feature-flag name.
+#
+# PROVISIONAL: the operator is coordinating the shared opt-in-knob naming with
+# scitex-dev. Keep the env-var / config-key spelling in THIS ONE PLACE so a
+# later rename to match scitex-dev's shared feature-flag contract is a one-line
+# change (do NOT hard-code the string anywhere else).
+# ---------------------------------------------------------------------------
+SIGNATURE_FOOTER_ENV = "SCITEX_WRITER_SIGNATURE_FOOTER"
+SIGNATURE_FOOTER_CONFIG_KEY = "signature_footer"
+
+# Unique marker prepended to the inlined footer block; also the idempotency
+# sentinel so a repeated flatten does not stack a second copy (mirrors
+# DARK_MODE_SENTINEL in compile_tex_structure.py).
+SIGNATURE_FOOTER_SENTINEL = "% SciTeX signature footer (inlined at compile time)"
+
+# Token in 00_shared/latex_styles/signature_footer.tex replaced with the
+# resolved writer version just before injection.
+VERSION_PLACEHOLDER = "__SCITEX_WRITER_VERSION__"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def _env_bool(value):
+    """True iff ``value`` is a truthy token (1/true/yes/on)."""
+    return value.strip().lower() in _TRUTHY
+
+
+def resolve_signature_footer_enabled(cli_flag, project_dir, *, environ=None):
+    """Resolve whether the visible signature footer is enabled.
+
+    Parameters
+    ----------
+    cli_flag : bool
+        The ``--signature-footer`` store_true flag. Opt-in only: True forces
+        ON; False is a no-op that falls through (it never forces OFF), exactly
+        like ``_resolve_dark_mode``'s ``explicit_flag``.
+    project_dir : str or Path
+        Project root holding ``./config.yaml``.
+    environ : mapping or None
+        Environment mapping to read (defaults to ``os.environ``; injectable
+        for tests without monkeypatch).
+
+    Returns
+    -------
+    bool
+        True when any tier turns the footer ON; default False.
+    """
+    if cli_flag:
+        return True
+    env = os.environ if environ is None else environ
+    raw = env.get(SIGNATURE_FOOTER_ENV)
+    if raw is not None and raw.strip() != "":
+        return _env_bool(raw)
+    project = read_config_bool(
+        Path(project_dir) / "config.yaml", SIGNATURE_FOOTER_CONFIG_KEY
+    )
+    if project is not None:
+        return project
+    # Path.home() is resolved at call time (honors a changed $HOME) -- matches
+    # the sibling _severity user-config tier.
+    user = read_config_bool(
+        Path.home() / ".scitex" / "writer" / "config.yaml",
+        SIGNATURE_FOOTER_CONFIG_KEY,
+    )
+    if user is not None:
+        return user
+    return False
+
+
+def resolve_writer_version(*, environ=None, repo_root=None):
+    """Resolve the scitex-writer version string for the footer.
+
+    Mirrors the codebase's existing resolution for the pdfcreator metadata: the
+    shell ``config/load_config.sh`` exports ``SCITEX_WRITER_VERSION`` (read from
+    a ``VERSION`` file), and ``_tex_signature.generate_signature`` falls back to
+    ``pyproject.toml``. Order:
+        env SCITEX_WRITER_VERSION (set by load_config.sh, if not "unknown")
+        -> repo-root VERSION file
+        -> pyproject.toml [project] version
+        -> "unknown"
+    """
+    env = os.environ if environ is None else environ
+    val = env.get("SCITEX_WRITER_VERSION", "").strip()
+    if val and val.lower() != "unknown":
+        return val
+    # scripts/python/_signature_footer.py -> repo root is parent.parent.parent
+    root = (
+        Path(repo_root)
+        if repo_root is not None
+        else Path(__file__).resolve().parent.parent.parent
+    )
+    vfile = root / "VERSION"
+    try:
+        if vfile.exists():
+            text = vfile.read_text(encoding="utf-8").strip()
+            if text:
+                return text
+    except OSError:
+        pass
+    pyproject = root / "pyproject.toml"
+    try:
+        with open(pyproject, "r", encoding="utf-8") as handle:
+            for line in handle:
+                if line.startswith("version"):
+                    return line.split("=")[1].strip().strip('"').strip("'")
+    except Exception:
+        pass
+    return "unknown"
+
+
+def build_footer_injection(styles_dir, version):
+    """Build the LaTeX block to inline for the footer, or ''.
+
+    Reads ``00_shared/latex_styles/signature_footer.tex``, substitutes the
+    version placeholder, and prepends the idempotency sentinel. Returns '' when
+    the style file is missing -- an advertising footer must never abort a
+    compile (fail-safe), and '' also lets the caller skip injection cleanly.
+    """
+    style_file = Path(styles_dir) / "signature_footer.tex"
+    if not style_file.exists():
+        return ""
+    content = style_file.read_text(encoding="utf-8").replace(
+        VERSION_PLACEHOLDER, version
+    )
+    return "\n" + SIGNATURE_FOOTER_SENTINEL + "\n" + content + "\n"
+
+
+__all__ = [
+    "SIGNATURE_FOOTER_ENV",
+    "SIGNATURE_FOOTER_CONFIG_KEY",
+    "SIGNATURE_FOOTER_SENTINEL",
+    "VERSION_PLACEHOLDER",
+    "resolve_signature_footer_enabled",
+    "resolve_writer_version",
+    "build_footer_injection",
+]
+
+# EOF

--- a/scripts/python/_tectonic_compat.py
+++ b/scripts/python/_tectonic_compat.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/_tectonic_compat.py
+# Purpose: Tectonic-engine compatibility transforms for the flattened TeX.
+#          Extracted verbatim from compile_tex_structure.py to keep that module
+#          under the line limit (same pattern as _tex_signature.py /
+#          _build_id.py); pure helper, no behavior change.
+
+import re
+from pathlib import Path
+
+
+def apply_tectonic_compat(expanded_content: str, base_tex: Path) -> str:
+    r"""Rewrite the flattened TeX for tectonic compatibility.
+
+    Disables packages/commands that tectonic chokes on (lineno, bashful,
+    \linenumbers) and inlines \readwordcount{file} with the file's contents
+    (tectonic has no shell-escape). Returns the transformed content.
+    """
+    # Comment out incompatible packages
+    expanded_content = re.sub(
+        r"(\\usepackage\{[^}]*lineno[^}]*\})",
+        r"% \1  % Disabled for tectonic",
+        expanded_content,
+    )
+    expanded_content = re.sub(
+        r"(\\usepackage\{[^}]*bashful[^}]*\})",
+        r"% \1  % Disabled for tectonic",
+        expanded_content,
+    )
+    # Comment out \linenumbers command
+    expanded_content = re.sub(
+        r"(^\\linenumbers)",
+        r"% \1  % Disabled for tectonic",
+        expanded_content,
+        flags=re.MULTILINE,
+    )
+
+    # Replace \readwordcount{file} with actual file contents
+    def replace_wordcount(match):
+        file_path = match.group(1)
+        try:
+            # Resolve file path (could be relative or absolute)
+            if not file_path.startswith("/"):
+                # Paths starting with ./ are relative to project root, not base_tex
+                if file_path.startswith("./"):
+                    # Use current working directory as base (should be project root)
+                    full_path = Path(file_path)
+                else:
+                    # Relative to base_tex directory
+                    full_path = base_tex.parent / file_path
+            else:
+                full_path = Path(file_path)
+
+            # Read the count value
+            with open(full_path, "r") as f:
+                count_value = f.read().strip()
+
+            # Match the \readwordcount macro's thousands separator (e.g.
+            # 1,259) so tectonic mode (which inlines the raw number) renders
+            # the same as the latexmk/pdflatex path.
+            if count_value.isdigit():
+                count_value = f"{int(count_value):,}"
+            return count_value
+        except Exception as e:
+            # If file can't be read, return a placeholder with debug info
+            return f"??({e})"
+
+    expanded_content = re.sub(
+        r"\\readwordcount\{([^}]+)\}", replace_wordcount, expanded_content
+    )
+    return expanded_content
+
+
+__all__ = ["apply_tectonic_compat"]
+
+# EOF

--- a/scripts/python/compile_tex_structure.py
+++ b/scripts/python/compile_tex_structure.py
@@ -22,6 +22,13 @@ from _build_id import (  # noqa: E402
     inject_build_metadata,
     register_build,
 )
+from _signature_footer import (  # noqa: E402
+    SIGNATURE_FOOTER_SENTINEL,
+    build_footer_injection,
+    resolve_signature_footer_enabled,
+    resolve_writer_version,
+)
+from _tectonic_compat import apply_tectonic_compat  # noqa: E402
 from _tex_signature import generate_signature  # noqa: E402
 
 # Unique marker for the inlined dark-mode block; also used as the idempotency
@@ -186,6 +193,7 @@ def compile_tex_structure(
     verbose: bool = True,
     dark_mode: bool = False,
     tectonic_mode: bool = False,
+    signature_footer: bool = False,
 ) -> bool:
     r"""
     Compile TeX structure by expanding all \input{} commands.
@@ -196,6 +204,7 @@ def compile_tex_structure(
         verbose: Print progress
         dark_mode: Enable dark mode (black background, white text)
         tectonic_mode: Disable incompatible packages for tectonic engine
+        signature_footer: Inject the opt-in visible footer (default OFF)
 
     Returns:
         True if successful
@@ -277,59 +286,7 @@ def compile_tex_structure(
 
     # Apply tectonic compatibility if enabled
     if tectonic_mode:
-        # Comment out incompatible packages
-        expanded_content = re.sub(
-            r"(\\usepackage\{[^}]*lineno[^}]*\})",
-            r"% \1  % Disabled for tectonic",
-            expanded_content,
-        )
-        expanded_content = re.sub(
-            r"(\\usepackage\{[^}]*bashful[^}]*\})",
-            r"% \1  % Disabled for tectonic",
-            expanded_content,
-        )
-        # Comment out \linenumbers command
-        expanded_content = re.sub(
-            r"(^\\linenumbers)",
-            r"% \1  % Disabled for tectonic",
-            expanded_content,
-            flags=re.MULTILINE,
-        )
-
-        # Replace \readwordcount{file} with actual file contents
-        # Find all \readwordcount commands
-        def replace_wordcount(match):
-            file_path = match.group(1)
-            try:
-                # Resolve file path (could be relative or absolute)
-                if not file_path.startswith("/"):
-                    # Paths starting with ./ are relative to project root, not base_tex
-                    if file_path.startswith("./"):
-                        # Use current working directory as base (should be project root)
-                        full_path = Path(file_path)
-                    else:
-                        # Relative to base_tex directory
-                        full_path = base_tex.parent / file_path
-                else:
-                    full_path = Path(file_path)
-
-                # Read the count value
-                with open(full_path, "r") as f:
-                    count_value = f.read().strip()
-
-                # Match the \readwordcount macro's thousands separator (e.g.
-                # 1,259) so tectonic mode (which inlines the raw number) renders
-                # the same as the latexmk/pdflatex path.
-                if count_value.isdigit():
-                    count_value = f"{int(count_value):,}"
-                return count_value
-            except Exception as e:
-                # If file can't be read, return a placeholder with debug info
-                return f"??({e})"
-
-        expanded_content = re.sub(
-            r"\\readwordcount\{([^}]+)\}", replace_wordcount, expanded_content
-        )
+        expanded_content = apply_tectonic_compat(expanded_content, base_tex)
 
     # Inject dark mode styling if enabled
     if dark_mode:
@@ -393,6 +350,24 @@ def compile_tex_structure(
             expanded_content = re.sub(
                 r"(?m)^([ \t]*)\\begin\{document\}",
                 lambda m: m.group(0) + "\n" + banner_tex,
+                expanded_content,
+                count=1,
+            )
+
+    # Inject the OPT-IN visible signature footer before \begin{document} (same
+    # idiom as dark mode). Default OFF -> no injection -> default compiles stay
+    # byte-identical. Idempotent via the sentinel. DISTINCT from the always-on
+    # invisible pdfcreator metadata (00_shared/scitex_writer_version.tex).
+    if signature_footer and SIGNATURE_FOOTER_SENTINEL not in expanded_content:
+        styles_dir = base_tex.parent.parent / "00_shared" / "latex_styles"
+        version = resolve_writer_version()
+        footer_injection = build_footer_injection(styles_dir, version)
+        if footer_injection:
+            if verbose:
+                print(f"Signature footer: enabled (scitex-writer v{version})")
+            expanded_content = re.sub(
+                r"(?m)^([ \t]*)\\begin\{document\}",
+                lambda m: footer_injection + m.group(0),
                 expanded_content,
                 count=1,
             )
@@ -492,6 +467,13 @@ def main():
         action="store_true",
         help="Enable tectonic compatibility (disable incompatible packages)",
     )
+    parser.add_argument(
+        "--signature-footer",
+        action="store_true",
+        help="Inject the opt-in visible 'Compiled by scitex-writer v<version>' "
+        "page footer (default OFF; also settable via "
+        "SCITEX_WRITER_SIGNATURE_FOOTER / config.yaml)",
+    )
 
     args = parser.parse_args()
 
@@ -502,6 +484,12 @@ def main():
         or os.getenv("SCITEX_WRITER_ENGINE", "") == "tectonic"
         or os.getenv("SCITEX_WRITER_SELECTED_ENGINE", "") == "tectonic"
     )
+    # Project root holds ./config.yaml (same tier the _severity resolver reads).
+    # It is base_tex's document-dir parent, matching _read_config_theme above.
+    project_dir = args.base_tex.resolve().parent.parent
+    signature_footer = resolve_signature_footer_enabled(
+        args.signature_footer, project_dir
+    )
 
     success = compile_tex_structure(
         base_tex=args.base_tex,
@@ -509,6 +497,7 @@ def main():
         verbose=not args.quiet,
         dark_mode=dark_mode,
         tectonic_mode=tectonic_mode,
+        signature_footer=signature_footer,
     )
 
     exit(0 if success else 1)

--- a/tests/scripts/python/test__signature_footer.py
+++ b/tests/scripts/python/test__signature_footer.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: _signature_footer.py — the opt-in visible "Compiled by
+# scitex-writer v<version>" page footer (feature toggle, default OFF).
+#
+# Style: no mocks (STX-NM002), one behavioral assert per test (STX-TQ007), no
+# monkeypatch (PA-306), explicit AAA markers (STX-TQ002). Precedence is
+# exercised with REAL config files under tmp_path + an injected `environ`
+# mapping (env tiers) + an isolated HOME (user config tier), like
+# tests/scripts/python/test__severity.py.
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from _signature_footer import (  # noqa: E402
+    SIGNATURE_FOOTER_CONFIG_KEY,
+    SIGNATURE_FOOTER_ENV,
+    SIGNATURE_FOOTER_SENTINEL,
+    build_footer_injection,
+    resolve_signature_footer_enabled,
+    resolve_writer_version,
+)
+
+# ============================================================================
+# helpers / fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def isolated_home():
+    """Isolate HOME (the user-config tier) so a real ~/.scitex config never
+    leaks into the default-OFF assertions. Restores HOME afterwards."""
+    saved = os.environ.get("HOME")
+    with tempfile.TemporaryDirectory() as home:
+        os.environ["HOME"] = home
+        yield Path(home)
+    if saved is None:
+        os.environ.pop("HOME", None)
+    else:
+        os.environ["HOME"] = saved
+
+
+def _write(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _user_config(home, text):
+    _write(home / ".scitex" / "writer" / "config.yaml", text)
+
+
+# ============================================================================
+# precedence ladder: CLI > env > project ./config.yaml > user config > default
+# ============================================================================
+
+
+def test_default_is_off(tmp_path, isolated_home):
+    """Nothing set anywhere -> the footer defaults OFF."""
+    # Arrange
+    environ = {}
+    # Act
+    result = resolve_signature_footer_enabled(False, tmp_path, environ=environ)
+    # Assert
+    assert result is False
+
+
+def test_cli_flag_forces_on(tmp_path, isolated_home):
+    """The CLI flag (opt-in) turns the footer ON regardless of config."""
+    # Arrange
+    environ = {}
+    # Act
+    result = resolve_signature_footer_enabled(True, tmp_path, environ=environ)
+    # Assert
+    assert result is True
+
+
+def test_env_true_enables(tmp_path, isolated_home):
+    """A truthy env var turns the footer ON."""
+    # Arrange
+    environ = {SIGNATURE_FOOTER_ENV: "true"}
+    # Act
+    result = resolve_signature_footer_enabled(False, tmp_path, environ=environ)
+    # Assert
+    assert result is True
+
+
+def test_env_false_disables(tmp_path, isolated_home):
+    """A falsy env var keeps the footer OFF."""
+    # Arrange
+    environ = {SIGNATURE_FOOTER_ENV: "false"}
+    # Act
+    result = resolve_signature_footer_enabled(False, tmp_path, environ=environ)
+    # Assert
+    assert result is False
+
+
+def test_project_config_true_enables(tmp_path, isolated_home):
+    """project ./config.yaml `signature_footer: true` turns the footer ON."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write(tmp_path / "config.yaml", "signature_footer: true\n")
+    # Act
+    result = resolve_signature_footer_enabled(False, tmp_path, environ={})
+    # Assert
+    assert result is True
+
+
+def test_project_config_false_disables(tmp_path, isolated_home):
+    """project ./config.yaml `signature_footer: false` keeps the footer OFF."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write(tmp_path / "config.yaml", "signature_footer: false\n")
+    # Act
+    result = resolve_signature_footer_enabled(False, tmp_path, environ={})
+    # Assert
+    assert result is False
+
+
+def test_user_config_true_enables(tmp_path, isolated_home):
+    """user ~/.scitex/writer/config.yaml is the global opt-in tier."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _user_config(isolated_home, "signature_footer: true\n")
+    # Act
+    result = resolve_signature_footer_enabled(False, tmp_path, environ={})
+    # Assert
+    assert result is True
+
+
+def test_env_beats_project_config(tmp_path, isolated_home):
+    """env (higher tier) overrides project ./config.yaml (lower tier)."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write(tmp_path / "config.yaml", "signature_footer: true\n")
+    environ = {SIGNATURE_FOOTER_ENV: "false"}
+    # Act
+    result = resolve_signature_footer_enabled(False, tmp_path, environ=environ)
+    # Assert
+    assert result is False
+
+
+def test_project_config_beats_user_config(tmp_path, isolated_home):
+    """project ./config.yaml overrides user ~/.scitex/writer/config.yaml."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write(tmp_path / "config.yaml", "signature_footer: false\n")
+    _user_config(isolated_home, "signature_footer: true\n")
+    # Act
+    result = resolve_signature_footer_enabled(False, tmp_path, environ={})
+    # Assert
+    assert result is False
+
+
+def test_cli_flag_beats_env_false(tmp_path, isolated_home):
+    """The CLI opt-in wins over an env var set to false."""
+    # Arrange
+    environ = {SIGNATURE_FOOTER_ENV: "false"}
+    # Act
+    result = resolve_signature_footer_enabled(True, tmp_path, environ=environ)
+    # Assert
+    assert result is True
+
+
+def test_yaml_off_token_disables(tmp_path, isolated_home):
+    """A bare YAML `off` (coerced to False by PyYAML) keeps the footer OFF."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write(tmp_path / "config.yaml", "signature_footer: off\n")
+    # Act
+    result = resolve_signature_footer_enabled(False, tmp_path, environ={})
+    # Assert
+    assert result is False
+
+
+def test_config_key_is_the_ssot_constant(tmp_path, isolated_home):
+    """The config key resolves via the SSoT constant (rename-safe)."""
+    # Arrange
+    pytest.importorskip("yaml")
+    _write(tmp_path / "config.yaml", f"{SIGNATURE_FOOTER_CONFIG_KEY}: true\n")
+    # Act
+    result = resolve_signature_footer_enabled(False, tmp_path, environ={})
+    # Assert
+    assert result is True
+
+
+# ============================================================================
+# version resolution (mirrors the pdfcreator metadata resolution)
+# ============================================================================
+
+
+def test_version_from_env(tmp_path):
+    """SCITEX_WRITER_VERSION (exported by load_config.sh) is used first."""
+    # Arrange
+    environ = {"SCITEX_WRITER_VERSION": "3.1.4"}
+    # Act
+    result = resolve_writer_version(environ=environ, repo_root=tmp_path)
+    # Assert
+    assert result == "3.1.4"
+
+
+def test_version_env_unknown_falls_through(tmp_path):
+    """A literal 'unknown' env value is ignored (falls through to files)."""
+    # Arrange
+    _write(tmp_path / "VERSION", "7.7.7\n")
+    environ = {"SCITEX_WRITER_VERSION": "unknown"}
+    # Act
+    result = resolve_writer_version(environ=environ, repo_root=tmp_path)
+    # Assert
+    assert result == "7.7.7"
+
+
+def test_version_from_version_file(tmp_path):
+    """A repo-root VERSION file is read when the env var is absent."""
+    # Arrange
+    _write(tmp_path / "VERSION", "2.9.0\n")
+    # Act
+    result = resolve_writer_version(environ={}, repo_root=tmp_path)
+    # Assert
+    assert result == "2.9.0"
+
+
+def test_version_from_pyproject(tmp_path):
+    """pyproject.toml [project] version is the final real source."""
+    # Arrange
+    _write(tmp_path / "pyproject.toml", 'version = "5.6.7"\n')
+    # Act
+    result = resolve_writer_version(environ={}, repo_root=tmp_path)
+    # Assert
+    assert result == "5.6.7"
+
+
+def test_version_unknown_when_nothing_available(tmp_path):
+    """No env, no VERSION, no pyproject -> 'unknown'."""
+    # Arrange
+    environ = {}
+    # Act
+    result = resolve_writer_version(environ=environ, repo_root=tmp_path)
+    # Assert
+    assert result == "unknown"
+
+
+# ============================================================================
+# preamble injection: right snippet emitted when ON, nothing when style missing
+# ============================================================================
+
+
+def _write_style(styles_dir):
+    _write(
+        styles_dir / "signature_footer.tex",
+        "% footer style\nCompiled by scitex-writer v__SCITEX_WRITER_VERSION__\n",
+    )
+
+
+def test_injection_substitutes_version(tmp_path):
+    """The version placeholder is replaced with the resolved version."""
+    # Arrange
+    _write_style(tmp_path)
+    # Act
+    injection = build_footer_injection(tmp_path, "4.2.0")
+    # Assert
+    assert "Compiled by scitex-writer v4.2.0" in injection
+
+
+def test_injection_carries_sentinel(tmp_path):
+    """The injected block starts with the idempotency sentinel."""
+    # Arrange
+    _write_style(tmp_path)
+    # Act
+    injection = build_footer_injection(tmp_path, "4.2.0")
+    # Assert
+    assert SIGNATURE_FOOTER_SENTINEL in injection
+
+
+def test_injection_leaves_no_placeholder(tmp_path):
+    """No unsubstituted placeholder token survives in the injected block."""
+    # Arrange
+    _write_style(tmp_path)
+    # Act
+    injection = build_footer_injection(tmp_path, "4.2.0")
+    # Assert
+    assert "__SCITEX_WRITER_VERSION__" not in injection
+
+
+def test_injection_empty_when_style_missing(tmp_path):
+    """A missing style file yields '' (fail-safe: never abort a compile)."""
+    # Arrange
+    missing_styles_dir = tmp_path
+    # Act
+    injection = build_footer_injection(missing_styles_dir, "4.2.0")
+    # Assert
+    assert injection == ""
+
+
+# ============================================================================
+# end-to-end flattener gating: footer present when ON, absent when OFF
+# ============================================================================
+
+
+def _make_project(tmp_path):
+    """Minimal <root>/doc/base.tex + <root>/00_shared/latex_styles project."""
+    styles = tmp_path / "00_shared" / "latex_styles"
+    real_style = ROOT_DIR / "00_shared" / "latex_styles" / "signature_footer.tex"
+    _write(styles / "signature_footer.tex", real_style.read_text(encoding="utf-8"))
+    base_tex = tmp_path / "doc" / "base.tex"
+    _write(base_tex, "\\documentclass{article}\n\\begin{document}\nHi\\end{document}\n")
+    return base_tex
+
+
+def _flatten(base_tex, out_tex, *, signature_footer):
+    import compile_tex_structure as cts
+
+    saved = os.environ.get("PROJECT_ROOT")
+    os.environ["PROJECT_ROOT"] = str(base_tex.parent.parent)
+    try:
+        cts.compile_tex_structure(
+            base_tex=base_tex,
+            output_tex=out_tex,
+            verbose=False,
+            signature_footer=signature_footer,
+        )
+    finally:
+        if saved is None:
+            os.environ.pop("PROJECT_ROOT", None)
+        else:
+            os.environ["PROJECT_ROOT"] = saved
+
+
+def test_flatten_injects_footer_when_on(tmp_path):
+    """signature_footer=True -> the footer block lands in the flattened TeX."""
+    # Arrange
+    base_tex = _make_project(tmp_path)
+    out_tex = tmp_path / "out.tex"
+    # Act
+    _flatten(base_tex, out_tex, signature_footer=True)
+    # Assert
+    assert SIGNATURE_FOOTER_SENTINEL in out_tex.read_text(encoding="utf-8")
+
+
+def test_flatten_omits_footer_when_off(tmp_path):
+    """signature_footer=False -> default compile is unchanged (no footer)."""
+    # Arrange
+    base_tex = _make_project(tmp_path)
+    out_tex = tmp_path / "out.tex"
+    # Act
+    _flatten(base_tex, out_tex, signature_footer=False)
+    # Assert
+    assert SIGNATURE_FOOTER_SENTINEL not in out_tex.read_text(encoding="utf-8")
+
+
+# EOF


### PR DESCRIPTION
## What

Adds an **opt-in, default-OFF, visible on-page footer** reading `Compiled by scitex-writer v<version>`. This advertises SciTeX across the operator's papers. It is **distinct from and additive to** the existing invisible `pdfcreator` PDF metadata signature (`00_shared/scitex_writer_version.tex`) — that metadata is kept unchanged; this adds a *visible* footer.

Closes scitex-todo card `writer-visible-signature-footer-optin`.

## Flag mechanism (boolean feature toggle, NOT a severity level)

Precedence ladder, mirroring `_resolve_dark_mode` and the `_severity` resolver:

```
CLI --signature-footer  >  env SCITEX_WRITER_SIGNATURE_FOOTER
  >  project ./config.yaml (signature_footer:)  >  user ~/.scitex/writer/config.yaml  >  default OFF
```

- The **user config tier** is the global opt-in the operator wants (enable once, applies to all their projects).
- The project + user config tiers **reuse the shared config-reading machinery**: a new public `_severity.read_config_bool()` (extracted alongside a new `_load_config_data()` helper that `_read_config_level` now also uses) provides the same optional-PyYAML load + YAML-1.1 bool coercion (`off/no/false` -> False) + path resolution. The severity **level enum is untouched** — the bool flag lives in its own resolver, keeping severity and feature-flag concerns separate.

### SSoT for the flag name — provisional

The flag/env/config name lives in **one place**: `_signature_footer.SIGNATURE_FOOTER_ENV` (+ `SIGNATURE_FOOTER_CONFIG_KEY`). **The name `SCITEX_WRITER_SIGNATURE_FOOTER` is PROVISIONAL** pending scitex-dev's shared opt-in-knob feature-flag contract — a later rename to match the ecosystem convention is a one-line change here.

## Render

- New preamble file `00_shared/latex_styles/signature_footer.tex` stamps every shipped page via `\AtBeginShipout` (from `atbegshi`, always available since `hyperref` loads it) + a TikZ overlay node anchored to `(current page.south)` (tikz is already loaded).
- **Pagestyle-agnostic**: it does NOT touch `\pagestyle` / fancyhdr / the elsarticle `\ps@pprintTitle` footer, so existing page numbers and journal headers are preserved.
- The flattener `compile_tex_structure.py` injects the block before `\begin{document}` **only when the flag is ON** (idempotent via a sentinel), so **default compiles are byte-for-byte visually unchanged**.
- Version resolved the same way as the pdfcreator metadata: env `SCITEX_WRITER_VERSION` (exported by `load_config.sh`) -> repo `VERSION` file -> `pyproject.toml`.

## Housekeeping

Extracted the tectonic-compat transform out of `compile_tex_structure.py` into `_tectonic_compat.py` to keep the file under the 512-line limit (same extraction pattern as `_tex_signature.py` / `_build_id.py`); **no behavior change** — verified by the unchanged `test_compile_tex_structure.py` suite.

## Tests

23 new tests in `tests/scripts/python/test__signature_footer.py` — full precedence ladder (CLI/env/project/user/default), YAML `off` coercion, version resolution, injection substitution + sentinel, and **end-to-end flattener gating** (footer present when ON, absent when OFF). Real config files under `tmp_path`, no mocks (STX-NM002), no monkeypatch (PA-306), one assert each (STX-TQ007), explicit AAA markers (STX-TQ002).

Local run: **89 passed** (23 new + severity + the existing compile_tex_structure suite).

## Pending

- **Visual host-verification of the rendered PDF is pending** — no LaTeX toolchain in-container, so the `.tex` injection + resolution logic is covered but the actual page render must be eyeballed on a host.
