### PR TITLE
chore(release): 2.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to SciTeX Writer will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.25.0] - 2026-07-06
+
+### Added
+- **PDF annotation → agent feedback loop (design doc).** Design for a loop
+  that turns PDF annotations into actionable agent feedback (#247).
+- **Opt-in page-footer signature.** A visible "SciTeX Writer" page-footer
+  signature, disabled by default (#248).
+- **Annotation persist + emit spike.** The writer-owned slice of the
+  annotation→feedback loop: persist annotations and emit them (#249).
+- **Self-documenting vendored tree.** The vendored tree now carries role
+  hint-comments and is set read-only via `update-project` (#250).
+- **`\captionfootnote` helper.** A footnote-in-caption marker that expands to
+  `\footnotemark` + `\footnotetext` placed after the float (#251).
+- **Combined supplement↔main compile target.** `compile.sh all` / `-a` compiles
+  supplement and main together in one pass for cross-ref resolution (#252).
+- **Pre-compile reference-integrity gate.** Runs by default at `warn`, escalates
+  to `error` in research projects (`project-type: research`); `off` disables —
+  an opt-out model (#254).
+- **Auto-run overflow check after each compile.** A new post-compile "Overflow
+  Check" stage runs automatically (#255).
+- **Table-decimal consistency warn-lint.** Covers the non-pandas /
+  external-`csv2latex` / hand-authored table paths the auto-pad misses (#256).
+
+### Changed
+- **Compiled-PDF signature branding.** The compiled-PDF signature now displays
+  "SciTeX Writer" rather than the lowercase form (#253).
+
 ## [2.24.9] - 2026-07-06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.24.9"
+version = "2.25.0"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Release 2.25.0 (MINOR)

Bumps the develop version 2.24.9 → 2.25.0. MINOR bump: this release adds new features (10 feature PRs merged since 2.24.9).

### Files changed
- `pyproject.toml` — version 2.24.9 → 2.25.0
- `CHANGELOG.md` — new `## [2.25.0] - 2026-07-06` entry

### Included feature PRs
- #247 design doc for the PDF annotation → agent feedback loop
- #248 opt-in visible "SciTeX Writer" page-footer signature (default OFF)
- #249 annotation persist+emit spike (writer-owned slice of the feedback loop)
- #250 self-documenting vendored tree (role hint-comments + read-only perms)
- #251 `\captionfootnote` helper (→ `\footnotemark` + `\footnotetext` after the float)
- #252 combined supplement↔main compile target (`compile.sh all` / `-a`)
- #253 branding: compiled-PDF signature displays "SciTeX Writer"
- #254 pre-compile reference-integrity gate (warn default, error in research, off disables)
- #255 auto-run overflow check after each compile (post-compile "Overflow Check" stage)
- #256 table-decimal consistency warn-lint

Note: develop→main promotion and tagging are handled separately by the coordinator.