### PR TITLE
fix(branding): signature displays "SciTeX Writer" not "scitex-writer"

### DIFF
--- a/00_shared/latex_styles/signature_footer.tex
+++ b/00_shared/latex_styles/signature_footer.tex
@@ -30,7 +30,7 @@
       \node[anchor=south, yshift=4pt,
             font=\ttfamily\scriptsize, text=gray]
         at (current page.south)
-        {Compiled by scitex-writer v__SCITEX_WRITER_VERSION__};%
+        {Compiled by SciTeX Writer v__SCITEX_WRITER_VERSION__};%
     \end{tikzpicture}%
   }%
 }

--- a/00_shared/scitex_writer_version.tex
+++ b/00_shared/scitex_writer_version.tex
@@ -1,2 +1,2 @@
 \def\ScitexWriterVersion{2.13.4}
-\hypersetup{pdfcreator={Compiled by scitex-writer v2.13.4}}
+\hypersetup{pdfcreator={Compiled by SciTeX Writer v2.13.4}}

--- a/src/scitex_writer/_mcp/handlers/_compile.py
+++ b/src/scitex_writer/_mcp/handlers/_compile.py
@@ -39,7 +39,7 @@ def _inject_version_stamp(project_path) -> None:
         version_tex = project_path / "00_shared" / "scitex_writer_version.tex"
         version_tex.write_text(
             f"\\def\\ScitexWriterVersion{{{__version__}}}\n"
-            f"\\hypersetup{{pdfcreator={{Compiled by scitex-writer v{__version__}}}}}\n"
+            f"\\hypersetup{{pdfcreator={{Compiled by SciTeX Writer v{__version__}}}}}\n"
         )
     except Exception:
         pass  # Never block compilation due to version stamp

--- a/src/scitex_writer/_mcp/handlers/_update/_handler.py
+++ b/src/scitex_writer/_mcp/handlers/_update/_handler.py
@@ -56,7 +56,7 @@ def _restamp_version_tex(project_path: Path, pkg_version: str) -> None:
             return
         version_tex.write_text(
             f"\\def\\ScitexWriterVersion{{{pkg_version}}}\n"
-            f"\\hypersetup{{pdfcreator={{Compiled by scitex-writer v{pkg_version}}}}}\n",
+            f"\\hypersetup{{pdfcreator={{Compiled by SciTeX Writer v{pkg_version}}}}}\n",
             encoding="utf-8",
         )
     except OSError:

--- a/tests/scripts/python/test__signature_footer.py
+++ b/tests/scripts/python/test__signature_footer.py
@@ -254,7 +254,7 @@ def test_version_unknown_when_nothing_available(tmp_path):
 def _write_style(styles_dir):
     _write(
         styles_dir / "signature_footer.tex",
-        "% footer style\nCompiled by scitex-writer v__SCITEX_WRITER_VERSION__\n",
+        "% footer style\nCompiled by SciTeX Writer v__SCITEX_WRITER_VERSION__\n",
     )
 
 
@@ -265,7 +265,7 @@ def test_injection_substitutes_version(tmp_path):
     # Act
     injection = build_footer_injection(tmp_path, "4.2.0")
     # Assert
-    assert "Compiled by scitex-writer v4.2.0" in injection
+    assert "Compiled by SciTeX Writer v4.2.0" in injection
 
 
 def test_injection_carries_sentinel(tmp_path):


### PR DESCRIPTION
The human-readable brand in the compiled-PDF signature must read the proper-cased **SciTeX Writer**, not the lowercase package id `scitex-writer`.

## Scope — DISPLAY string only
Changed only the user-facing "Compiled by scitex-writer v<version>" display text to "Compiled by SciTeX Writer v<version>" in two surfaces:

1. **Visible opt-in page footer** (PR #248 feature) — `00_shared/latex_styles/signature_footer.tex`
2. **PDF pdfcreator metadata** — generated by `src/scitex_writer/_mcp/handlers/_compile.py` and `_update/_handler.py`; also the committed `00_shared/scitex_writer_version.tex`

Package/distribution name, import name, env-var (`SCITEX_WRITER_SIGNATURE_FOOTER`), CLI command, `pdfkeywords={scitex-writer}`, and the version token are all left unchanged (they stay the lowercase machine identifiers).

## Tests
`tests/scripts/python/test__signature_footer.py` expected strings updated to "SciTeX Writer". 27 affected tests pass (footer + update-handler). `scitex-dev ecosystem audit-all scitex-writer` reproduced: audit-skills / audit-python-apis / audit-project all SUCC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)