### PR TITLE
feat(vendored-tree): self-documenting engine tree — role markers + read-only perms

### DIFF
--- a/00_shared/bib_files/bibliography.bib
+++ b/00_shared/bib_files/bibliography.bib
@@ -1,3 +1,5 @@
+%% ROLE: consumer-owned — safe to edit here; preserved across re-vendor
+%% (update-project never overwrites PRESERVED_PATHS files).
 @article{example_reference_2020,
   author  = {Author, First and Author, Second},
   title   = {Example Article Title},

--- a/00_shared/journal_name.tex
+++ b/00_shared/journal_name.tex
@@ -1,1 +1,3 @@
+%% ROLE: consumer-owned — safe to edit here; preserved across re-vendor
+%% (update-project never overwrites PRESERVED_PATHS files).
 \journal{Journal Name Here}

--- a/00_shared/keywords.tex
+++ b/00_shared/keywords.tex
@@ -1,3 +1,5 @@
+%% ROLE: consumer-owned — safe to edit here; preserved across re-vendor
+%% (update-project never overwrites PRESERVED_PATHS files).
 % \pdfbookmark[1]{Keywords}{keywords}
 \begin{keyword}
 keyword one \sep keyword two \sep keyword three \sep keyword four \sep keyword five

--- a/00_shared/latex_styles/bibliography.tex
+++ b/00_shared/latex_styles/bibliography.tex
@@ -1,4 +1,8 @@
 %% -*- coding: utf-8 -*-
+%% ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+%% overwrites this file on every re-vendor; fix it upstream in the
+%% scitex-writer package instead (local edits are lost, and update-project
+%% may set it read-only in the consumer workspace after vendoring).
 %% File: 00_shared/latex_styles/bibliography.tex
 
 %% ============================================================================

--- a/00_shared/latex_styles/clew_presentation.tex
+++ b/00_shared/latex_styles/clew_presentation.tex
@@ -1,4 +1,8 @@
 %% -*- coding: utf-8 -*-
+%% ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+%% overwrites this file on every re-vendor; fix it upstream in the
+%% scitex-writer package instead (local edits are lost, and update-project
+%% may set it read-only in the consumer workspace after vendoring).
 %% File: 00_shared/latex_styles/clew_presentation.tex
 %% Purpose: STATIC style for the clew presentation layer -- the RENDERING half.
 %%

--- a/00_shared/latex_styles/columns.tex
+++ b/00_shared/latex_styles/columns.tex
@@ -1,4 +1,8 @@
 %% -*- coding: utf-8 -*-
+%% ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+%% overwrites this file on every re-vendor; fix it upstream in the
+%% scitex-writer package instead (local edits are lost, and update-project
+%% may set it read-only in the consumer workspace after vendoring).
 %% File: 00_shared/latex_styles/columns.tex
 
 %% --- Columns ---

--- a/00_shared/latex_styles/dark_mode.tex
+++ b/00_shared/latex_styles/dark_mode.tex
@@ -1,4 +1,8 @@
 %% -*- coding: utf-8 -*-
+%% ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+%% overwrites this file on every re-vendor; fix it upstream in the
+%% scitex-writer package instead (local edits are lost, and update-project
+%% may set it read-only in the consumer workspace after vendoring).
 %% Timestamp: "2025-11-10 01:30:00 (ywatanabe)"
 %% File: ./00_shared/latex_styles/dark_mode.tex
 %% Description: Dark mode styling for scientific manuscripts

--- a/00_shared/latex_styles/formatting.tex
+++ b/00_shared/latex_styles/formatting.tex
@@ -1,4 +1,8 @@
 %% -*- coding: utf-8 -*-
+%% ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+%% overwrites this file on every re-vendor; fix it upstream in the
+%% scitex-writer package instead (local edits are lost, and update-project
+%% may set it read-only in the consumer workspace after vendoring).
 %% File: 00_shared/latex_styles/formatting.tex
 
 %% --- Journal name header (show journal name as-is, without "Preprint submitted to" prefix) ---

--- a/00_shared/latex_styles/linker.tex
+++ b/00_shared/latex_styles/linker.tex
@@ -1,4 +1,8 @@
 %% -*- coding: utf-8 -*-
+%% ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+%% overwrites this file on every re-vendor; fix it upstream in the
+%% scitex-writer package instead (local edits are lost, and update-project
+%% may set it read-only in the consumer workspace after vendoring).
 %% File: 00_shared/latex_styles/linker.tex
 
 %% --- Linker for supplemtal material ---

--- a/00_shared/latex_styles/packages.tex
+++ b/00_shared/latex_styles/packages.tex
@@ -1,4 +1,8 @@
 %% -*- coding: utf-8 -*-
+%% ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+%% overwrites this file on every re-vendor; fix it upstream in the
+%% scitex-writer package instead (local edits are lost, and update-project
+%% may set it read-only in the consumer workspace after vendoring).
 %% File: 00_shared/latex_styles/packages.tex
 %% -*- coding: utf-8 -*-
 %% Timestamp: "2025-09-27 16:01:16 (ywatanabe)"

--- a/00_shared/latex_styles/signature_footer.tex
+++ b/00_shared/latex_styles/signature_footer.tex
@@ -1,4 +1,8 @@
 %% -*- coding: utf-8 -*-
+%% ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+%% overwrites this file on every re-vendor; fix it upstream in the
+%% scitex-writer package instead (local edits are lost, and update-project
+%% may set it read-only in the consumer workspace after vendoring).
 %% File: 00_shared/latex_styles/signature_footer.tex
 %% Description: OPT-IN visible on-page footer advertising scitex-writer.
 %%

--- a/01_manuscript/base.tex
+++ b/01_manuscript/base.tex
@@ -1,4 +1,8 @@
 %% -*- coding: utf-8 -*-
+%% ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+%% overwrites this file on every re-vendor; fix it upstream in the
+%% scitex-writer package instead (local edits are lost, and update-project
+%% may set it read-only in the consumer workspace after vendoring).
 %% File: 01_manuscript/base.tex
 \UseRawInputEncoding
 

--- a/02_supplementary/base.tex
+++ b/02_supplementary/base.tex
@@ -1,4 +1,8 @@
 %% -*- coding: utf-8 -*-
+%% ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+%% overwrites this file on every re-vendor; fix it upstream in the
+%% scitex-writer package instead (local edits are lost, and update-project
+%% may set it read-only in the consumer workspace after vendoring).
 %% File: 02_supplementary/base.tex
 \UseRawInputEncoding
 

--- a/03_revision/base.tex
+++ b/03_revision/base.tex
@@ -1,4 +1,8 @@
 %% -*- coding: utf-8 -*-
+%% ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+%% overwrites this file on every re-vendor; fix it upstream in the
+%% scitex-writer package instead (local edits are lost, and update-project
+%% may set it read-only in the consumer workspace after vendoring).
 %% File: 03_revision/base.tex
 \UseRawInputEncoding
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Makefile for SciTeX Writer
 # Usage: make [target]
 # Author: ywatanabe

--- a/compile.sh
+++ b/compile.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-10-29 12:59:32 (ywatanabe)"
 # File: ./compile.sh
 

--- a/scripts/containers/Dockerfile
+++ b/scripts/containers/Dockerfile
@@ -1,3 +1,7 @@
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # SciTeX Writer - Docker Container
 # Complete LaTeX environment for reproducible manuscript compilation
 # Build: docker build -t scitex-writer .

--- a/scripts/containers/Dockerfile.gui
+++ b/scripts/containers/Dockerfile.gui
@@ -1,3 +1,7 @@
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # SciTeX Writer GUI - Docker Container
 # Browser-based LaTeX editor with PDF preview and compilation
 #

--- a/scripts/containers/docker-compose.gui.yml
+++ b/scripts/containers/docker-compose.gui.yml
@@ -1,3 +1,7 @@
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # SciTeX Writer GUI - Docker Compose
 #
 # Usage:

--- a/scripts/containers/mermaid.def
+++ b/scripts/containers/mermaid.def
@@ -1,3 +1,7 @@
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 Bootstrap: docker
 From: node:20-slim
 

--- a/scripts/containers/scitex-writer.def
+++ b/scripts/containers/scitex-writer.def
@@ -1,3 +1,7 @@
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 Bootstrap: docker
 From: ubuntu:24.04
 

--- a/scripts/containers/texlive.def
+++ b/scripts/containers/texlive.def
@@ -1,3 +1,7 @@
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # scripts/containers/texlive.def — scitex-writer LaTeX sub-tool SIF.
 #
 # Lean LaTeX environment delivered as an independent, read-only sub-tool

--- a/scripts/installation/check_requirements.sh
+++ b/scripts/installation/check_requirements.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-09-26 22:46:00 (ywatanabe)"
 # File: ./paper/scripts/installation/check_requirements.sh
 

--- a/scripts/installation/download_containers.sh
+++ b/scripts/installation/download_containers.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-09-26 23:29:05 (ywatanabe)"
 # File: ./paper/scripts/installation/download_containers.sh
 

--- a/scripts/installation/init_project.sh
+++ b/scripts/installation/init_project.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2026-01-09 (ywatanabe)"
 # File: ./scripts/installation/init_project.sh
 # Description: Initialize project with required preprocessing artifacts

--- a/scripts/installation/install_on_ubuntu.sh
+++ b/scripts/installation/install_on_ubuntu.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-09-26 23:31:10 (ywatanabe)"
 # File: ./paper/scripts/installation/install_on_ubuntu.sh
 

--- a/scripts/installation/requirements/install.sh
+++ b/scripts/installation/requirements/install.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Universal dependency installer for scitex-writer
 # Handles system and Python dependencies across platforms
 

--- a/scripts/installation/requirements/system-debian.txt
+++ b/scripts/installation/requirements/system-debian.txt
@@ -1,3 +1,7 @@
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 texlive-latex-base
 texlive-latex-extra
 texlive-fonts-recommended

--- a/scripts/installation/requirements/system-macos.txt
+++ b/scripts/installation/requirements/system-macos.txt
@@ -1,3 +1,7 @@
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 basictex
 latexdiff
 ghostscript

--- a/scripts/maintenance/generate_demo_previews.sh
+++ b/scripts/maintenance/generate_demo_previews.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-11-10 02:14:17 (ywatanabe)"
 # File: ./scripts/maintenance/generate_demo_previews.sh
 

--- a/scripts/maintenance/show_usage.sh
+++ b/scripts/maintenance/show_usage.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/maintenance/show_usage.sh
 # Description: Display project usage guide (delegates to compile.sh --help-recursive)
 

--- a/scripts/maintenance/strip_example_content.sh
+++ b/scripts/maintenance/strip_example_content.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2026-01-09 (ywatanabe)"
 # File: ./scripts/strip_example_content.sh
 # Description: Strip example content for minimal template setup (GitHub Issue #14)

--- a/scripts/maintenance/update.sh
+++ b/scripts/maintenance/update.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-11-09 19:00:00 (ywatanabe)"
 # File: ./scripts/maintenance/update.sh
 # Description: Update scitex-writer while preserving user content

--- a/scripts/powershell/pptx2tiff.ps1
+++ b/scripts/powershell/pptx2tiff.ps1
@@ -1,3 +1,7 @@
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 param(
     [string]$inputFilePath,
     [string]$outputFilePath

--- a/scripts/python/_build_id.py
+++ b/scripts/python/_build_id.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/_build_id.py
 # Purpose: Per-compilation build IDs, PDF metadata injection, build registry.
 #

--- a/scripts/python/_citation_banner.py
+++ b/scripts/python/_citation_banner.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/_citation_banner.py
 # Purpose: The citation-gate BANNER render layer. When the gate runs in `banner`
 #          mode (compile-anyway, accepted-risk draft), it emits a red page-1

--- a/scripts/python/_logging.py
+++ b/scripts/python/_logging.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-11-11 (ywatanabe)"
 
 

--- a/scripts/python/_severity.py
+++ b/scripts/python/_severity.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/_severity.py
 # Purpose: Shared severity-model resolver for the writer pre-compile / lint
 #          checks. Single source of truth for resolving a check's effective

--- a/scripts/python/_signature_footer.py
+++ b/scripts/python/_signature_footer.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/_signature_footer.py
 # Purpose: Resolve + render the OPT-IN, DEFAULT-OFF, VISIBLE on-page footer
 #          "Compiled by scitex-writer v<version>". This is DISTINCT from the

--- a/scripts/python/_tectonic_compat.py
+++ b/scripts/python/_tectonic_compat.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/_tectonic_compat.py
 # Purpose: Tectonic-engine compatibility transforms for the flattened TeX.
 #          Extracted verbatim from compile_tex_structure.py to keep that module

--- a/scripts/python/_tex_signature.py
+++ b/scripts/python/_tex_signature.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/_tex_signature.py
 # Purpose: Build the compilation signature comment block prepended to the
 #          flattened TeX by compile_tex_structure.py. Extracted from that

--- a/scripts/python/check_caption_footnote.py
+++ b/scripts/python/check_caption_footnote.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/check_caption_footnote.py
 # Purpose: Catch \footnote (and \footnotetext used as an in-caption workaround)
 #          inside a \caption{} at LINT time, before compile.

--- a/scripts/python/check_citations.py
+++ b/scripts/python/check_citations.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/check_citations.py
 # Purpose: Pre-compile CITATION GATE -- before a research manuscript is
 #          compiled, check every \cite key actually used in the document against

--- a/scripts/python/check_cited_states.py
+++ b/scripts/python/check_cited_states.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-11-11 (ywatanabe)"
 
 

--- a/scripts/python/check_clew_verify.py
+++ b/scripts/python/check_clew_verify.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/check_clew_verify.py
 # Purpose: Pre-compile provenance GATE -- before a research manuscript is
 #          compiled, re-verify every clew-registered claim against its bound

--- a/scripts/python/check_compile_artifacts.py
+++ b/scripts/python/check_compile_artifacts.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/check_compile_artifacts.py
 # Purpose: POST-compile verification gate. Catches a FALSE-SUCCESS compile --
 #          one that exits 0 but produced a DEFICIENT PDF -- and fails loud.

--- a/scripts/python/check_figure_media.py
+++ b/scripts/python/check_figure_media.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/check_figure_media.py
 # Purpose: Pre-compile FIGURE-MEDIA gate. A manuscript declares a figure by
 #          dropping a caption `.tex` file under

--- a/scripts/python/check_float_order.py
+++ b/scripts/python/check_float_order.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/check_float_order.py
 # Purpose: Validate and auto-renumber figure/table reference ordering in LaTeX manuscripts
 # Usage:

--- a/scripts/python/check_limits.py
+++ b/scripts/python/check_limits.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/check_limits.py
 # Purpose: Fast pre-compile validation of per-section word limits and the
 #          reference (citation) cap declared in config/config_<doctype>.yaml

--- a/scripts/python/check_media_provenance.py
+++ b/scripts/python/check_media_provenance.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/check_media_provenance.py
 # Purpose: Verify that media artifacts committed to a manuscript are SYMLINKS
 #          (and, in strict mode, that they resolve under the project's

--- a/scripts/python/check_overflow.py
+++ b/scripts/python/check_overflow.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/check_overflow.py
 # Purpose: Detect content that runs off the page -- wide tables/figures and
 #          over-tall pages -- by parsing the LaTeX .log for `Overfull \hbox`

--- a/scripts/python/check_paper_symlink.py
+++ b/scripts/python/check_paper_symlink.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/check_paper_symlink.py
 # Purpose: Detect (and optionally repair) drift in the top-level `paper`
 #          convenience symlink that should point at the canonical manuscript

--- a/scripts/python/check_ref_integrity.py
+++ b/scripts/python/check_ref_integrity.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/check_ref_integrity.py
 # Purpose: Pre-compile REFERENCE-INTEGRITY gate. Validate every reference class
 #          up front, report ALL problems at once (file:line), then exit non-zero

--- a/scripts/python/check_references.py
+++ b/scripts/python/check_references.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/check_references.py
 # Purpose: Validate all cross-references, citations, and labels in LaTeX manuscripts
 # Usage:

--- a/scripts/python/check_version_freshness.py
+++ b/scripts/python/check_version_freshness.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/check_version_freshness.py
 # Purpose: Pre-compile VERSION-FRESHNESS gate. Fails loud when the VENDORED
 #          engine tree is STALE relative to the installed scitex-writer.

--- a/scripts/python/compile_tex_structure.py
+++ b/scripts/python/compile_tex_structure.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-11-12 14:19:14 (ywatanabe)"
 
 r"""

--- a/scripts/python/crop_tif.py
+++ b/scripts/python/crop_tif.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 """
 TIF Image Cropping Utility
 

--- a/scripts/python/csv_to_latex.py
+++ b/scripts/python/csv_to_latex.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2024-09-28 18:20:00 (ywatanabe)"
 # File: csv_to_latex.py
 

--- a/scripts/python/explore_bibtex.py
+++ b/scripts/python/explore_bibtex.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/explore_bibtex.py
 # ----------------------------------------
 from __future__ import annotations

--- a/scripts/python/generate_ai2_prompt.py
+++ b/scripts/python/generate_ai2_prompt.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-11-12 12:57:38 (ywatanabe)"
 
 

--- a/scripts/python/manage_builds.py
+++ b/scripts/python/manage_builds.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/manage_builds.py
 # Purpose: List and inspect compiled-manuscript build IDs (writer #77).
 

--- a/scripts/python/manuscript_hints.py
+++ b/scripts/python/manuscript_hints.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/manuscript_hints.py
 # Purpose: Emit a structured MANUSCRIPT-HINTS feed (JSON) that the writer UI's
 #          Details pane renders as non-intrusive, Overleaf/OpenAI-style inline

--- a/scripts/python/merge_bibliographies.py
+++ b/scripts/python/merge_bibliographies.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-11-09 21:30:00 (ywatanabe)"
 # File: ./scripts/python/merge_bibliographies.py
 """

--- a/scripts/python/optimize_figure.py
+++ b/scripts/python/optimize_figure.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 """
 Automatic Figure Optimization for SciTex
 

--- a/scripts/python/png_to_jpg.py
+++ b/scripts/python/png_to_jpg.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/png_to_jpg.py
 # Purpose: Pillow-based PNG->JPG fallback for the figure pipeline, used when
 #          ImageMagick (magick/convert) is absent. Flattens alpha onto a white

--- a/scripts/python/pptx2tif.py
+++ b/scripts/python/pptx2tif.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/pptx2tif.py
 # ----------------------------------------
 import os

--- a/scripts/python/render_claims.py
+++ b/scripts/python/render_claims.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/render_claims.py
 # Purpose: Pre-compile generation step -- regenerate 00_shared/claims_rendered.tex
 #          from 00_shared/claims.json (the \vclaim value SSoT) before the

--- a/scripts/python/render_clew.py
+++ b/scripts/python/render_clew.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/render_clew.py
 # Purpose: Pre-compile generation step -- emit 00_shared/clew_rendered.tex from
 #          scitex-clew's runtime export (.scitex/clew/runtime/claims.json,

--- a/scripts/python/render_clew_toggles.py
+++ b/scripts/python/render_clew_toggles.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/render_clew_toggles.py
 # Purpose: Pre-compile step -- resolve the WRITER-side clew presentation opt-in
 #          from config/env and emit 00_shared/clew_presentation_toggles.tex,

--- a/scripts/python/tex_snippet2full.py
+++ b/scripts/python/tex_snippet2full.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: 2026-02-08
 # File: scripts/python/tex_snippet2full.py
 

--- a/scripts/python/tile_panels.py
+++ b/scripts/python/tile_panels.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/python/tile_panels.py
 # ----------------------------------------
 from __future__ import annotations

--- a/scripts/shell/check_project.sh
+++ b/scripts/shell/check_project.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: 2026-02-09
 # File: scripts/shell/check_project.sh
 # Purpose: Validate project structure, naming conventions, and references before compilation

--- a/scripts/shell/compile_content.sh
+++ b/scripts/shell/compile_content.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: 2026-02-08
 # File: scripts/shell/compile_content.sh
 

--- a/scripts/shell/compile_manuscript.sh
+++ b/scripts/shell/compile_manuscript.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-11-11 06:58:09 (ywatanabe)"
 # File: ./scripts/shell/compile_manuscript.sh
 

--- a/scripts/shell/compile_revision.sh
+++ b/scripts/shell/compile_revision.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-09-27 15:10:53 (ywatanabe)"
 # File: ./paper/scripts/shell/compile_revision
 

--- a/scripts/shell/compile_supplementary.sh
+++ b/scripts/shell/compile_supplementary.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-09-27 15:20:00 (ywatanabe)"
 # File: ./paper/scripts/shell/compile_supplementary.sh
 

--- a/scripts/shell/export_arxiv.sh
+++ b/scripts/shell/export_arxiv.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: 2026-02-10
 # File: scripts/shell/export_arxiv.sh
 # Purpose: Package manuscript as arXiv-ready tarball

--- a/scripts/shell/initialize_contents.sh
+++ b/scripts/shell/initialize_contents.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: 2026-02-09
 # File: scripts/shell/initialize_contents.sh
 # Purpose: Reset content files to clean template placeholders

--- a/scripts/shell/modules/add_diff_signature.sh
+++ b/scripts/shell/modules/add_diff_signature.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-11-12 (ywatanabe)"
 # File: ./scripts/shell/modules/add_diff_signature.sh
 # Description: Add metadata signature to diff TeX files

--- a/scripts/shell/modules/apply_citation_style.sh
+++ b/scripts/shell/modules/apply_citation_style.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-11-08 10:42:00 (ywatanabe)"
 # File: ./scripts/shell/modules/apply_citation_style.sh
 

--- a/scripts/shell/modules/check_crossrefs.sh
+++ b/scripts/shell/modules/check_crossrefs.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/shell/modules/check_crossrefs.sh
 # Purpose: Cross-reference validation for check_project.sh
 # Sourced by check_project.sh - requires log_pass, log_warn, log_detail functions

--- a/scripts/shell/modules/check_dependancy_commands.sh
+++ b/scripts/shell/modules/check_dependancy_commands.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-11-11 07:23:33 (ywatanabe)"
 # File: ./scripts/shell/modules/check_dependancy_commands.sh
 

--- a/scripts/shell/modules/check_spartan_login.sh
+++ b/scripts/shell/modules/check_spartan_login.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/shell/modules/check_spartan_login.sh
 #
 # Refuse to run the TeX toolchain on a Spartan HPC LOGIN node. Compiling

--- a/scripts/shell/modules/cleanup.sh
+++ b/scripts/shell/modules/cleanup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-09-27 16:35:00 (ywatanabe)"
 # File: ./paper/scripts/shell/modules/cleanup.sh
 

--- a/scripts/shell/modules/command_switching.src
+++ b/scripts/shell/modules/command_switching.src
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/shell/modules/command_switching.src
 # shellcheck disable=SC2034,SC2120,SC2155
 # SC2034 (THIS_DIR): exported for symmetry with other modules.

--- a/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
+++ b/scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-11-11 23:18:00 (ywatanabe)"
 # File: ./scripts/shell/modules/compilation_compiled_tex_to_compiled_pdf.sh
 # Main compilation orchestrator - delegates to engine-specific modules

--- a/scripts/shell/modules/compilation_structure_tex_to_compiled_tex.sh
+++ b/scripts/shell/modules/compilation_structure_tex_to_compiled_tex.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-09-26 18:00:21 (ywatanabe)"
 # File: ./paper/scripts/shell/modules/compilation_structure_tex_to_compiled_tex.sh
 

--- a/scripts/shell/modules/container_runtime.src
+++ b/scripts/shell/modules/container_runtime.src
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/shell/modules/container_runtime.src
 # shellcheck disable=SC2034,SC2155
 #

--- a/scripts/shell/modules/count_words.sh
+++ b/scripts/shell/modules/count_words.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-09-26 10:52:54 (ywatanabe)"
 # File: ./paper/scripts/shell/modules/count_words.sh
 

--- a/scripts/shell/modules/custom_tree.sh
+++ b/scripts/shell/modules/custom_tree.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-09-26 10:52:59 (ywatanabe)"
 # File: ./paper/scripts/shell/modules/custom_tree.sh
 

--- a/scripts/shell/modules/engines/compile_3pass.sh
+++ b/scripts/shell/modules/engines/compile_3pass.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-11-11 23:16:00 (ywatanabe)"
 # File: ./scripts/shell/modules/engines/compile_3pass.sh
 # 3-pass compilation engine (most compatible)

--- a/scripts/shell/modules/engines/compile_latexmk.sh
+++ b/scripts/shell/modules/engines/compile_latexmk.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-11-11 23:14:00 (ywatanabe)"
 # File: ./scripts/shell/modules/engines/compile_latexmk.sh
 # latexmk compilation engine with BIBINPUTS fix

--- a/scripts/shell/modules/engines/compile_tectonic.sh
+++ b/scripts/shell/modules/engines/compile_tectonic.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-11-11 23:12:00 (ywatanabe)"
 # File: ./scripts/shell/modules/engines/compile_tectonic.sh
 # Tectonic compilation engine

--- a/scripts/shell/modules/merge_bibliographies.sh
+++ b/scripts/shell/modules/merge_bibliographies.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-11-10 00:00:00 (ywatanabe)"
 # File: ./scripts/shell/modules/merge_bibliographies.sh
 

--- a/scripts/shell/modules/mmd2png_all.sh
+++ b/scripts/shell/modules/mmd2png_all.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-09-28 17:55:24 (ywatanabe)"
 # File: ./paper/scripts/shell/modules/mmd2png_all.sh
 

--- a/scripts/shell/modules/png2tif_all.sh
+++ b/scripts/shell/modules/png2tif_all.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-09-27 00:29:33 (ywatanabe)"
 # File: ./paper/scripts/shell/modules/png2tif_all.sh
 

--- a/scripts/shell/modules/pptx2tif_all.sh
+++ b/scripts/shell/modules/pptx2tif_all.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-09-27 00:15:04 (ywatanabe)"
 # File: ./paper/scripts/shell/modules/pptx2tif_all.sh
 

--- a/scripts/shell/modules/pptx2tif_single.sh
+++ b/scripts/shell/modules/pptx2tif_single.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-09-26 10:53:55 (ywatanabe)"
 # File: ./paper/scripts/shell/modules/pptx2tif_single.sh
 

--- a/scripts/shell/modules/process_archive.sh
+++ b/scripts/shell/modules/process_archive.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2026-01-19 (ywatanabe)"
 # File: ./scripts/shell/modules/process_archive.sh
 # Description: Archive compiled documents with git-based naming (timestamp + commit hash)

--- a/scripts/shell/modules/process_diff.sh
+++ b/scripts/shell/modules/process_diff.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2026-01-19 (ywatanabe)"
 # File: ./scripts/shell/modules/process_diff.sh
 # Description: Generate diff between current and previous git commit (or arbitrary commits)

--- a/scripts/shell/modules/process_figures.sh
+++ b/scripts/shell/modules/process_figures.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "$(date +"%Y-%m-%d %H:%M:%S") ($(whoami))"
 # File: process_figures.sh
 # Refactored modular version of process_figures.sh

--- a/scripts/shell/modules/process_figures_modules/00_common.src
+++ b/scripts/shell/modules/process_figures_modules/00_common.src
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: process_figures_modules/00_common.sh
 # Common utilities and initialization for figure processing
 

--- a/scripts/shell/modules/process_figures_modules/01_caption_management.src
+++ b/scripts/shell/modules/process_figures_modules/01_caption_management.src
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: process_figures_modules/01_caption_management.sh
 # Caption file management for figures
 

--- a/scripts/shell/modules/process_figures_modules/02_format_conversion.src
+++ b/scripts/shell/modules/process_figures_modules/02_format_conversion.src
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: process_figures_modules/02_format_conversion.sh
 # Format conversion functions for figures
 

--- a/scripts/shell/modules/process_figures_modules/03_panel_tiling.src
+++ b/scripts/shell/modules/process_figures_modules/03_panel_tiling.src
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: process_figures_modules/03_panel_tiling.sh
 # Panel tiling functions for multi-panel figures
 

--- a/scripts/shell/modules/process_figures_modules/04_compilation.src
+++ b/scripts/shell/modules/process_figures_modules/04_compilation.src
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: process_figures_modules/04_compilation.src
 # Figure compilation and final assembly functions
 

--- a/scripts/shell/modules/process_tables.sh
+++ b/scripts/shell/modules/process_tables.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2026-01-19 02:59:33 (ywatanabe)"
 # File: ./scripts/shell/modules/process_tables.sh
 

--- a/scripts/shell/modules/process_tables_modules/03_csv2tex.src
+++ b/scripts/shell/modules/process_tables_modules/03_csv2tex.src
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: process_tables_modules/03_csv2tex.src
 # CSV -> LaTeX table generation (csv2tex + fallbacks). Sourced by
 # process_tables.sh. Extracted verbatim (no logic change) to keep the

--- a/scripts/shell/modules/process_tables_modules/04_gather.src
+++ b/scripts/shell/modules/process_tables_modules/04_gather.src
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: process_tables_modules/04_gather.src
 # Table gathering / final-assembly functions (create_table_header +
 # gather_table_tex_files). Sourced by process_tables.sh. Extracted so the

--- a/scripts/shell/modules/render_claims.sh
+++ b/scripts/shell/modules/render_claims.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/shell/modules/render_claims.sh
 #
 # Regenerate 00_shared/claims_rendered.tex from 00_shared/claims.json (the

--- a/scripts/shell/modules/render_clew.sh
+++ b/scripts/shell/modules/render_clew.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/shell/modules/render_clew.sh
 #
 # Prepare the clew presentation-layer inputs before the manuscript is flattened:

--- a/scripts/shell/modules/run_compile_verification.sh
+++ b/scripts/shell/modules/run_compile_verification.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/shell/modules/run_compile_verification.sh
 #
 # POST-compile verification gate. Runs scripts/python/check_compile_artifacts.py

--- a/scripts/shell/modules/run_provenance_checks.sh
+++ b/scripts/shell/modules/run_provenance_checks.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/shell/modules/run_provenance_checks.sh
 #
 # Run the config-driven pre-compile checks at their RESOLVED severity

--- a/scripts/shell/modules/select_compilation_engine.sh
+++ b/scripts/shell/modules/select_compilation_engine.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-11-11 23:10:00 (ywatanabe)"
 # File: ./scripts/shell/modules/select_compilation_engine.sh
 # Select and verify compilation engine

--- a/scripts/shell/modules/utils/_clear_archive.sh
+++ b/scripts/shell/modules/utils/_clear_archive.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 
 echo -e "$0 ..."
 

--- a/scripts/shell/modules/utils/_load_files_list.sh
+++ b/scripts/shell/modules/utils/_load_files_list.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-05-06 12:58:17 (ywatanabe)"
 # File: ./manuscript/scripts/shell/modules/load_files_list.sh
 

--- a/scripts/shell/modules/utils/open_pdf_or_exit.sh
+++ b/scripts/shell/modules/utils/open_pdf_or_exit.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 
 echo -e "$0 ..."
 

--- a/scripts/shell/modules/utils/rename_archive_diff_files.sh
+++ b/scripts/shell/modules/utils/rename_archive_diff_files.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2025-09-26 23:30:00 (ywatanabe)"
 # File: ./paper/scripts/shell/modules/utils/rename_archive_diff_files.sh
 # Description: One-time script to rename existing diff files from manuscript_diff_vXXX to manuscript_vXXX_diff

--- a/scripts/shell/modules/validate_tex.src
+++ b/scripts/shell/modules/validate_tex.src
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # File: scripts/shell/modules/validate_tex.src
 # shellcheck disable=SC2034  # THIS_DIR exported for parity with other modules
 

--- a/scripts/shell/modules/yq_wrapper.sh
+++ b/scripts/shell/modules/yq_wrapper.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Universal yq wrapper - handles both Python and Go versions
 # Provides consistent interface regardless of which yq is installed
 

--- a/scripts/shell/restore_contents.sh
+++ b/scripts/shell/restore_contents.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: 2026-02-09
 # File: scripts/shell/restore_contents.sh
 # Purpose: Restore content files from a snapshot created by initialize_contents.sh

--- a/scripts/shell/watch_compile.sh
+++ b/scripts/shell/watch_compile.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "$(date '+%Y-%m-%d %H:%M:%S') ($(whoami))"
 # File: ./paper/scripts/shell/watch_compile.sh
 

--- a/src/scitex_writer/_mcp/handlers/_update/_handler.py
+++ b/src/scitex_writer/_mcp/handlers/_update/_handler.py
@@ -221,6 +221,12 @@ def _apply_updates(
         src = source_files[rel]
         dst = project_path / rel
         dst.parent.mkdir(parents=True, exist_ok=True)
+        if dst.exists():
+            # A previous vendor may have set this engine file read-only
+            # (see _set_engine_readonly). Restore the write bit before
+            # overwriting so a re-vendor never fails on the second run --
+            # this is what keeps update-project idempotent.
+            dst.chmod(dst.stat().st_mode | 0o200)
         shutil.copy2(src, dst)
 
     # Ensure compile.sh is executable
@@ -234,7 +240,39 @@ def _apply_updates(
         for script in scripts_dir.rglob("*.sh"):
             script.chmod(script.stat().st_mode | 0o111)
 
+    # Make the freshly-vendored engine files read-only in the consumer
+    # workspace so an accidental local edit fails loudly instead of being
+    # silently lost on the next re-vendor. Done LAST so it sees the final
+    # (post +x) mode bits. PRESERVED_PATHS (consumer-owned) files are never
+    # in the sync set, so they are untouched and stay writable.
+    _set_engine_readonly(project_path, modified + added)
+
     return backup_dir
+
+
+def _set_engine_readonly(project_path: Path, written_rels: list[str]) -> None:
+    """Set freshly-vendored engine files read-only in the CONSUMER workspace.
+
+    Engine-vendored files are overwritten by every re-vendor, so a local edit
+    is always lost -- worse, it silently masks the need to fix the file
+    upstream in scitex-writer (the band-aid class of bug this guards against).
+    Marking them read-only (r-x for executables, r-- otherwise) turns an
+    accidental edit into an immediate, visible permission error, forcing the
+    fix upstream. update-project clears the write bit again before re-writing
+    (see _apply_updates), so this stays idempotent across repeated runs. Git
+    only tracks the +x bit, so these perms live only in the consumer
+    workspace, never in a commit. Best-effort: a chmod failure never aborts a
+    vendor.
+    """
+    for rel in written_rels:
+        dst = project_path / rel
+        if not dst.is_file():
+            continue
+        try:
+            executable = bool(dst.stat().st_mode & 0o111)
+            dst.chmod(0o555 if executable else 0o444)
+        except OSError:
+            pass
 
 
 def _build_message(

--- a/tests/scitex_writer/_mcp/handlers/_update/test__handler_readonly.py
+++ b/tests/scitex_writer/_mcp/handlers/_update/test__handler_readonly.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: _update/_handler.py — read-only perms on vendored engine files
+
+from scitex_writer._mcp.handlers._update._handler import (
+    _apply_updates,
+    _set_engine_readonly,
+)
+
+
+def test_set_engine_readonly_clears_write_bit(tmp_path):
+    # Arrange
+    target = tmp_path / "scripts" / "python" / "csv_to_latex.py"
+    target.parent.mkdir(parents=True)
+    target.write_text("print('hi')\n")
+    target.chmod(0o644)
+    # Act
+    _set_engine_readonly(tmp_path, ["scripts/python/csv_to_latex.py"])
+    # Assert
+    assert not (target.stat().st_mode & 0o222)
+
+
+def test_set_engine_readonly_keeps_execute_bit(tmp_path):
+    # Arrange
+    target = tmp_path / "scripts" / "shell" / "compile_core.sh"
+    target.parent.mkdir(parents=True)
+    target.write_text("echo hi\n")
+    target.chmod(0o755)
+    # Act
+    _set_engine_readonly(tmp_path, ["scripts/shell/compile_core.sh"])
+    # Assert
+    assert target.stat().st_mode & 0o111
+
+
+def test_apply_updates_leaves_written_engine_file_read_only(tmp_path):
+    # Arrange
+    project = tmp_path / "project"
+    project.mkdir()
+    src = tmp_path / "template" / "Makefile"
+    src.parent.mkdir(parents=True)
+    src.write_text("all:\n")
+    # Act
+    _apply_updates(project, {"Makefile": src}, modified=[], added=["Makefile"])
+    # Assert
+    assert not ((project / "Makefile").stat().st_mode & 0o222)
+
+
+def test_apply_updates_is_idempotent_over_read_only_target(tmp_path):
+    # A second vendor must not fail on the now-read-only file it wrote before.
+    # Arrange
+    project = tmp_path / "project"
+    project.mkdir()
+    src = tmp_path / "template" / "Makefile"
+    src.parent.mkdir(parents=True)
+    src.write_text("all:\n")
+    _apply_updates(project, {"Makefile": src}, modified=[], added=["Makefile"])
+    src.write_text("all:\n\techo v2\n")
+    # Act
+    _apply_updates(project, {"Makefile": src}, modified=["Makefile"], added=[])
+    # Assert
+    assert (project / "Makefile").read_text() == "all:\n\techo v2\n"


### PR DESCRIPTION
Makes scitex-writer's vendored/engine file tree self-documenting so consuming projects/agents navigate it correctly and can't accidentally band-aid an engine-vendored file instead of fixing it upstream (root-cause fix for the neurovista-style interim-edit class of bug). Card: `writer-vendored-tree-self-documenting` (PR-B, pairs with #181).

Roles are taken from the authoritative update-project role map in `src/scitex_writer/_mcp/handlers/_update/_constants.py` (SYNC_DIRS / SYNC_FILES / LEGACY_ENGINE_PATHS / PRESERVED_PATHS), so the markers + perms match actual sync behavior.

## 1. ROLE hint-comments (additive, low risk)
Top-of-file role marker on 121 engine/vendored files, comment syntax per file type (`#` / `%%`), matching the #181 marker style:
- **engine-vendored** (DO NOT edit here; overwritten on every re-vendor): `scripts/**`, `compile.sh`, `Makefile`, `01/02/03_*/base.tex`, `00_shared/latex_styles/*.tex`.
- **consumer-owned** (safe to edit; preserved on re-vendor): `00_shared/keywords.tex`, `journal_name.tex`, `bib_files/bibliography.bib` (PRESERVED_PATHS).
- `title.tex` / `authors.tex` already carry SSoT markers from #181.
- Placement is after any shebang + coding line; idempotent (a second pass is a no-op — sentinel-guarded).
- Not marked: `README.md` docs (rendering noise) and `claims.json` (JSON has no comment syntax) — noted as a follow-up limitation.

## 2. Read-only perms (behavior change, idempotent)
`update_project` now chmods freshly-vendored engine files read-only in the **consumer** workspace after sync (`0555` for executables, `0444` otherwise) via `_set_engine_readonly`, so an accidental local edit fails loudly instead of being silently lost on the next re-vendor. Before re-writing on the next sync, `_apply_updates` restores the write bit, so update-project stays idempotent and never fails on a second run. PRESERVED_PATHS (consumer-owned) files are never in the sync set, so they stay writable. Git only tracks the `+x` bit, so these perms live only in the consumer workspace — never committed.

## Tests
4 no-mock tests (tmp workspace, one-assert-per-test): write-bit cleared, execute-bit preserved, apply-updates leaves engine file read-only, idempotency over a read-only target. All 16 update-handler tests pass.

## Audit
`scitex-dev ecosystem audit-all scitex-writer`: `audit-project` (PS-204/PS-140) and `audit-python-apis` PASS. Remaining failures are pre-existing and unrelated: `audit-cli` §6a env-var naming (`WRITER_DJANGO_SECRET`/`WRITER_WORKING_DIR`, untouched here) and an `audit-mcp-tools` crash on a stale installed-package `ModuleNotFoundError: scitex_writer._dataclasses.config`.