### PR TITLE
feat(compile): combined 'all'/-a target for supplement↔main cross-ref ordering

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -74,6 +74,9 @@ DOCUMENT TYPES:
     manuscript, -m        Compile manuscript (= ./scripts/shell/compile_manuscript.sh)
     supplementary, -s     Compile supplementary (= ./scripts/shell/compile_supplementary.sh)
     revision, -r          Compile revision (= ./scripts/shell/compile_revision.sh)
+    all, -a               Compile supplement THEN manuscript in dependency order
+                          so main->supplement cross-refs (xr-hyper) resolve in a
+                          single invocation (supplement .aux is produced first).
 
 BUILD INSPECTION:
     builds [-n N]         List recent build IDs embedded in PDFs
@@ -107,11 +110,19 @@ EXAMPLES:
     ./compile.sh manuscript                # Explicitly compile manuscript
     ./compile.sh supplementary             # Compile supplementary materials
     ./compile.sh revision                  # Compile revision responses
+    ./compile.sh all                       # Supplement then manuscript (xr-hyper)
 
     Short forms:
     ./compile.sh -m                        # Compile manuscript
     ./compile.sh -s                        # Compile supplementary
     ./compile.sh -r                        # Compile revision
+    ./compile.sh -a                        # Supplement then manuscript
+
+    Cross-references (main <-> supplement):
+    ./compile.sh all                       # One-shot: resolves \ref into the
+                                           # supplement without a manual -s then -m.
+                                           # Speed flags pass through to both, e.g.:
+    ./compile.sh all --no-diff             # Combined build, skip diff on both
 
     Speed options:
     ./compile.sh -m --no-figs --no-diff    # Fast manuscript (~12s)
@@ -182,6 +193,12 @@ while [ $# -gt 0 ]; do
         DOC_TYPE="revision"
         shift
         ;;
+    all | -a)
+        # Combined target: compile supplement then manuscript in dependency
+        # order so main->supplement cross-refs (xr-hyper) resolve in one call.
+        DOC_TYPE="all"
+        shift
+        ;;
     builds)
         # Inspect the build registry (#77). Delegates to manage_builds.py.
         shift
@@ -221,7 +238,7 @@ while [ $# -gt 0 ]; do
         # Collect remaining arguments
         if [ -z "$DOC_TYPE" ]; then
             echo "ERROR: Unknown document type '$1'"
-            echo "Valid types: manuscript, supplementary, revision"
+            echo "Valid types: manuscript, supplementary, revision, all"
             echo "Use './compile --help' for usage information"
             exit 1
         else
@@ -276,6 +293,24 @@ supplementary)
     ;;
 revision)
     "$PROJECT_ROOT/scripts/shell/compile_revision.sh" ${REMAINING_ARGS:+$REMAINING_ARGS}
+    ;;
+all)
+    # Dependency-ordered combined build for cross-references.
+    #
+    # 1. Supplement FIRST: its compile ends by exposing supplementary.aux at
+    #    doc-root (./02_supplementary/supplementary.aux) — the target that the
+    #    manuscript's xr-hyper \externaldocument/\link reads.
+    # 2. Manuscript SECOND: with the supplement .aux now present, main->supplement
+    #    \ref/\pageref resolve instead of printing "??".
+    #
+    # This replaces the manual "compile.sh -s && compile.sh -m" dance. Reverse
+    # refs (supplement->main) additionally require the manuscript to expose its
+    # own .aux at doc-root; that is a separate follow-up (pairs with
+    # writer-supp-aux-docroot) and would add a third supplement pass here.
+    echo -e "${CYAN}[all] Step 1/2: supplement (produces supplementary.aux)${NC}"
+    "$PROJECT_ROOT/scripts/shell/compile_supplementary.sh" ${REMAINING_ARGS:+$REMAINING_ARGS} || exit $?
+    echo -e "${CYAN}[all] Step 2/2: manuscript (resolves cross-refs into supplement)${NC}"
+    "$PROJECT_ROOT/scripts/shell/compile_manuscript.sh" ${REMAINING_ARGS:+$REMAINING_ARGS}
     ;;
 *)
     echo "Error: Unknown document type: $DOC_TYPE"

--- a/tests/scripts/shell/test_compile_dispatch.py
+++ b/tests/scripts/shell/test_compile_dispatch.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scripts/shell/test_compile_dispatch.py
+
+"""Dispatch/ordering tests for the top-level ``compile.sh`` wrapper.
+
+These exercise the REAL ``compile.sh`` (the code under test) inside a
+throw-away sandbox project. The heavy per-document compile scripts it
+delegates to (``compile_manuscript.sh`` / ``compile_supplementary.sh`` /
+``compile_revision.sh``) are replaced with tiny recorder scripts that only
+append their name to an order file. These recorders are genuine executables
+standing in for external programs the wrapper shells out to — NOT mocks of
+any internal code path — so the dispatch/ordering logic is observed exactly
+as it runs in production, without needing a real (unavailable in-container)
+LaTeX toolchain.
+
+The combined ``all`` target must compile the supplement FIRST (so its
+``.aux`` exists) and the manuscript SECOND, so that main->supplement
+xr-hyper cross-references resolve in a single invocation. Single targets
+(``-m`` / ``-s`` / ``-r``) must be unchanged: exactly one delegate runs.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+RECORDER = '#!/bin/bash\necho {name} >> "$PROJECT_ROOT/order.log"\nexit 0\n'
+
+
+def _find_repo_root() -> Path:
+    p = Path(__file__).resolve()
+    for parent in [p, *p.parents]:
+        if (parent / "pyproject.toml").is_file() and (parent / "compile.sh").is_file():
+            return parent
+    raise RuntimeError(f"Could not find repo root from {__file__}")
+
+
+@pytest.fixture
+def sandbox(tmp_path):
+    """A minimal project whose delegate scripts only record their name."""
+    root = _find_repo_root()
+    # Real wrapper under test.
+    (tmp_path / "compile.sh").write_bytes((root / "compile.sh").read_bytes())
+    (tmp_path / "compile.sh").chmod(0o755)
+    # Recorder stand-ins for the heavy per-document compile scripts.
+    shell_dir = tmp_path / "scripts" / "shell"
+    shell_dir.mkdir(parents=True)
+    for name in ("manuscript", "supplementary", "revision"):
+        script = shell_dir / f"compile_{name}.sh"
+        script.write_text(RECORDER.format(name=name))
+        script.chmod(0o755)
+    return tmp_path
+
+
+def _run(sandbox: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(sandbox / "compile.sh"), *args],
+        cwd=str(sandbox),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _order(sandbox: Path) -> list[str]:
+    log = sandbox / "order.log"
+    if not log.is_file():
+        return []
+    return [ln for ln in log.read_text().splitlines() if ln]
+
+
+def test_all_runs_supplement_before_manuscript(sandbox):
+    # Arrange
+    target = "all"
+    # Act
+    _run(sandbox, target)
+    # Assert
+    assert _order(sandbox) == ["supplementary", "manuscript"]
+
+
+def test_all_short_flag_runs_supplement_before_manuscript(sandbox):
+    # Arrange
+    target = "-a"
+    # Act
+    _run(sandbox, target)
+    # Assert
+    assert _order(sandbox) == ["supplementary", "manuscript"]
+
+
+def test_all_does_not_run_revision(sandbox):
+    # Arrange
+    target = "all"
+    # Act
+    _run(sandbox, target)
+    # Assert
+    assert "revision" not in _order(sandbox)
+
+
+def test_manuscript_single_target_runs_only_manuscript(sandbox):
+    # Arrange
+    target = "-m"
+    # Act
+    _run(sandbox, target)
+    # Assert
+    assert _order(sandbox) == ["manuscript"]
+
+
+def test_supplementary_single_target_runs_only_supplementary(sandbox):
+    # Arrange
+    target = "-s"
+    # Act
+    _run(sandbox, target)
+    # Assert
+    assert _order(sandbox) == ["supplementary"]
+
+
+def test_revision_single_target_runs_only_revision(sandbox):
+    # Arrange
+    target = "-r"
+    # Act
+    _run(sandbox, target)
+    # Assert
+    assert _order(sandbox) == ["revision"]
+
+
+def test_default_no_args_runs_only_manuscript(sandbox):
+    # Arrange
+    no_args = ()
+    # Act
+    _run(sandbox, *no_args)
+    # Assert
+    assert _order(sandbox) == ["manuscript"]
+
+
+def test_all_help_lists_combined_target(sandbox):
+    # Arrange
+    flag = "--help"
+    # Act
+    result = _run(sandbox, flag)
+    # Assert
+    assert "all, -a" in result.stdout
+
+
+# EOF


### PR DESCRIPTION
## Summary

Adds a combined compile target to `compile.sh` so supplement↔main
cross-references (xr-hyper) resolve in a **single** invocation, replacing the
manual `compile.sh -s && compile.sh -m` dance.

- New target: **`all`** (short form **`-a`**)
- Ordering: **supplement first, then manuscript**
  - The supplement compile ends by exposing `supplementary.aux` at doc-root
    (`./02_supplementary/supplementary.aux`, landed in PR #172 /
    `writer-supp-aux-docroot`).
  - The manuscript then compiles with that `.aux` present, so
    `main→supplement` `\ref`/`\pageref` resolve instead of printing `??`.
- Speed flags (`--no-figs`, `--no-diff`, `--draft`, …) pass through to **both**
  delegated compiles.

Existing behavior is untouched: `-m` / `-s` / `-r` and the bare-invocation
default (manuscript) are byte-for-byte unchanged. `all` is purely additive.

## Why an explicit target (not auto-run inside `-m`)

Per the card, a hidden "`-m` secretly runs `-s` first" behavior is more
surprising than an explicit combined target, so this is opt-in via `all`/`-a`.

## Reverse refs (follow-up)

`supplement→main` reverse refs additionally require the **manuscript** to
expose its own `.aux` at doc-root (and a third supplement pass to settle).
That is out of scope here and noted as a follow-up pairing with
`writer-supp-aux-docroot`. This PR fixes the reported forward case
(neurovista `nv-supp-xref`).

## Tests

`tests/scripts/shell/test_compile_dispatch.py` (8 tests, one assert each)
drives the **real** `compile.sh` inside a sandbox project whose per-document
delegates are tiny recorder scripts (genuine executables standing in for the
external compile programs — **not** mocks, and no LaTeX toolchain needed). It
asserts:
- `all` / `-a` → supplement **then** manuscript, in that order
- `all` does not run revision
- `-m` / `-s` / `-r` and bare invocation each run exactly their one delegate

Docs: `compile.sh --help` (the SSoT for compile flags) lists the new target
under DOCUMENT TYPES + examples. (The README's compile examples are in a file
already over the repo's `.md` line limit — the pre-existing oversize hook
blocks edits there; `--help` remains the authoritative listing.)

Card: `writer-supp-xref-ordering`