### PR TITLE
feat: auto-run overflow check after each compile (card item 2)

### DIFF
--- a/scripts/shell/compile_manuscript.sh
+++ b/scripts/shell/compile_manuscript.sh
@@ -425,6 +425,18 @@ main() {
     fi
     log_stage_end "Compile Verification"
 
+    # Post-compile overflow check: surface off-page content (wide tables/figures,
+    # over-tall pages) AUTOMATICALLY from the LaTeX .log, so overflow no longer
+    # needs a manual `scitex-writer check-overflow` call. warn (default) reports
+    # and continues; error blocks; off is a loud no-op. A missing .log is
+    # reported, not fatal.
+    log_stage_start "Overflow Check"
+    if ! "$PROJECT_ROOT/scripts/shell/modules/run_overflow_check.sh"; then
+        log_error "Overflow check failed — content overflows the page (overflow.level=error). Aborting."
+        exit 1
+    fi
+    log_stage_end "Overflow Check"
+
     # Manuscript Hints feed (ADVISORY): aggregate the signals the compile
     # already produced (undefined \ref/\cite in the log, unverified clew claims)
     # into .scitex/writer/hints.json — the data layer the writer UI's Details

--- a/scripts/shell/compile_revision.sh
+++ b/scripts/shell/compile_revision.sh
@@ -390,6 +390,16 @@ parse_arguments() {
     fi
     log_stage_end "Compile Verification"
 
+    # Post-compile overflow check: surface off-page content automatically from
+    # the LaTeX .log (warn reports+continues, error blocks, off is a loud no-op;
+    # a missing .log is reported, not fatal).
+    log_stage_start "Overflow Check"
+    if ! ./scripts/shell/modules/run_overflow_check.sh; then
+        echo_error "Overflow check failed — content overflows the page (overflow.level=error). Aborting."
+        exit 1
+    fi
+    log_stage_end "Overflow Check"
+
     # Skip diff generation for revision (revision document already shows changes inline)
     echo_info "Skipping diff generation (revision document shows changes inline)"
 

--- a/scripts/shell/compile_supplementary.sh
+++ b/scripts/shell/compile_supplementary.sh
@@ -347,6 +347,16 @@ main() {
     fi
     log_stage_end "Compile Verification"
 
+    # Post-compile overflow check: surface off-page content automatically from
+    # the LaTeX .log (warn reports+continues, error blocks, off is a loud no-op;
+    # a missing .log is reported, not fatal).
+    log_stage_start "Overflow Check"
+    if ! ./scripts/shell/modules/run_overflow_check.sh; then
+        echo_error "Overflow check failed — content overflows the page (overflow.level=error). Aborting."
+        exit 1
+    fi
+    log_stage_end "Overflow Check"
+
     # Diff (skip if --no_diff specified)
     if [ "$no_diff" = false ]; then
         log_stage_start "Diff Generation"

--- a/scripts/shell/modules/run_overflow_check.sh
+++ b/scripts/shell/modules/run_overflow_check.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
+# File: scripts/shell/modules/run_overflow_check.sh
+#
+# POST-compile OVERFLOW gate. Runs scripts/python/check_overflow.py at its
+# RESOLVED severity (off|warn|error via CLI/env/config, shared _severity
+# resolver, default warn). It parses the LaTeX .log produced by the LAST
+# compile for `Overfull \hbox`/`Overfull \vbox` — content that runs off the
+# page (wide tables/figures, over-tall pages) — so overflow surfaces
+# AUTOMATICALLY after every compile without a manual `scitex-writer
+# check-overflow` call. It CANNOT run in the pre-compile validate gate
+# (run_provenance_checks.sh): the .log does not exist until LaTeX has run.
+#   off   -> no-op with a loud disabled note (exit 0)
+#   warn  -> reports, exit 0 (does NOT block) — the default
+#   error -> exit 1 (blocks, fail-loud) when content overflows the page
+# ROBUST when the .log is MISSING (an earlier compile failure produced no
+# .log): check_overflow.py reports "No .log found ... compile first, then
+# overflow can be checked." and exits 0 — no crash, no silent swallow.
+#
+# Doc-type comes from SCITEX_WRITER_DOC_TYPE (exported by each compile_*.sh);
+# defaults to manuscript when run standalone.
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$THIS_DIR/../../.." && pwd)}"
+PY="${SCITEX_WRITER_PYTHON:-python3}"
+
+script="$THIS_DIR/../../python/check_overflow.py"
+[ -f "$script" ] || exit 0
+
+"$PY" "$script" "$PROJECT_ROOT" --doc-type "${SCITEX_WRITER_DOC_TYPE:-manuscript}"

--- a/tests/scripts/shell/modules/test_run_overflow_check.py
+++ b/tests/scripts/shell/modules/test_run_overflow_check.py
@@ -1,0 +1,121 @@
+"""run_overflow_check.sh auto-runs the overflow check post-compile.
+
+Item 2 of writer-overflow-prevention-followups: after each compile the
+post-compile wiring must invoke check_overflow.py against the just-produced
+LaTeX .log, honoring the resolved overflow severity (off/warn/error) and
+staying robust when the .log is missing (an earlier compile failure).
+
+No mocks (STX-NM002): each test drives the REAL run_overflow_check.sh over a
+sandbox project with a stand-in .log and asserts on its behavior.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+_MODULE = (
+    Path(__file__).resolve().parents[4] / "scripts/shell/modules/run_overflow_check.sh"
+)
+
+# A real pdfTeX overfull-hbox line (a too-wide tabular / table not shown
+# entirely) — check_overflow.py parses exactly this shape.
+_OVERFULL_LOG = (
+    "This is pdfTeX, Version 3.14159265\n"
+    "Overfull \\hbox (72.26999pt too wide) in alignment at lines 120--145\n"
+    "[1] [2] )\n"
+)
+
+
+def _run(project_dir, level=None):
+    env = {
+        "PROJECT_ROOT": str(project_dir),
+        "SCITEX_WRITER_DOC_TYPE": "manuscript",
+        # Isolate from the real ~/.scitex/writer/config.yaml so the resolver
+        # falls through to the check's own default (warn) unless overridden.
+        "HOME": str(project_dir),
+        "PATH": os.environ["PATH"],
+    }
+    if level is not None:
+        env["SCITEX_WRITER_OVERFLOW"] = level
+    return subprocess.run(
+        ["bash", str(_MODULE)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _project_with_log(tmp_path, log_text):
+    logs = tmp_path / "01_manuscript" / "logs"
+    logs.mkdir(parents=True)
+    (logs / "manuscript.log").write_text(log_text)
+    return tmp_path
+
+
+def _project_without_log(tmp_path):
+    # doc dir exists (compile started) but no .log landed (compile failed).
+    (tmp_path / "01_manuscript").mkdir(parents=True)
+    return tmp_path
+
+
+def test_overflow_box_in_log_is_reported(tmp_path):
+    # Arrange
+    project = _project_with_log(tmp_path, _OVERFULL_LOG)
+    # Act
+    result = _run(project)
+    # Assert
+    assert "72.3pt too wide" in result.stdout
+
+
+def test_warn_level_does_not_block_compile(tmp_path):
+    # Arrange
+    project = _project_with_log(tmp_path, _OVERFULL_LOG)
+    # Act
+    result = _run(project)  # default level is warn
+    # Assert
+    assert result.returncode == 0
+
+
+def test_error_level_blocks_on_overflow(tmp_path):
+    # Arrange
+    project = _project_with_log(tmp_path, _OVERFULL_LOG)
+    # Act
+    result = _run(project, level="error")
+    # Assert
+    assert result.returncode == 1
+
+
+def test_off_level_skips_with_loud_disabled_note(tmp_path):
+    # Arrange
+    project = _project_with_log(tmp_path, _OVERFULL_LOG)
+    # Act
+    result = _run(project, level="off")
+    # Assert
+    assert "disabled" in result.stdout
+
+
+def test_off_level_does_not_block(tmp_path):
+    # Arrange
+    project = _project_with_log(tmp_path, _OVERFULL_LOG)
+    # Act
+    result = _run(project, level="off")
+    # Assert
+    assert result.returncode == 0
+
+
+def test_missing_log_reports_could_not_check(tmp_path):
+    # Arrange
+    project = _project_without_log(tmp_path)
+    # Act
+    result = _run(project)
+    # Assert
+    assert "No .log found" in result.stdout
+
+
+def test_missing_log_does_not_crash(tmp_path):
+    # Arrange
+    project = _project_without_log(tmp_path)
+    # Act
+    result = _run(project)
+    # Assert
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary

Implements **item 2** of the scitex-todo card `writer-overflow-prevention-followups`:
> Run check-overflow AUTOMATICALLY after each compile so overflow surfaces without a manual call.

The overflow check parses the compiled LaTeX `.log` for `Overfull \hbox`/`\vbox`, so it cannot live in the pre-compile validate gate (`run_provenance_checks.sh`) — the `.log` does not exist until LaTeX has run. This wires an automatic post-compile invocation.

## Changes

- **New module** `scripts/shell/modules/run_overflow_check.sh` — mirrors `run_compile_verification.sh`. Runs `check_overflow.py` at its RESOLVED severity (off/warn/error via the shared `_severity` resolver, default **warn**) for the current `SCITEX_WRITER_DOC_TYPE`.
- **Wired into all three compile flows** (`compile_manuscript.sh`, `compile_supplementary.sh`, `compile_revision.sh`) as a new **Overflow Check** stage immediately after **Compile Verification** (post-PDF, `.log` present), matching each file's local invocation style.
- Severity honored (unchanged defaults): `warn` reports + continues; `error` blocks the compile (fail-loud); `off` is a loud disabled no-op.
- **Robust on missing `.log`** (an earlier compile failure): `check_overflow.py` reports `No .log found ... compile first` and exits 0 — no crash, no silent swallow.

## Tests

`tests/scripts/shell/modules/test_run_overflow_check.py` — drives the REAL module over a sandbox project with a stand-in `.log` (no mocks, one assert per test): overflow reported at warn, `error` blocks, `off` skips with a disabled note + does not block, missing `.log` reports "couldn't check" + does not crash. 7/7 pass.

## Out of scope (remain OPEN on the card)

- **Item 1** (breakable placeholder caption path) — overlaps the scitex-dev-owned card `writer-caption-overflow-handling`; left to avoid double-implementation.
- **Item 3** (visual float-placement confirmation) — blocked on a neurovista recompile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
