### PR TITLE
chore: bump version to 2.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to SciTeX Writer will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.25.1] - 2026-07-07
+
+### Fixed
+- **Breakable placeholder-caption edit-path.** The scaffolded placeholder-caption
+  edit-path is now wrapped in a breakable `\url{}` to prevent an Overfull `\hbox`
+  off-page overflow (#259).
+
 ## [2.25.0] - 2026-07-06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.25.0"
+version = "2.25.1"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Patch release 2.25.1. Releases the already-merged #259 fix: wrap scaffolded placeholder-caption edit-path in breakable \url{} to prevent Overfull \hbox off-page overflow.

- pyproject.toml: 2.25.0 → 2.25.1
- CHANGELOG.md: 2.25.1 entry added

Do not merge until CI is green; coordinator handles develop→main→tag.