### PR TITLE
release: 2.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to SciTeX Writer will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.25.1] - 2026-07-07
+
+### Fixed
+- **Breakable placeholder-caption edit-path.** The scaffolded placeholder-caption
+  edit-path is now wrapped in a breakable `\url{}` to prevent an Overfull `\hbox`
+  off-page overflow (#259).
+
 ## [2.25.0] - 2026-07-06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.25.0"
+version = "2.25.1"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/scripts/shell/modules/process_figures_modules/01_caption_management.src
+++ b/scripts/shell/modules/process_figures_modules/01_caption_management.src
@@ -32,12 +32,11 @@ ensure_caption() {
             else
                 # Create default caption template
                 local rel_path="${caption_tex_file#./}"
-                local escaped_path="${rel_path//_/\\_}"
                 cat <<EOF >"$caption_tex_file"
 %% Edit this file: $rel_path
 \caption{\textbf{FIGURE TITLE HERE}\\\\
 \smallskip
-FIGURE LEGEND HERE. Edit this caption at \texttt{$escaped_path}.
+FIGURE LEGEND HERE. Edit this caption at \url{$rel_path}.
 }
 %%%% EOF
 EOF

--- a/scripts/shell/modules/process_tables.sh
+++ b/scripts/shell/modules/process_tables.sh
@@ -125,12 +125,11 @@ function ensure_caption() {
             echo_info "    Creating default caption for table $base_name"
             mkdir -p "$(dirname "$caption_file")"
             local rel_path="${caption_file#./}"
-            local escaped_path="${rel_path//_/\\_}"
             cat >"$caption_file" <<EOF
 %% Edit this file: $rel_path
 \\caption{\\textbf{TABLE TITLE HERE}\\\\
 \\smallskip
-TABLE CAPTION HERE. Edit this caption at \\texttt{$escaped_path}.
+TABLE CAPTION HERE. Edit this caption at \\url{$rel_path}.
 }
 EOF
         fi

--- a/tests/scripts/shell/modules/test_default_caption_path_breakable.py
+++ b/tests/scripts/shell/modules/test_default_caption_path_breakable.py
@@ -1,0 +1,52 @@
+"""ensure_caption wraps the placeholder edit-path in a breakable \\url{} macro.
+
+A bare \\texttt{<long path>} in the generated placeholder caption cannot break
+and overflows the right text margin (Overfull \\hbox). \\url{} (backed by the
+already-loaded xurl+hyperref preamble) breaks the path at any character.
+"""
+
+import subprocess
+from pathlib import Path
+
+_MODULES = (
+    Path(__file__).resolve().parents[4]
+    / "scripts/shell/modules/process_figures_modules"
+)
+
+# A long, underscore-heavy stem so the generated path is exactly the kind that
+# overflows the margin when left un-breakable.
+_FIGURE_STEM = "01_a_very_long_example_figure_file_name_that_overflows"
+
+
+def _run_ensure_caption(tmp_path):
+    cam = tmp_path / "cam"
+    cam.mkdir(parents=True)
+    # A main figure (not a panel: stem is NN_..., not NNx_...) with no caption
+    # file yet, so ensure_caption emits the default placeholder caption.
+    (cam / f"{_FIGURE_STEM}.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+    script = (
+        f'export SCITEX_WRITER_FIGURE_CAPTION_MEDIA_DIR="{cam}";'
+        f"source '{_MODULES}/00_common.src';"
+        f"source '{_MODULES}/01_caption_management.src';"
+        f"ensure_caption"
+    )
+    subprocess.run(["bash", "-c", script], capture_output=True, text=True, check=True)
+    return (cam / f"{_FIGURE_STEM}.tex").read_text()
+
+
+def test_placeholder_caption_wraps_path_in_url(tmp_path):
+    # Arrange
+    expected = f"\\url{{{tmp_path}/cam/{_FIGURE_STEM}.tex}}"
+    # Act
+    caption = _run_ensure_caption(tmp_path)
+    # Assert
+    assert expected in caption
+
+
+def test_placeholder_caption_leaves_no_unbreakable_texttt_path(tmp_path):
+    # Arrange
+    unbreakable = "\\texttt"
+    # Act
+    caption = _run_ensure_caption(tmp_path)
+    # Assert
+    assert unbreakable not in caption


### PR DESCRIPTION
Patch release 2.25.1. Ships the breakable placeholder-caption edit-path fix (#259) so the scaffolded caption path no longer overflows off-page (Overfull \hbox). Version bump #260.