### PR TITLE
feat(figures): footnote-in-caption via \captionfootnote marker

### DIFF
--- a/scripts/python/caption_footnote_split.py
+++ b/scripts/python/caption_footnote_split.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: scripts/python/caption_footnote_split.py
+# Purpose: Turn an author-declared \captionfootnote{...} marker inside a figure
+#          caption body into the blessed footnote-in-caption LaTeX split.
+#
+#          A \footnote inside a float (figure*/table*) does NOT render -- the
+#          caption argument is reprocessed and the footnote is lost/fatal. The
+#          blessed pattern is:
+#
+#              \caption[short]{long\protect\footnotemark}   % inside the float
+#              \footnotetext{...}                            % AFTER \end{figure*}
+#
+#          So an author writes their caption body with an inline marker:
+#
+#              \caption{\textbf{Title}\\ Legend text.\captionfootnote{Disclosure.}}
+#
+#          and the figure float-wrapper (process_figures_modules/04_compilation.src)
+#          feeds the caption body through this helper. This helper:
+#            - rewrites the FIRST \captionfootnote{...} to \protect\footnotemark
+#              (brace-matched, so nested braces inside the disclosure are kept), and
+#            - reports the extracted disclosure text so the caller can emit
+#              \footnotetext{...} immediately after the float closes.
+#
+#          No marker -> the caption body is returned byte-for-byte unchanged and
+#          no footnote text is reported, so a default manuscript is unaffected.
+#
+#          \captionfootnote is a COMPILE-TIME marker only: it is stripped here and
+#          never reaches LaTeX, so no preamble macro definition is required.
+#
+# Usage (from the shell assembler):
+#   printf '%s' "$caption_body" | \
+#     python3 caption_footnote_split.py --footnote-out /path/to/footnote.txt
+#   # stdout = transformed caption body
+#   # footnote.txt = disclosure text (only written when a marker was found)
+#
+# Self-contained: stdlib only.
+
+import argparse
+import sys
+from pathlib import Path
+
+_MARKER = r"\captionfootnote"
+_REPLACEMENT = r"\protect\footnotemark"
+
+
+def split_caption_footnote(text):
+    r"""Split a caption body into (transformed_caption, footnote_text).
+
+    Finds the FIRST ``\captionfootnote{...}`` marker (brace-matched, honoring
+    escaped braces), replaces it in place with ``\protect\footnotemark``, and
+    returns the extracted inner text (stripped). When no valid marker is present
+    the input is returned unchanged and ``footnote_text`` is ``None``.
+    """
+    idx = text.find(_MARKER)
+    if idx == -1:
+        return text, None
+
+    i = idx + len(_MARKER)
+    n = len(text)
+    # Allow whitespace between the marker and its brace.
+    while i < n and text[i] in " \t\r\n":
+        i += 1
+    if i >= n or text[i] != "{":
+        # Not a well-formed \captionfootnote{...} call -- leave untouched.
+        return text, None
+
+    start = i + 1
+    depth = 1
+    j = start
+    while j < n and depth:
+        ch = text[j]
+        if ch == "\\":
+            j += 2  # skip an escaped char (incl. \{ \} \\)
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                break
+        j += 1
+    if depth != 0:
+        # Unbalanced braces -- leave untouched rather than corrupt the caption.
+        return text, None
+
+    footnote = text[start:j]
+    transformed = text[:idx] + _REPLACEMENT + text[j + 1 :]
+    return transformed, footnote.strip()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Rewrite a \\captionfootnote{...} marker in a caption body to "
+        "\\protect\\footnotemark and report the disclosure text."
+    )
+    parser.add_argument(
+        "--footnote-out",
+        help="Path to write the extracted footnote text (only written when a "
+        "marker is found).",
+    )
+    args = parser.parse_args()
+
+    text = sys.stdin.read()
+    transformed, footnote = split_caption_footnote(text)
+
+    sys.stdout.write(transformed)
+
+    if args.footnote_out and footnote:
+        Path(args.footnote_out).write_text(footnote, encoding="utf-8")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/shell/modules/process_figures_modules/04_compilation.src
+++ b/scripts/shell/modules/process_figures_modules/04_compilation.src
@@ -91,6 +91,29 @@ compile_figure_tex_files() {
             caption_content="\\caption{\\textbf{Figure $figure_number}\\\\Description for figure $figure_number.}"
         fi
 
+        # Footnote-in-caption support: an author may declare a caption-level
+        # footnote with \captionfootnote{...} inside the caption body. A
+        # \footnote inside a float does NOT render; the blessed split is
+        # \caption{...\protect\footnotemark} + \footnotetext{...} AFTER the
+        # float. The helper rewrites the marker to \protect\footnotemark in the
+        # caption and reports the disclosure text, which we emit as
+        # \footnotetext right after \end{figure*} below. No marker present ->
+        # caption_content is byte-for-byte unchanged (default compiles unaffected).
+        local caption_footnote_text=""
+        if printf '%s' "$caption_content" | grep -q '\\captionfootnote'; then
+            local _cf_dir
+            _cf_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+            local _cf_helper="$_cf_dir/../../../python/caption_footnote_split.py"
+            if [ -f "$_cf_helper" ] && command -v python3 >/dev/null 2>&1; then
+                local _cf_out
+                _cf_out="$(mktemp)"
+                caption_content=$(printf '%s' "$caption_content" |
+                    python3 "$_cf_helper" --footnote-out "$_cf_out")
+                [ -s "$_cf_out" ] && caption_footnote_text="$(cat "$_cf_out")"
+                rm -f "$_cf_out"
+            fi
+        fi
+
         # Determine image path (use figure_path_base for tectonic compatibility)
         image_path="$figure_path_base/${figure_id}.jpg"
         if [ ! -f "$image_path" ]; then
@@ -125,6 +148,11 @@ compile_figure_tex_files() {
             echo "    $caption_content"
             [ -n "$_label_line" ] && echo "$_label_line"
             echo "\\end{figure*}"
+            # Emit the caption-declared footnote AFTER the float closes (a
+            # \footnote inside a float does not render). Kept in the placeable
+            # file so it travels with the float in BOTH placement modes (inline
+            # \scitexfig{<n>} and the guarded end-of-document block).
+            [ -n "$caption_footnote_text" ] && echo "\\footnotetext{$caption_footnote_text}"
         } >"$placeable_file"
 
         # Emit into FINAL, guarded: render here only if NOT already placed

--- a/tests/scripts/python/test_caption_footnote_split.py
+++ b/tests/scripts/python/test_caption_footnote_split.py
@@ -1,0 +1,75 @@
+"""split_caption_footnote rewrites \\captionfootnote{...} to \\protect\\footnotemark."""
+
+import importlib.util
+from pathlib import Path
+
+_HELPER = (
+    Path(__file__).resolve().parents[3] / "scripts/python/caption_footnote_split.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("caption_footnote_split", _HELPER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_marker_replaced_with_footnotemark():
+    # Arrange
+    mod = _load()
+    caption = "\\caption{\\textbf{T}\\\\ Legend.\\captionfootnote{Disclosure.}}"
+    # Act
+    transformed, _ = mod.split_caption_footnote(caption)
+    # Assert
+    assert "\\protect\\footnotemark" in transformed
+
+
+def test_marker_removed_from_caption():
+    # Arrange
+    mod = _load()
+    caption = "\\caption{\\textbf{T}\\\\ Legend.\\captionfootnote{Disclosure.}}"
+    # Act
+    transformed, _ = mod.split_caption_footnote(caption)
+    # Assert
+    assert "\\captionfootnote" not in transformed
+
+
+def test_footnote_text_extracted():
+    # Arrange
+    mod = _load()
+    caption = "\\caption{\\textbf{T}\\\\ Legend.\\captionfootnote{Disclosure.}}"
+    # Act
+    _, footnote = mod.split_caption_footnote(caption)
+    # Assert
+    assert footnote == "Disclosure."
+
+
+def test_nested_braces_in_footnote_preserved():
+    # Arrange
+    mod = _load()
+    caption = "\\caption{Legend.\\captionfootnote{See \\textbf{ref} for detail.}}"
+    # Act
+    _, footnote = mod.split_caption_footnote(caption)
+    # Assert
+    assert footnote == "See \\textbf{ref} for detail."
+
+
+def test_no_marker_returns_input_unchanged():
+    # Arrange
+    mod = _load()
+    caption = "\\caption{\\textbf{T}\\\\ Plain legend with no footnote.}"
+    # Act
+    transformed, _ = mod.split_caption_footnote(caption)
+    # Assert
+    assert transformed == caption
+
+
+def test_no_marker_reports_no_footnote():
+    # Arrange
+    mod = _load()
+    caption = "\\caption{\\textbf{T}\\\\ Plain legend with no footnote.}"
+    # Act
+    _, footnote = mod.split_caption_footnote(caption)
+    # Assert
+    assert footnote is None

--- a/tests/scripts/shell/modules/test_caption_footnote_in_caption.py
+++ b/tests/scripts/shell/modules/test_caption_footnote_in_caption.py
@@ -1,0 +1,61 @@
+"""compile_figure_tex_files renders a \\captionfootnote{...} as footnote-in-caption."""
+
+import subprocess
+from pathlib import Path
+
+_MODULES = (
+    Path(__file__).resolve().parents[4]
+    / "scripts/shell/modules/process_figures_modules"
+)
+
+_WITH_FOOTNOTE = "\\caption{\\textbf{T}\\\\ desc.\\captionfootnote{Note me.}}"
+_PLAIN = "\\caption{\\textbf{T}\\\\ plain desc.}"
+
+
+def _run_assembler(tmp_path, caption_body):
+    compiled = tmp_path / "compiled"
+    cam = tmp_path / "cam"
+    jpg = cam / "jpg_for_compilation"
+    for d in (compiled, cam, jpg):
+        d.mkdir(parents=True)
+    (compiled / "01_Test.tex").write_text("% fig\n")
+    (cam / "01_Test.tex").write_text(caption_body + "\n")
+    (jpg / "01_Test.jpg").write_bytes(b"\xff\xd8\xff\xe0")
+    script = (
+        f'export SCITEX_WRITER_FIGURE_COMPILED_DIR="{compiled}";'
+        f'export SCITEX_WRITER_FIGURE_COMPILED_FILE="{compiled}/FINAL.tex";'
+        f'export SCITEX_WRITER_FIGURE_CAPTION_MEDIA_DIR="{cam}";'
+        f'export SCITEX_WRITER_FIGURE_JPG_DIR="{jpg}";'
+        f"source '{_MODULES}/00_common.src';"
+        f"source '{_MODULES}/04_compilation.src';"
+        f"compile_figure_tex_files"
+    )
+    subprocess.run(["bash", "-c", script], capture_output=True, text=True, check=True)
+    return (compiled / "_placeable" / "01.tex").read_text()
+
+
+def test_declared_footnote_becomes_footnotemark_in_caption(tmp_path):
+    # Arrange
+    caption = _WITH_FOOTNOTE
+    # Act
+    placeable = _run_assembler(tmp_path, caption)
+    # Assert
+    assert "\\footnotemark" in placeable
+
+
+def test_declared_footnote_emits_footnotetext_after_float_close(tmp_path):
+    # Arrange
+    caption = _WITH_FOOTNOTE
+    # Act
+    placeable = _run_assembler(tmp_path, caption)
+    # Assert
+    assert "\\footnotetext{Note me.}" in placeable.split("\\end{figure*}", 1)[1]
+
+
+def test_no_declared_footnote_leaves_placeable_without_footnotetext(tmp_path):
+    # Arrange
+    caption = _PLAIN
+    # Act
+    placeable = _run_assembler(tmp_path, caption)
+    # Assert
+    assert "\\footnotetext" not in placeable


### PR DESCRIPTION
## Summary

Adds first-class support for a **footnote-in-caption** in figures. A `\footnote` placed inside a float (`figure*`) does not render — the caption argument is reprocessed and the footnote is lost/fatal. The blessed LaTeX split is `\caption{...\protect\footnotemark}` inside the float + `\footnotetext{...}` emitted **after** `\end{figure*}`.

Authors can now declare a caption-level footnote with a `\captionfootnote{...}` marker inside the caption body:

```latex
\caption{\textbf{Title}\\ Legend text.\captionfootnote{Disclosure text.}}
```

The figure float-wrapper rewrites the marker to `\protect\footnotemark` in the caption and emits `\footnotetext{Disclosure text.}` right after the float closes.

## Design (KISS)

- `\captionfootnote` is a **compile-time marker only** — stripped before LaTeX sees it, so **no preamble macro** is required.
- New stdlib helper `scripts/python/caption_footnote_split.py` does the brace-matched transform (nested braces in the disclosure preserved).
- `process_figures_modules/04_compilation.src` invokes the helper **only when the marker is present**, so default captions are **byte-for-byte unchanged** (default compiles unaffected).
- `\footnotetext` is written into the per-figure `_placeable` file after `\end{figure*}`, so it travels with the float in **both** placement modes (inline `\scitexfig{<n>}` and the guarded end-of-document block).

## Scope

Figures only. Tables are CSV-driven with a different caption path (`process_tables_modules/03_csv2tex.src`) and would be a separate, larger change — noted as a follow-up. This matches the card's low-priority / KISS mandate (neurovista's use case was figures 03 & 05).

## Tests (real inputs, no mocks)

- `tests/scripts/python/test_caption_footnote_split.py` — helper unit tests (marker → footnotemark, text extracted, nested braces preserved, no-marker no-op).
- `tests/scripts/shell/modules/test_caption_footnote_in_caption.py` — end-to-end: declared footnote → `\footnotemark` in caption + `\footnotetext` after float close; no marker → placeable has no `\footnotetext`.

All 9 new tests pass; existing `test_inline_figure_placement.py` + `test_check_caption_footnote.py` (17 tests) still green.

Refs card `writer-footnote-in-caption-helper`.