### PR TITLE
fix: wrap placeholder-caption edit-path in breakable \url{} (stop Overfull \hbox)

### DIFF
--- a/scripts/shell/modules/process_figures_modules/01_caption_management.src
+++ b/scripts/shell/modules/process_figures_modules/01_caption_management.src
@@ -32,12 +32,11 @@ ensure_caption() {
             else
                 # Create default caption template
                 local rel_path="${caption_tex_file#./}"
-                local escaped_path="${rel_path//_/\\_}"
                 cat <<EOF >"$caption_tex_file"
 %% Edit this file: $rel_path
 \caption{\textbf{FIGURE TITLE HERE}\\\\
 \smallskip
-FIGURE LEGEND HERE. Edit this caption at \texttt{$escaped_path}.
+FIGURE LEGEND HERE. Edit this caption at \url{$rel_path}.
 }
 %%%% EOF
 EOF

--- a/scripts/shell/modules/process_tables.sh
+++ b/scripts/shell/modules/process_tables.sh
@@ -125,12 +125,11 @@ function ensure_caption() {
             echo_info "    Creating default caption for table $base_name"
             mkdir -p "$(dirname "$caption_file")"
             local rel_path="${caption_file#./}"
-            local escaped_path="${rel_path//_/\\_}"
             cat >"$caption_file" <<EOF
 %% Edit this file: $rel_path
 \\caption{\\textbf{TABLE TITLE HERE}\\\\
 \\smallskip
-TABLE CAPTION HERE. Edit this caption at \\texttt{$escaped_path}.
+TABLE CAPTION HERE. Edit this caption at \\url{$rel_path}.
 }
 EOF
         fi

--- a/tests/scripts/shell/modules/test_default_caption_path_breakable.py
+++ b/tests/scripts/shell/modules/test_default_caption_path_breakable.py
@@ -1,0 +1,52 @@
+"""ensure_caption wraps the placeholder edit-path in a breakable \\url{} macro.
+
+A bare \\texttt{<long path>} in the generated placeholder caption cannot break
+and overflows the right text margin (Overfull \\hbox). \\url{} (backed by the
+already-loaded xurl+hyperref preamble) breaks the path at any character.
+"""
+
+import subprocess
+from pathlib import Path
+
+_MODULES = (
+    Path(__file__).resolve().parents[4]
+    / "scripts/shell/modules/process_figures_modules"
+)
+
+# A long, underscore-heavy stem so the generated path is exactly the kind that
+# overflows the margin when left un-breakable.
+_FIGURE_STEM = "01_a_very_long_example_figure_file_name_that_overflows"
+
+
+def _run_ensure_caption(tmp_path):
+    cam = tmp_path / "cam"
+    cam.mkdir(parents=True)
+    # A main figure (not a panel: stem is NN_..., not NNx_...) with no caption
+    # file yet, so ensure_caption emits the default placeholder caption.
+    (cam / f"{_FIGURE_STEM}.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+    script = (
+        f'export SCITEX_WRITER_FIGURE_CAPTION_MEDIA_DIR="{cam}";'
+        f"source '{_MODULES}/00_common.src';"
+        f"source '{_MODULES}/01_caption_management.src';"
+        f"ensure_caption"
+    )
+    subprocess.run(["bash", "-c", script], capture_output=True, text=True, check=True)
+    return (cam / f"{_FIGURE_STEM}.tex").read_text()
+
+
+def test_placeholder_caption_wraps_path_in_url(tmp_path):
+    # Arrange
+    expected = f"\\url{{{tmp_path}/cam/{_FIGURE_STEM}.tex}}"
+    # Act
+    caption = _run_ensure_caption(tmp_path)
+    # Assert
+    assert expected in caption
+
+
+def test_placeholder_caption_leaves_no_unbreakable_texttt_path(tmp_path):
+    # Arrange
+    unbreakable = "\\texttt"
+    # Act
+    caption = _run_ensure_caption(tmp_path)
+    # Assert
+    assert unbreakable not in caption


### PR DESCRIPTION
## Problem
When scaffolding a new project (or a new figure/table), the generated **placeholder caption** embeds the caption file's path as bare `\texttt{<long path>}`:

```
FIGURE LEGEND HERE. Edit this caption at \texttt{01_manuscript/.../02_another_example.tex}.
```

LaTeX cannot break plain `\texttt` text, so the long path overflows the right text margin (**Overfull \hbox**) and runs off the page. `xurl` (already in the preamble) only breaks `\url`/`\href`, not `\texttt`, so it does not help here.

## Fix
Wrap the path in `\url{...}`. The preamble already loads `xurl` + `hyperref` **specifically** to "break long URLs / DOIs at any character" (`00_shared/latex_styles/packages.tex:58`), so this reuses the established convention. `\url` renders in typewriter (same look as `\texttt`) but breaks anywhere. Since `\url` is verbatim, the manual underscore-escaping (`escaped_path`) is dropped.

`\seqsplit`/url's `\path` were not chosen: `seqsplit` is not in the preamble, and `\path` collides with the loaded `tikz` package.

## Sites fixed (both `ensure_caption`)
- `scripts/shell/modules/process_tables.sh`
- `scripts/shell/modules/process_figures_modules/01_caption_management.src`

## Test
`tests/scripts/shell/modules/test_default_caption_path_breakable.py` — sources the figure module and drives the real `ensure_caption` (no mocks), asserting the emitted path is wrapped in `\url{}` and no bare `\texttt` path remains. Mirrors the sibling `test_caption_footnote_in_caption.py`. 2 tests, 1 assert each — green.

Note: `process_tables.sh` runs a full pipeline at top level (not safely sourceable in isolation), so it receives the identical fix but is covered by the shared-convention reasoning rather than an independent unit test.

A LaTeX compile was not run in-container (heavy toolchain); the fix relies on the unit test plus the fact that xurl-backed `\url` is the same mechanism already proven for URLs/DOIs in this preamble.