### PR TITLE
feat(ref-integrity): run pre-compile gate by default (warn; error in research projects)

### DIFF
--- a/scripts/python/check_ref_integrity.py
+++ b/scripts/python/check_ref_integrity.py
@@ -21,15 +21,30 @@
 #               explicitly rather than reporting every supple- ref as undefined.
 #
 #          Reuses scripts/python/check_references.py's extractors (don't
-#          rewrite). Severity off|warn|error (DEFAULT error -- a broken ref ships
-#          a ?-mark / wrong PDF):
-#            off   -- skip the gate
+#          rewrite). This gate RUNS AUTOMATICALLY as part of the normal
+#          pre-compile stage (run_provenance_checks.sh), so it is on by default
+#          ("opt-out" model -- opt out by setting the level to `off`).
+#
+#          DEFAULT depends on project type (mirrors check_figure_media /
+#          check_citations / check_clew_verify): a *research* project (marked by
+#          .scitex/dev/config.yaml `project-type: research`) defaults to error
+#          -- a broken ref ships a ?-mark / wrong PDF in a research manuscript --
+#          and a non-research project (the public template) defaults to warn (a
+#          normal single-target compile still succeeds, loud warning only).
+#
+#          Severity off|warn|error:
+#            off   -- skip the gate (prints a loud "disabled (level=off)" note)
 #            warn  -- report problems, exit 0 (does NOT block)
-#            error -- report problems, exit 1 (caller blocks the compile)
-#          Precedence (highest -> lowest): --level, env SCITEX_WRITER_REF_INTEGRITY,
-#          project ./config.yaml ref_integrity.level, user
-#          ~/.scitex/writer/config.yaml, default error. (To migrate onto the
-#          unified scripts/python/_severity.py resolver once that lands.)
+#            error -- report ALL problems, exit 1 (caller blocks the compile
+#                     BEFORE the expensive LaTeX run: fail-fast, report-all)
+#          Precedence (highest -> lowest), via the shared _severity resolver:
+#          --level, env SCITEX_WRITER_REF_INTEGRITY, project ./config.yaml
+#          ref_integrity.level, user ~/.scitex/writer/config.yaml, default
+#          (error for research, warn otherwise).
+#
+#          KNOB NAMING IS PROVISIONAL: the env var name lives in the single
+#          `_REF_INTEGRITY_ENV` constant below so a later rename per the
+#          scitex-dev SciTeX-standard knob contract is a one-line change.
 #
 # Usage:
 #   python check_ref_integrity.py [project_dir]
@@ -69,6 +84,11 @@ FAIL_COUNT = 0
 
 _LEVELS = ("off", "warn", "error")
 
+# SSoT for the per-check env knob. PROVISIONAL: pending the scitex-dev
+# SciTeX-standard knob-naming contract, a later rename is a one-line change
+# here (the CLI flag + config key stay `ref_integrity`).
+_REF_INTEGRITY_ENV = "SCITEX_WRITER_REF_INTEGRITY"
+
 _DOC_DIRS = {
     "manuscript": "01_manuscript",
     "supplementary": "02_supplementary",
@@ -105,6 +125,33 @@ def log_detail(msg):
     print(f"    {DIM}{msg}{NC}")
 
 
+def _is_research_project(project_dir):
+    """True iff .scitex/dev/config.yaml marks this a ``project-type: research``.
+
+    Mirrors check_figure_media / check_citations / check_clew_verify so every
+    gate shares one research-mode signal. PyYAML optional; falls back to a
+    textual marker scan.
+    """
+    cfg = Path(project_dir) / ".scitex" / "dev" / "config.yaml"
+    if not cfg.is_file():
+        return False
+    try:
+        text = cfg.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    try:
+        import yaml
+
+        data = yaml.safe_load(text) or {}
+        if isinstance(data, dict):
+            return str(data.get("project-type", "")).strip().lower() == "research"
+    except Exception:
+        pass
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("project-type:"):
+            return stripped.split(":", 1)[1].strip().strip("\"'").lower() == "research"
+    return False
 
 
 def _read_aux_labels(aux_path):
@@ -142,22 +189,30 @@ def main():
         "--level",
         choices=list(_LEVELS),
         default=None,
-        help="Severity: off, warn, or error (default). Overrides env and config.",
+        help="Severity: off, warn, or error. Overrides env and config. "
+        "Default: error for research projects, warn otherwise.",
     )
     args = parser.parse_args()
 
     project_dir = Path(args.project_dir).resolve()
+    research = _is_research_project(project_dir)
+    default = "error" if research else "warn"
     level = resolve_level(
         "ref_integrity",
         args.level,
         project_dir,
-        default="error",
-        env_var="SCITEX_WRITER_REF_INTEGRITY",
+        default=default,
+        env_var=_REF_INTEGRITY_ENV,
     )
+    kind = "research" if research else "non-research"
 
-    print(f"\n{BOLD}=== Reference Integrity Gate (level={level}) ==={NC}\n")
+    print(f"\n{BOLD}=== Reference Integrity Gate (level={level}, {kind}) ==={NC}\n")
     if level == "off":
-        print(f"  {DIM}[INFO]{NC} reference-integrity gate is disabled (level=off).")
+        print(
+            f"  {BOLD}{YELLOW}[INFO]{NC} reference-integrity gate is "
+            f"DISABLED (level=off) -- broken \\ref/\\cite/supple- xrefs will "
+            f"NOT be checked before compile."
+        )
         print(
             f"\n{BOLD}Summary:{NC} {GREEN}0 passed{NC}, "
             f"{YELLOW}0 warnings{NC}, {RED}0 errors{NC}"
@@ -190,7 +245,9 @@ def main():
             if key in labels:
                 continue
             for f, line in locs:
-                report(f"{doc_type}: {f.name}:{line}: {_classify(key)} \\ref{{{key}}} -> ?? (no \\label)")
+                report(
+                    f"{doc_type}: {f.name}:{line}: {_classify(key)} \\ref{{{key}}} -> ?? (no \\label)"
+                )
 
         # Class 4: supple- xrefs need the supplement .aux.
         if supple_refs:
@@ -200,10 +257,12 @@ def main():
                     f"{(project_dir / _SUPPLE_AUX)} missing; "
                     f"{len(supple_refs)} supple- xref(s) cannot resolve"
                 )
-                log_detail("fix: run `compile.sh -s` before `compile.sh -m` so the supplement .aux exists.")
+                log_detail(
+                    "fix: run `compile.sh -s` before `compile.sh -m` so the supplement .aux exists."
+                )
             else:
                 for key, locs in sorted(supple_refs.items()):
-                    bare = key[len(_SUPPLE_PREFIX):]
+                    bare = key[len(_SUPPLE_PREFIX) :]
                     if bare in supp_labels:
                         continue
                     for f, line in locs:
@@ -217,7 +276,9 @@ def main():
             if key in bib_keys:
                 continue
             for f, line in locs:
-                report(f"{doc_type}: {f.name}:{line}: \\cite{{{key}}} -> not in bibliography")
+                report(
+                    f"{doc_type}: {f.name}:{line}: \\cite{{{key}}} -> not in bibliography"
+                )
 
     if not any_doc:
         log_pass("no document directories found to check")

--- a/scripts/shell/modules/run_provenance_checks.sh
+++ b/scripts/shell/modules/run_provenance_checks.sh
@@ -31,6 +31,13 @@
 # process_figures.sh (which creates the placeholder), so at error-level the
 # placeholder path is never reached; defaults to error for research projects,
 # warn otherwise (the public template ships example captions without media).
+# ref_integrity is the REFERENCE-INTEGRITY GATE: it validates every figure/table
+# \ref, every \cite against the merged bib, and every supple- xref against the
+# supplement .aux, reporting ALL problems at once (file:line) BEFORE the
+# expensive LaTeX run -- catching ?-refs and undefined \cites up front instead
+# of buried in the log. Runs automatically (opt-out = level=off); defaults to
+# error for research projects, warn otherwise (a normal single-target compile in
+# a non-research project still succeeds with a loud warning).
 #
 # Returns the worst exit code across the checks (0 unless a check errored).
 
@@ -41,7 +48,7 @@ PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$THIS_DIR/../../.." && pwd)}"
 PY="${SCITEX_WRITER_PYTHON:-python3}"
 
 rc=0
-for chk in check_paper_symlink check_media_provenance check_figure_media check_caption_footnote check_clew_verify check_citations check_version_freshness; do
+for chk in check_paper_symlink check_media_provenance check_figure_media check_ref_integrity check_caption_footnote check_clew_verify check_citations check_version_freshness; do
     script="$THIS_DIR/../../python/${chk}.py"
     [ -f "$script" ] || continue
     "$PY" "$script" "$PROJECT_ROOT" || rc=$?

--- a/tests/scripts/python/test_check_ref_integrity.py
+++ b/tests/scripts/python/test_check_ref_integrity.py
@@ -38,8 +38,18 @@ def _base_project(tmp_path, body):
     results.tex whose body the caller supplies."""
     _write(tmp_path, f"{_FIG_MEDIA}/01.tex", "Figure one.\n")
     _write(tmp_path, f"{_TAB_MEDIA}/01.tex", "Table one.\n")
-    _write(tmp_path, "00_shared/bib_files/bibliography.bib", "@article{Known2020, title={x}}\n")
+    _write(
+        tmp_path,
+        "00_shared/bib_files/bibliography.bib",
+        "@article{Known2020, title={x}}\n",
+    )
     _write(tmp_path, "01_manuscript/contents/results.tex", body)
+    return tmp_path
+
+
+def _mark_research(tmp_path):
+    """Mark the project a research project (the warn->error escalation signal)."""
+    _write(tmp_path, ".scitex/dev/config.yaml", "project-type: research\n")
     return tmp_path
 
 
@@ -73,17 +83,36 @@ def clean_env():
 # ============================================================================
 
 
-def test_resolve_level_defaults_to_error(tmp_path, clean_env):
-    """With no --level, no env, no config, the default level is error."""
+def test_resolve_level_default_warn_non_research(tmp_path, clean_env):
+    """Non-research default is warn (the opt-out gate does not block)."""
     # Arrange
     # Act
     level = resolve_level(
         "ref_integrity",
         None,
         str(tmp_path),
-        default="error",
+        default="warn",
         env_var="SCITEX_WRITER_REF_INTEGRITY",
     )
+    # Assert
+    assert level == "warn"
+
+
+def test_env_knob_escalates_to_error(tmp_path, clean_env):
+    """The SCITEX_WRITER_REF_INTEGRITY env knob overrides the default to error."""
+    # Arrange
+    os.environ["SCITEX_WRITER_REF_INTEGRITY"] = "error"
+    try:
+        # Act
+        level = resolve_level(
+            "ref_integrity",
+            None,
+            str(tmp_path),
+            default="warn",
+            env_var="SCITEX_WRITER_REF_INTEGRITY",
+        )
+    finally:
+        os.environ.pop("SCITEX_WRITER_REF_INTEGRITY", None)
     # Assert
     assert level == "error"
 
@@ -93,12 +122,43 @@ def test_resolve_level_defaults_to_error(tmp_path, clean_env):
 # ============================================================================
 
 
-def test_undefined_figure_ref_errors(tmp_path, clean_env):
-    """A \\ref to a non-existent figure label blocks (exit 1)."""
+def test_default_non_research_does_not_block(tmp_path, clean_env):
+    """Default (non-research) is warn: a broken \\ref reports but exits 0."""
     # Arrange
     _base_project(tmp_path, "See \\ref{fig:99}.\n")
     # Act
     proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_default_non_research_emits_warning(tmp_path, clean_env):
+    """Default (non-research) still reports the broken \\ref loudly (as a warning)."""
+    # Arrange
+    _base_project(tmp_path, "See \\ref{fig:99}.\n")
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert "1 warnings" in proc.stdout
+
+
+def test_research_project_blocks_by_default(tmp_path, clean_env):
+    """A project-type: research project defaults to error: a broken \\ref blocks."""
+    # Arrange
+    _base_project(tmp_path, "See \\ref{fig:99}.\n")
+    _mark_research(tmp_path)
+    # Act
+    proc = _run(tmp_path)
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_undefined_figure_ref_errors(tmp_path, clean_env):
+    """At --level error a \\ref to a non-existent figure label blocks (exit 1)."""
+    # Arrange
+    _base_project(tmp_path, "See \\ref{fig:99}.\n")
+    # Act
+    proc = _run(tmp_path, "--level", "error")
     # Assert
     assert proc.returncode == 1
 
@@ -114,11 +174,11 @@ def test_resolved_figure_and_table_refs_pass(tmp_path, clean_env):
 
 
 def test_undefined_citation_errors(tmp_path, clean_env):
-    """A \\cite key absent from the bib blocks (exit 1)."""
+    """At --level error a \\cite key absent from the bib blocks (exit 1)."""
     # Arrange
     _base_project(tmp_path, "Cite \\cite{Missing2021}.\n")
     # Act
-    proc = _run(tmp_path)
+    proc = _run(tmp_path, "--level", "error")
     # Assert
     assert proc.returncode == 1
 
@@ -134,11 +194,11 @@ def test_known_citation_passes(tmp_path, clean_env):
 
 
 def test_supple_ref_without_aux_errors(tmp_path, clean_env):
-    """A supple- xref with no supplement .aux blocks (exit 1)."""
+    """At --level error a supple- xref with no supplement .aux blocks (exit 1)."""
     # Arrange
     _base_project(tmp_path, "See \\ref{supple-fig:S01}.\n")
     # Act
-    proc = _run(tmp_path)
+    proc = _run(tmp_path, "--level", "error")
     # Assert
     assert proc.returncode == 1
 
@@ -157,7 +217,9 @@ def test_supple_ref_resolved_by_aux_passes(tmp_path, clean_env):
     """A supple- xref resolves against the supplement .aux \\newlabel (exit 0)."""
     # Arrange
     _base_project(tmp_path, "See \\ref{supple-fig:S01}.\n")
-    _write(tmp_path, "02_supplementary/supplementary.aux", "\\newlabel{fig:S01}{{S1}{1}}\n")
+    _write(
+        tmp_path, "02_supplementary/supplementary.aux", "\\newlabel{fig:S01}{{S1}{1}}\n"
+    )
     # Act
     proc = _run(tmp_path)
     # Assert
@@ -165,16 +227,29 @@ def test_supple_ref_resolved_by_aux_passes(tmp_path, clean_env):
 
 
 def test_reports_all_classes_at_once(tmp_path, clean_env):
-    """One run surfaces every broken class together (3 errors), not one-at-a-time."""
+    """At error one run surfaces every broken class together (3 errors)."""
     # Arrange
     _base_project(
         tmp_path,
         "See \\ref{fig:99}. Cite \\cite{Missing2021}. See \\ref{supple-fig:S01}.\n",
     )
     # Act
-    proc = _run(tmp_path)
+    proc = _run(tmp_path, "--level", "error")
     # Assert
     assert "3 errors" in proc.stdout
+
+
+def test_report_all_then_abort_at_error(tmp_path, clean_env):
+    """Report-all-then-abort: all 3 classes reported AND the run aborts (exit 1)."""
+    # Arrange
+    _base_project(
+        tmp_path,
+        "See \\ref{fig:99}. Cite \\cite{Missing2021}. See \\ref{supple-fig:S01}.\n",
+    )
+    # Act
+    proc = _run(tmp_path, "--level", "error")
+    # Assert
+    assert proc.returncode == 1
 
 
 def test_off_level_skips(tmp_path, clean_env):
@@ -185,6 +260,16 @@ def test_off_level_skips(tmp_path, clean_env):
     proc = _run(tmp_path, "--level", "off")
     # Assert
     assert proc.returncode == 0
+
+
+def test_off_level_prints_loud_disabled_note(tmp_path, clean_env):
+    """--level off is not silent: it prints a loud DISABLED (level=off) note."""
+    # Arrange
+    _base_project(tmp_path, "See \\ref{fig:99}.\n")
+    # Act
+    proc = _run(tmp_path, "--level", "off")
+    # Assert
+    assert "DISABLED (level=off)" in proc.stdout
 
 
 def test_warn_level_does_not_block(tmp_path, clean_env):


### PR DESCRIPTION
## Summary

Finishes scitex-todo card \`writer-precompile-ref-integrity-gate\` per the explicit operator decision (2026-07-06). The reference-integrity gate (engine + check-only mode landed in #174) now **runs automatically as part of the normal pre-compile flow** — an opt-out / always-runs model, not a per-run prompt.

**This is a compile-behavior change.** The check now runs on every compile:
- **Default severity is now \`warn\`** (was \`error\`): a normal single-target compile in a **non-research** project proceeds — broken \`\ref\`/\`\cite\`/\`supple-\` xrefs are reported **loudly** but do **not** block.
- **Research projects default to \`error\`** and block the compile. Research detection reuses the **existing** \`.scitex/dev/config.yaml\` \`project-type: research\` signal via the same \`_is_research_project()\` mechanism already used by \`check_figure_media\` / \`check_citations\` / \`check_clew_verify\` — no parallel mechanism invented.
- **Opt-out = \`level=off\`**, which prints a **loud DISABLED (level=off)** note (no silent fallback).

## Behavior model

| Context | Default | On broken ref/cite |
|---|---|---|
| non-research project | \`warn\` | reports loudly, compile proceeds |
| research project (\`project-type: research\`) | \`error\` | reports ALL problems, aborts before LaTeX |
| \`level=off\` (any project) | disabled | loud DISABLED note, no checking |

Severity precedence unchanged (shared \`_severity.resolve_level\`): CLI \`--level\` > env \`SCITEX_WRITER_REF_INTEGRITY\` > project \`./config.yaml\` > user \`~/.scitex/writer/config.yaml\` > default.

## Pre-compile wiring

Added \`check_ref_integrity\` to \`scripts/shell/modules/run_provenance_checks.sh\` — the same loop that runs \`check_figure_media\` / \`check_citations\` etc. This runs at the **Provenance Checks** stage of \`compile_manuscript.sh\` / \`compile_supplementary.sh\` / \`compile_revision.sh\`, **before** the bibliography merge and the expensive LaTeX run. At \`error\` the gate reports **all** problems (file:line) across all classes, then aborts (fail-fast, report-all — the card's core requirement).

## Knob naming (PROVISIONAL)

The env knob (\`SCITEX_WRITER_REF_INTEGRITY\`) is held in a **single SSoT constant** \`_REF_INTEGRITY_ENV\` in \`check_ref_integrity.py\`, so a later rename per the **scitex-dev SciTeX-standard knob-naming contract** (consult in progress in parallel) is a one-line change. Noted as provisional in the module header.

## Tests (no mocks; real fixture .tex/.aux/.bib)

- default non-research → \`warn\`: compile proceeds (exit 0) + warning emitted
- env knob \`SCITEX_WRITER_REF_INTEGRITY=error\` → escalates to error
- \`project-type: research\` → error by default → broken ref blocks (exit 1)
- \`level=off\` → disabled, loud \`DISABLED (level=off)\` note
- report-all-then-abort at error (all 3 classes surfaced, exit 1)

Affected tests green: \`test_check_ref_integrity.py\` (17), plus \`test_check_figure_media.py\` + \`test_check_references.py\` unaffected (60 passed total). \`scitex-dev ecosystem audit-all scitex-writer\` clean (skills / python-apis / project all SUCC).

Card: \`writer-precompile-ref-integrity-gate\`