### PR TITLE
release: 2.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to SciTeX Writer will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.26.0] - 2026-07-07
+
+### Added
+- **Clew provenance overlay (`--clew-overlay`).** New compile toggle (manuscript/revision/supplementary) that colors each claim span by its clew verification verdict (verified/suspect/failed/exception) with a 4-state legend, aliasing onto the `SCITEX_WRITER_CLEW_PRESENTATION` master switch; `\vclaim` marks light up from the clew join with zero author edits, degrading loud-but-graceful when no clew feed is present (#262).
+
 ## [2.25.1] - 2026-07-07
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.25.1"
+version = "2.26.0"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/scripts/shell/compile_manuscript.sh
+++ b/scripts/shell/compile_manuscript.sh
@@ -90,6 +90,7 @@ export do_force=false # Reserved for force-rebuild logic; exported so --force fl
 no_diff=false
 draft_mode=false
 dark_mode=${SCITEX_WRITER_DARK_MODE:-false}
+clew_overlay=false
 
 # Colors for usage output
 GRAY='\033[0;90m'
@@ -142,6 +143,7 @@ usage() {
     echo "  -c,   --crop_tif      Crop TIF whitespace"
     echo "  -q,   --quiet         Minimal output"
     echo "  --force               Force full recompilation"
+    echo "  --clew-overlay        Color \\vclaim values by clew provenance status"
     echo "  -h,   --help          Show this help"
     echo ""
     echo -e "${GRAY}Note: Options accept both hyphens and underscores${NC}"
@@ -218,6 +220,7 @@ parse_arguments() {
         -v | --verbose) do_verbose=true ;;
         -q | --quiet) do_verbose=false ;;
         --force) do_force=true ;;
+        --clew-overlay) clew_overlay=true ;;
         *)
             echo "Unknown option: $1"
             usage
@@ -240,6 +243,7 @@ main() {
     $dark_mode && options_display="${options_display} --dark_mode"
     $do_crop_tif && options_display="${options_display} --crop_tif"
     $do_verbose && options_display="${options_display} --verbose"
+    $clew_overlay && options_display="${options_display} --clew-overlay"
 
     # Show options only in verbose mode
     if [ "${SCITEX_LOG_LEVEL:-1}" -ge 2 ] && [ -n "$options_display" ]; then
@@ -255,6 +259,15 @@ main() {
 
     # Dark mode (black background, white text)
     export SCITEX_WRITER_DARK_MODE=$dark_mode
+
+    # Clew overlay (--clew-overlay): an alias onto the clew presentation master
+    # switch. `on` makes render_clew_toggles.py enable the provenance marks +
+    # badge/legend/signature/explainer, so \vclaim marks color by clew verdict
+    # with zero author edits. Only set when requested — never clobber an
+    # existing SCITEX_WRITER_CLEW_PRESENTATION coming from config/env when off.
+    if [ "$clew_overlay" = true ]; then
+        export SCITEX_WRITER_CLEW_PRESENTATION=on
+    fi
 
     # Refuse to compile on a Spartan login node (prohibited heavy compute) —
     # fail loud with the srun hint BEFORE the toolchain probe, which would

--- a/scripts/shell/compile_revision.sh
+++ b/scripts/shell/compile_revision.sh
@@ -83,6 +83,7 @@ no_tables=false
 do_verbose=false
 draft_mode=false
 dark_mode=${SCITEX_WRITER_DARK_MODE:-false}
+clew_overlay=false
 
 usage() {
     echo ""
@@ -142,6 +143,7 @@ usage() {
     echo "  -d,   --draft         Single-pass compilation (~5s faster)"
     echo "  -dm,  --dark_mode     Dark mode: black background, white text"
     echo "  -q,   --quiet         Minimal output"
+    echo "  --clew-overlay        Color \\vclaim values by clew provenance status"
     echo "  -h,   --help          Show this help"
     echo ""
     echo -e "${GRAY}Note: Options accept both hyphens and underscores${NC}"
@@ -182,6 +184,7 @@ parse_arguments() {
         -nt | --no-tables) no_tables=true ;;
         -d | --draft) draft_mode=true ;;
         -dm | --dark-mode) dark_mode=true ;;
+        --clew-overlay) clew_overlay=true ;;
         -v | --verbose) do_verbose=true ;;
         -q | --quiet) do_verbose=false ;;
         *)
@@ -203,6 +206,7 @@ parse_arguments() {
     $draft_mode && options_display="${options_display} --draft"
     $dark_mode && options_display="${options_display} --dark_mode"
     $do_verbose && options_display="${options_display} --verbose"
+    $clew_overlay && options_display="${options_display} --clew-overlay"
     echo_info "Running $0${options_display}..."
 
     # Verbosity
@@ -214,6 +218,13 @@ parse_arguments() {
 
     # Dark mode (black background, white text)
     export SCITEX_WRITER_DARK_MODE=$dark_mode
+
+    # Clew overlay (--clew-overlay): alias onto the clew presentation master
+    # switch so \vclaim marks color by clew verdict. Only set when requested,
+    # never clobbering an existing SCITEX_WRITER_CLEW_PRESENTATION when off.
+    if [ "$clew_overlay" = true ]; then
+        export SCITEX_WRITER_CLEW_PRESENTATION=on
+    fi
 
     # Refuse to compile on a Spartan login node (prohibited heavy compute) —
     # fail loud with the srun hint before the toolchain probe.

--- a/scripts/shell/compile_supplementary.sh
+++ b/scripts/shell/compile_supplementary.sh
@@ -82,6 +82,7 @@ export do_force=false # Reserved for force-rebuild logic; exported so --force fl
 no_diff=false
 draft_mode=false
 dark_mode=${SCITEX_WRITER_DARK_MODE:-false}
+clew_overlay=false
 
 usage() {
     echo ""
@@ -121,6 +122,7 @@ usage() {
     echo "  -c,   --crop_tif      Crop TIF whitespace"
     echo "  -q,   --quiet         Minimal output"
     echo "  --force               Force full recompilation"
+    echo "  --clew-overlay        Color \\vclaim values by clew provenance status"
     echo "  -h,   --help          Show this help"
     echo ""
     echo -e "${GRAY}Note: Options accept both hyphens and underscores${NC}"
@@ -191,6 +193,7 @@ parse_arguments() {
         -v | --verbose) do_verbose=true ;;
         -q | --quiet) do_verbose=false ;;
         --force) do_force=true ;;
+        --clew-overlay) clew_overlay=true ;;
         *)
             echo "Unknown option: $1"
             usage
@@ -213,6 +216,7 @@ main() {
     $dark_mode && options_display="${options_display} --dark_mode"
     $do_crop_tif && options_display="${options_display} --crop_tif"
     $do_verbose && options_display="${options_display} --verbose"
+    $clew_overlay && options_display="${options_display} --clew-overlay"
     echo_info "Running $0${options_display}..."
 
     # Verbosity
@@ -224,6 +228,13 @@ main() {
 
     # Dark mode (black background, white text)
     export SCITEX_WRITER_DARK_MODE=$dark_mode
+
+    # Clew overlay (--clew-overlay): alias onto the clew presentation master
+    # switch so \vclaim marks color by clew verdict. Only set when requested,
+    # never clobbering an existing SCITEX_WRITER_CLEW_PRESENTATION when off.
+    if [ "$clew_overlay" = true ]; then
+        export SCITEX_WRITER_CLEW_PRESENTATION=on
+    fi
 
     # Refuse to compile on a Spartan login node (prohibited heavy compute) —
     # fail loud with the srun hint before the toolchain probe.

--- a/scripts/shell/modules/render_clew.sh
+++ b/scripts/shell/modules/render_clew.sh
@@ -48,4 +48,20 @@ if command -v "$CLEW_BIN" >/dev/null 2>&1; then
     fi
 fi
 
+# Loud-but-graceful degrade for --clew-overlay: the overlay was REQUESTED
+# (master switch on) but no clew feed exists to color from. The presentation
+# layer is DECORATIVE -- it must never abort a compile -- so warn clearly and
+# continue (exit 0, marks simply do not light up). This is distinct from the
+# FAIL-LOUD path for a MALFORMED claims.json, which stays in render_clew.py.
+_clew_pres="$(printf '%s' "${SCITEX_WRITER_CLEW_PRESENTATION:-}" | tr '[:upper:]' '[:lower:]')"
+case "$_clew_pres" in
+1 | true | yes | on)
+    _clew_feed="$PROJECT_ROOT/.scitex/clew/runtime/claims.json"
+    if [ ! -s "$_clew_feed" ]; then
+        echo "WARN: --clew-overlay requested but no clew feed found at $_clew_feed;" >&2
+        echo "      run \`clew export-claims --unified\` first -- compiling without provenance marks." >&2
+    fi
+    ;;
+esac
+
 exec "$PY" "$PROJECT_ROOT/scripts/python/render_clew.py" "$PROJECT_ROOT"

--- a/src/scitex_writer/_mcp/handlers/_claim.py
+++ b/src/scitex_writer/_mcp/handlers/_claim.py
@@ -14,14 +14,17 @@ Usage in LaTeX (after render_claims is called before compile):
 """
 
 import json
-import re
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 from ..utils import resolve_project_path
+from ._claim_format import (
+    CLAIM_TYPES,
+    FORMAT_STYLES,
+    _render_claim,
+    _sanitize_id,
+)
 
-CLAIM_TYPES = ("statistic", "value", "citation", "figure", "table")
-FORMAT_STYLES = ("nature", "apa", "plain")
 CLAIMS_FILE = "00_shared/claims.json"
 CLAIMS_RENDERED = "00_shared/claims_rendered.tex"
 
@@ -50,202 +53,6 @@ def _save_claims(project_path: Path, data: Dict) -> None:
     p.write_text(
         json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
     )
-
-
-def _sanitize_id(claim_id: str) -> str:
-    """Sanitize claim ID for use in LaTeX macro names (letters only)."""
-    return re.sub(r"[^a-zA-Z0-9]", "", claim_id)
-
-
-def _format_p(p: float, style: str) -> str:
-    """Format p-value according to style."""
-    if p < 0.001:
-        return "< 0.001" if style != "apa" else "< .001"
-    if p < 0.01:
-        fmt = f"{p:.3f}"
-        return fmt if style != "apa" else fmt.lstrip("0")
-    fmt = f"{p:.3f}"
-    return f"= {fmt}" if style != "apa" else f"= {fmt.lstrip('0')}"
-
-
-def _format_statistic(value: Dict, style: str) -> str:
-    """Format a statistic claim."""
-    t = value.get("t")
-    f = value.get("F")
-    df = value.get("df")
-    df1 = value.get("df1")
-    df2 = value.get("df2")
-    p = value.get("p")
-    d = value.get("d")
-    eta2 = value.get("eta2")
-    r = value.get("r")
-
-    parts = []
-
-    if t is not None and df is not None:
-        if style == "plain":
-            parts.append(f"t({df}) = {t:.2f}")
-        else:
-            parts.append(f"$t({df}) = {t:.2f}$")
-    elif f is not None and df1 is not None and df2 is not None:
-        if style == "plain":
-            parts.append(f"F({df1},{df2}) = {f:.2f}")
-        else:
-            parts.append(f"$F({df1},{df2}) = {f:.2f}$")
-    elif r is not None:
-        if style == "plain":
-            parts.append(f"r = {r:.2f}")
-        else:
-            parts.append(f"$r = {r:.2f}$")
-
-    if p is not None:
-        p_str = _format_p(p, style)
-        if style == "plain":
-            parts.append(f"p {p_str}")
-        else:
-            parts.append(f"$p {p_str}$")
-
-    if d is not None:
-        if style == "apa":
-            label = "Cohen's $d$"
-            val_str = f"{d:.2f}"
-            parts.append(f"{label} = {val_str}")
-        elif style == "plain":
-            parts.append(f"d = {d:.2f}")
-        else:
-            parts.append(f"$d = {d:.2f}$")
-    elif eta2 is not None:
-        if style == "plain":
-            parts.append(f"eta2 = {eta2:.3f}")
-        else:
-            label = "$\\eta^2$" if style == "nature" else "$\\eta^2_p$"
-            parts.append(f"{label} = {eta2:.3f}")
-
-    return ", ".join(parts) if parts else str(value)
-
-
-def _format_value(value: Dict, style: str) -> str:
-    """Format a value claim.
-
-    Supported shapes (checked in order):
-
-    1. ``{"template_<style>": "...", ...}`` — per-style format string,
-       rendered with ``template.format(**value)``. ``<style>`` is one of
-       ``nature``, ``apa``, ``plain``. Lets a single claim carry three
-       differently-typeset renderings (useful when math goes into
-       ``$...$`` for nature/apa but stays plain for ``plain`` style).
-
-    2. ``{"template": "...", ...}`` — single style-agnostic format
-       string, rendered with ``template.format(**value)``. Takes the
-       whole value dict as keyword args, so compound claims like
-       ``{"n_sig": 73, "n_tot": 240, "frac": 0.304, ...}`` can pack a
-       rich rendering into one claim ID without exploding the JSON into
-       atomic sub-claims.
-
-    3. ``{"value": X, "unit": Y}`` (legacy single-value shape) — renders
-       as ``X Y`` (plain) or ``$X$ Y`` (nature/apa). Unit optional.
-
-    4. Any other dict — falls back to ``key=val, key=val, ...`` so the
-       claim is at least visible in the rendered tex and users can spot
-       that they need to add a ``template``.
-
-    Parameters
-    ----------
-    value : dict
-        The claim's value payload.
-    style : str
-        One of the FORMAT_STYLES constants (nature, apa, plain).
-    """
-    if not isinstance(value, dict):
-        return str(value)
-
-    # (1) per-style template
-    per_style = value.get(f"template_{style}")
-    if isinstance(per_style, str):
-        try:
-            return per_style.format(**value)
-        except (KeyError, IndexError, ValueError):
-            pass
-
-    # (2) single shared template
-    template = value.get("template")
-    if isinstance(template, str):
-        try:
-            return template.format(**value)
-        except (KeyError, IndexError, ValueError):
-            pass
-
-    # (3) legacy single-value shape
-    if "value" in value:
-        v = _latex_escape_value(value.get("value", ""))
-        unit = _latex_escape_value(value.get("unit", ""))
-        if unit:
-            return f"{v} {unit}" if style == "plain" else f"${v}$ {unit}"
-        return str(v)
-
-    # (4) fallback — flat key=val dump
-    return ", ".join(
-        f"{k}={_latex_escape_value(v)}"
-        for k, v in value.items()
-        if not (isinstance(k, str) and k.startswith("template"))
-    )
-
-
-def _format_citation(value: Dict, style: str) -> str:
-    """Format a citation claim — just returns user-supplied text."""
-    return _latex_escape_value(value.get("text", ""))
-
-
-def _format_figure(value: Dict, style: str) -> str:
-    """Format a figure reference."""
-    label = value.get("label", "")
-    return f"\\ref{{{label}}}"
-
-
-def _format_table(value: Dict, style: str) -> str:
-    """Format a table reference."""
-    label = value.get("label", "")
-    return f"\\ref{{{label}}}"
-
-
-def _latex_escape_value(s: str) -> str:
-    """Escape LaTeX special characters in a claim value string.
-
-    Only the silent-killer specials (`%`, unbalanced `{` / `}`, `&`, `#`,
-    `$`, `_`) are escaped — characters that template-authors might use
-    intentionally (`\\`, `^`, `~`) are left alone. The motivating bug:
-    a claim value of `"25%"` (e.g. bix-6 q5 percentage) was inlined raw
-    into LaTeX, where `%` starts a comment that consumed the closing
-    brace of the surrounding `\\IfFileExists{file}{BODY}` wrapper and
-    triggered a runaway-argument error on every compile. Discovered
-    2026-05-03 in paper-scitex-clew."""
-    if not isinstance(s, str):
-        s = str(s)
-    return (
-        s.replace("\\", "\\textbackslash{}")
-        .replace("&", "\\&")
-        .replace("%", "\\%")
-        .replace("$", "\\$")
-        .replace("#", "\\#")
-        .replace("_", "\\_")
-    )
-
-
-def _render_claim(claim: Dict, style: str) -> str:
-    """Render a single claim as a LaTeX string."""
-    claim_type = claim.get("type", "value")
-    value = claim.get("value", {})
-    if isinstance(value, str):
-        return _latex_escape_value(value)
-    formatters = {
-        "statistic": _format_statistic,
-        "value": _format_value,
-        "citation": _format_citation,
-        "figure": _format_figure,
-        "table": _format_table,
-    }
-    fn = formatters.get(claim_type, _format_value)
-    return fn(value, style)
 
 
 # ---------------------------------------------------------------------------
@@ -515,8 +322,35 @@ def render_claims(project_dir: str) -> Dict:
             "  \\expandafter\\ifx\\csname v@claim@##2@##1\\endcsname\\relax",
             "    [\\texttt{claim:##2}]%",
             "  \\else",
-            "    \\csname v@claim@##2@##1\\endcsname%",
+            "    \\v@claim@maybecolor{##2}{\\csname v@claim@##2@##1\\endcsname}%",
             "  \\fi}",
+            "",
+            "%% \\v@claim@maybecolor{id}{rendered} — clew provenance overlay.",
+            "%% When the clew presentation markers layer is ACTIVE",
+            "%% (\\ifclewpresmarkers, set by --clew-overlay / the master switch)",
+            "%% AND this claim id has a clew color registered (clew@hex@<id>, emitted",
+            "%% into clew_rendered.tex by render_clew using the SAME sanitize as the",
+            "%% v@claim@ names, so keys align), wrap the rendered value in the",
+            "%% verdict-colored decoration the clew layer uses (\\clewDecorate — the",
+            "%% ulem \\uwave span). The value is \\mbox-wrapped first: the \\vclaim",
+            '%% value macro bundles a \\hypertarget, and ulem \\uwave chokes ("Bad',
+            '%% space factor (0)") on that box unless it is a single \\hbox; claim',
+            "%% values are short single units, so this is safe. Falls back to the",
+            "%% PLAIN rendered value (no \\mbox, no wave) in every",
+            "%% other case, guarded by \\@ifundefined so a non-overlay compile (no",
+            "%% clew_rendered.tex, markers off, or claim absent from the clew feed)",
+            "%% never touches an undefined color/toggle macro.",
+            "\\providecommand{\\v@claim@maybecolor}[2]{%",
+            "  \\@ifundefined{clew@hex@##1}{##2}{%",
+            "    \\@ifundefined{ifclewpresmarkers}{##2}{%",
+            "      \\ifclewpresmarkers",
+            "        \\begingroup",
+            "        \\edef\\v@claim@clewhex{\\csname clew@hex@##1\\endcsname}%",
+            "        \\definecolor{clewVerdict}{HTML}{\\v@claim@clewhex}%",
+            "        \\clewDecorate{\\mbox{##2}}%",
+            "        \\endgroup",
+            "      \\else ##2\\fi}}%",
+            "}",
             "",
         ]
 

--- a/src/scitex_writer/_mcp/handlers/_claim_format.py
+++ b/src/scitex_writer/_mcp/handlers/_claim_format.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_mcp/handlers/_claim_format.py
+
+"""Claim → LaTeX-string formatting layer.
+
+Pure, side-effect-free rendering helpers extracted from ``_claim.py`` (which
+stays the CRUD + render-to-file orchestrator). Everything here maps a claim
+dict to a LaTeX string for one of the FORMAT_STYLES; nothing here touches the
+filesystem. Imported by ``_claim.py``; not part of the public MCP surface.
+"""
+
+import re
+from typing import Dict
+
+CLAIM_TYPES = ("statistic", "value", "citation", "figure", "table")
+FORMAT_STYLES = ("nature", "apa", "plain")
+
+
+def _sanitize_id(claim_id: str) -> str:
+    """Sanitize claim ID for use in LaTeX macro names (letters only)."""
+    return re.sub(r"[^a-zA-Z0-9]", "", claim_id)
+
+
+def _format_p(p: float, style: str) -> str:
+    """Format a p-value according to style."""
+    if p < 0.001:
+        return "< 0.001" if style != "apa" else "< .001"
+    if p < 0.01:
+        fmt = f"{p:.3f}"
+        return fmt if style != "apa" else fmt.lstrip("0")
+    fmt = f"{p:.3f}"
+    return f"= {fmt}" if style != "apa" else f"= {fmt.lstrip('0')}"
+
+
+def _format_statistic(value: Dict, style: str) -> str:
+    """Format a statistic claim."""
+    t = value.get("t")
+    f = value.get("F")
+    df = value.get("df")
+    df1 = value.get("df1")
+    df2 = value.get("df2")
+    p = value.get("p")
+    d = value.get("d")
+    eta2 = value.get("eta2")
+    r = value.get("r")
+
+    parts = []
+
+    if t is not None and df is not None:
+        if style == "plain":
+            parts.append(f"t({df}) = {t:.2f}")
+        else:
+            parts.append(f"$t({df}) = {t:.2f}$")
+    elif f is not None and df1 is not None and df2 is not None:
+        if style == "plain":
+            parts.append(f"F({df1},{df2}) = {f:.2f}")
+        else:
+            parts.append(f"$F({df1},{df2}) = {f:.2f}$")
+    elif r is not None:
+        if style == "plain":
+            parts.append(f"r = {r:.2f}")
+        else:
+            parts.append(f"$r = {r:.2f}$")
+
+    if p is not None:
+        p_str = _format_p(p, style)
+        if style == "plain":
+            parts.append(f"p {p_str}")
+        else:
+            parts.append(f"$p {p_str}$")
+
+    if d is not None:
+        if style == "apa":
+            label = "Cohen's $d$"
+            val_str = f"{d:.2f}"
+            parts.append(f"{label} = {val_str}")
+        elif style == "plain":
+            parts.append(f"d = {d:.2f}")
+        else:
+            parts.append(f"$d = {d:.2f}$")
+    elif eta2 is not None:
+        if style == "plain":
+            parts.append(f"eta2 = {eta2:.3f}")
+        else:
+            label = "$\\eta^2$" if style == "nature" else "$\\eta^2_p$"
+            parts.append(f"{label} = {eta2:.3f}")
+
+    return ", ".join(parts) if parts else str(value)
+
+
+def _format_value(value: Dict, style: str) -> str:
+    """Format a value claim.
+
+    Supported shapes (checked in order):
+
+    1. ``{"template_<style>": "...", ...}`` — per-style format string,
+       rendered with ``template.format(**value)``. ``<style>`` is one of
+       ``nature``, ``apa``, ``plain``. Lets a single claim carry three
+       differently-typeset renderings (useful when math goes into
+       ``$...$`` for nature/apa but stays plain for ``plain`` style).
+
+    2. ``{"template": "...", ...}`` — single style-agnostic format
+       string, rendered with ``template.format(**value)``. Takes the
+       whole value dict as keyword args, so compound claims like
+       ``{"n_sig": 73, "n_tot": 240, "frac": 0.304, ...}`` can pack a
+       rich rendering into one claim ID without exploding the JSON into
+       atomic sub-claims.
+
+    3. ``{"value": X, "unit": Y}`` (legacy single-value shape) — renders
+       as ``X Y`` (plain) or ``$X$ Y`` (nature/apa). Unit optional.
+
+    4. Any other dict — falls back to ``key=val, key=val, ...`` so the
+       claim is at least visible in the rendered tex and users can spot
+       that they need to add a ``template``.
+
+    Parameters
+    ----------
+    value : dict
+        The claim's value payload.
+    style : str
+        One of the FORMAT_STYLES constants (nature, apa, plain).
+    """
+    if not isinstance(value, dict):
+        return str(value)
+
+    # (1) per-style template
+    per_style = value.get(f"template_{style}")
+    if isinstance(per_style, str):
+        try:
+            return per_style.format(**value)
+        except (KeyError, IndexError, ValueError):
+            pass
+
+    # (2) single shared template
+    template = value.get("template")
+    if isinstance(template, str):
+        try:
+            return template.format(**value)
+        except (KeyError, IndexError, ValueError):
+            pass
+
+    # (3) legacy single-value shape
+    if "value" in value:
+        v = _latex_escape_value(value.get("value", ""))
+        unit = _latex_escape_value(value.get("unit", ""))
+        if unit:
+            return f"{v} {unit}" if style == "plain" else f"${v}$ {unit}"
+        return str(v)
+
+    # (4) fallback — flat key=val dump
+    return ", ".join(
+        f"{k}={_latex_escape_value(v)}"
+        for k, v in value.items()
+        if not (isinstance(k, str) and k.startswith("template"))
+    )
+
+
+def _format_citation(value: Dict, style: str) -> str:
+    """Format a citation claim — just returns user-supplied text."""
+    return _latex_escape_value(value.get("text", ""))
+
+
+def _format_figure(value: Dict, style: str) -> str:
+    """Format a figure reference."""
+    label = value.get("label", "")
+    return f"\\ref{{{label}}}"
+
+
+def _format_table(value: Dict, style: str) -> str:
+    """Format a table reference."""
+    label = value.get("label", "")
+    return f"\\ref{{{label}}}"
+
+
+def _latex_escape_value(s: str) -> str:
+    """Escape LaTeX special characters in a claim value string.
+
+    Only the silent-killer specials (`%`, unbalanced `{` / `}`, `&`, `#`,
+    `$`, `_`) are escaped — characters that template-authors might use
+    intentionally (`\\`, `^`, `~`) are left alone. The motivating bug:
+    a claim value of `"25%"` (e.g. bix-6 q5 percentage) was inlined raw
+    into LaTeX, where `%` starts a comment that consumed the closing
+    brace of the surrounding `\\IfFileExists{file}{BODY}` wrapper and
+    triggered a runaway-argument error on every compile. Discovered
+    2026-05-03 in paper-scitex-clew."""
+    if not isinstance(s, str):
+        s = str(s)
+    return (
+        s.replace("\\", "\\textbackslash{}")
+        .replace("&", "\\&")
+        .replace("%", "\\%")
+        .replace("$", "\\$")
+        .replace("#", "\\#")
+        .replace("_", "\\_")
+    )
+
+
+def _render_claim(claim: Dict, style: str) -> str:
+    """Render a single claim as a LaTeX string."""
+    claim_type = claim.get("type", "value")
+    value = claim.get("value", {})
+    if isinstance(value, str):
+        return _latex_escape_value(value)
+    formatters = {
+        "statistic": _format_statistic,
+        "value": _format_value,
+        "citation": _format_citation,
+        "figure": _format_figure,
+        "table": _format_table,
+    }
+    fn = formatters.get(claim_type, _format_value)
+    return fn(value, style)
+
+
+__all__ = [
+    "CLAIM_TYPES",
+    "FORMAT_STYLES",
+    "_sanitize_id",
+    "_format_p",
+    "_format_statistic",
+    "_format_value",
+    "_format_citation",
+    "_format_figure",
+    "_format_table",
+    "_latex_escape_value",
+    "_render_claim",
+]
+
+# EOF

--- a/tests/scripts/python/test_clew_overlay_vclaim.py
+++ b/tests/scripts/python/test_clew_overlay_vclaim.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scripts/python/test_clew_overlay_vclaim.py
+
+"""End-to-end pdflatex smoke for the ``--clew-overlay`` \\vclaim coloring.
+
+Real inputs, no mocks: renders a genuine ``claims_rendered.tex`` via the actual
+``render_claims.py`` step, then compiles it with a real ``pdflatex``.
+
+``claims_rendered.tex`` doubles its macro-parameter ``#`` to ``##`` so the block
+survives being inlined inside another macro body during the manuscript flatten
+(the production load context); one ``\\def`` scan there collapses ``##`` back to
+the ``#`` parameter marker. To exercise the macro standalone we apply that same
+single collapse (``##`` -> ``#``) — i.e. we compile the EXACT runtime form the
+macro takes once loaded — then drive it through pdflatex to prove:
+
+- OVERLAY path (markers on + a registered ``clew@hex@<id>``): the value is
+  colored by reusing the clew presentation layer's ``\\clewDecorate`` span and
+  the document still produces a PDF.
+- NON-OVERLAY path (no clew layer / no ``clew@hex@<id>``): ``\\vclaim`` degrades
+  to the plain value and compiles clean — the normal compile is never broken.
+
+Skipped when pdflatex is unavailable; the macro wiring is also covered by the
+unit assertions in test_render_claims.py.
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_RENDER_SCRIPT = _REPO_ROOT / "scripts/python/render_claims.py"
+_CLEW_PRESENTATION = _REPO_ROOT / "00_shared/latex_styles/clew_presentation.tex"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("pdflatex") is None, reason="pdflatex not available in-container"
+)
+
+
+def _runtime_claims_tex(tmp_path: Path) -> str:
+    """Render one value claim and return the macro block in its runtime form.
+
+    Runs the REAL render_claims step, then collapses the ``##`` doubling once
+    (the single reduction the production flatten performs) so the block can be
+    ``\\input`` at top level exactly as it behaves after loading.
+    """
+    shared = tmp_path / "00_shared"
+    shared.mkdir(parents=True, exist_ok=True)
+    (shared / "claims.json").write_text(
+        json.dumps(
+            {
+                "version": "1.0",
+                "claims": {
+                    "foo": {"type": "value", "value": {"value": 42, "unit": "ms"}}
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    subprocess.run(
+        [sys.executable, str(_RENDER_SCRIPT), str(tmp_path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    doubled = (shared / "claims_rendered.tex").read_text(encoding="utf-8")
+    return doubled.replace("##", "#")
+
+
+def _compile(work: Path) -> None:
+    subprocess.run(
+        ["pdflatex", "-interaction=nonstopmode", "-halt-on-error", "doc.tex"],
+        cwd=str(work),
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_overlay_on_colors_vclaim_and_compiles(tmp_path):
+    # Arrange: markers on + a registered clew color for `foo`, reusing the real
+    # clew presentation layer and the genuine rendered claims macro.
+    claims_tex = _runtime_claims_tex(tmp_path)
+    work = tmp_path / "build_on"
+    work.mkdir()
+    shutil.copy(_CLEW_PRESENTATION, work / "clew_presentation.tex")
+    (work / "claims_runtime.tex").write_text(claims_tex, encoding="utf-8")
+    (work / "doc.tex").write_text(
+        "\\documentclass{article}\n"
+        "\\usepackage{graphicx}\n"
+        "\\usepackage{xcolor}\n"
+        "\\usepackage{hyperref}\n"
+        "\\input{clew_presentation.tex}\n"
+        "\\makeatletter\n"
+        "\\@namedef{clew@hex@foo}{2DA44E}\n"
+        "\\makeatother\n"
+        "\\input{claims_runtime.tex}\n"
+        "\\clewpresmarkerstrue\n"
+        "\\begin{document}\n"
+        "\\vclaim{foo}\n"
+        "\\end{document}\n",
+        encoding="utf-8",
+    )
+    # Act
+    _compile(work)
+    # Assert
+    assert (work / "doc.pdf").is_file()
+
+
+def test_non_overlay_degrades_to_plain_value_and_compiles(tmp_path):
+    # Arrange: no clew presentation layer and no clew@hex@foo — the exact
+    # normal (non-overlay) compile; \vclaim must fall back to the plain value.
+    claims_tex = _runtime_claims_tex(tmp_path)
+    work = tmp_path / "build_off"
+    work.mkdir()
+    (work / "claims_runtime.tex").write_text(claims_tex, encoding="utf-8")
+    (work / "doc.tex").write_text(
+        "\\documentclass{article}\n"
+        "\\usepackage{hyperref}\n"
+        "\\input{claims_runtime.tex}\n"
+        "\\begin{document}\n"
+        "\\vclaim{foo}\n"
+        "\\end{document}\n",
+        encoding="utf-8",
+    )
+    # Act
+    _compile(work)
+    # Assert
+    assert (work / "doc.pdf").is_file()
+
+
+# EOF

--- a/tests/scripts/python/test_render_claims.py
+++ b/tests/scripts/python/test_render_claims.py
@@ -5,9 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-_SCRIPT = (
-    Path(__file__).resolve().parents[3] / "scripts/python/render_claims.py"
-)
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts/python/render_claims.py"
 
 
 def _make_project(tmp_path, claims=None):
@@ -34,24 +32,89 @@ def test_noop_when_no_claims_json(tmp_path):
     # Act
     result = _run(project)
     # Assert
-    assert result.returncode == 0 and not (project / "00_shared/claims_rendered.tex").exists()
+    assert (
+        result.returncode == 0
+        and not (project / "00_shared/claims_rendered.tex").exists()
+    )
 
 
 def test_renders_when_claims_json_present(tmp_path):
     # Arrange
-    project = _make_project(tmp_path, claims={"foo": {"type": "value", "value": {"value": 42, "unit": "ms"}}})
+    project = _make_project(
+        tmp_path,
+        claims={"foo": {"type": "value", "value": {"value": 42, "unit": "ms"}}},
+    )
     # Act
     _run(project)
     # Assert
-    assert "\\vclaim" in (project / "00_shared/claims_rendered.tex").read_text(encoding="utf-8")
+    assert "\\vclaim" in (project / "00_shared/claims_rendered.tex").read_text(
+        encoding="utf-8"
+    )
 
 
 def test_regenerates_stale_file(tmp_path):
     # Arrange
-    project = _make_project(tmp_path, claims={"foo": {"type": "value", "value": {"value": 1}}})
+    project = _make_project(
+        tmp_path, claims={"foo": {"type": "value", "value": {"value": 1}}}
+    )
     stale = project / "00_shared/claims_rendered.tex"
     stale.write_text("%% STALE CLEW PROTOTYPE BLOCK\n", encoding="utf-8")
     # Act
     _run(project)
     # Assert
     assert "STALE CLEW PROTOTYPE" not in stale.read_text(encoding="utf-8")
+
+
+def _rendered_tex(tmp_path):
+    """Generate claims_rendered.tex for a single value claim and return its text."""
+    project = _make_project(
+        tmp_path, claims={"foo": {"type": "value", "value": {"value": 1}}}
+    )
+    _run(project)
+    return (project / "00_shared/claims_rendered.tex").read_text(encoding="utf-8")
+
+
+def test_vclaim_defines_clew_color_helper(tmp_path):
+    # Arrange
+    project = tmp_path
+    # Act
+    tex = _rendered_tex(project)
+    # Assert
+    assert "\\v@claim@maybecolor" in tex
+
+
+def test_vclaim_looks_up_clew_hex_by_id(tmp_path):
+    # Arrange
+    project = tmp_path
+    # Act
+    tex = _rendered_tex(project)
+    # Assert
+    assert "clew@hex@##1" in tex
+
+
+def test_vclaim_reuses_clew_decorate_for_coloring(tmp_path):
+    # Arrange
+    project = tmp_path
+    # Act
+    tex = _rendered_tex(project)
+    # Assert
+    assert "\\clewDecorate{\\mbox{##2}}" in tex
+
+
+def test_vclaim_guards_on_markers_toggle(tmp_path):
+    # Arrange
+    project = tmp_path
+    # Act
+    tex = _rendered_tex(project)
+    # Assert
+    assert "\\ifclewpresmarkers" in tex
+
+
+def test_vclaim_plain_fallback_when_no_clew_hex(tmp_path):
+    # Arrange: the \@ifundefined false-guard passes the plain value (##2)
+    # through when no clew@hex@<id> is registered (claim not in the clew feed).
+    project = tmp_path
+    # Act
+    tex = _rendered_tex(project)
+    # Assert
+    assert "\\@ifundefined{clew@hex@##1}{##2}" in tex

--- a/tests/scripts/shell/test_clew_overlay_flag.py
+++ b/tests/scripts/shell/test_clew_overlay_flag.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scripts/shell/test_clew_overlay_flag.py
+
+"""``--clew-overlay`` flag threading + render_clew.sh loud-but-graceful degrade.
+
+Two behaviors are covered:
+
+1. render_clew.sh (REAL script, executed in a sandbox whose sub-tools are tiny
+   no-op recorder scripts — genuine external programs the module shells out to,
+   NOT mocks of internal code, mirroring test_compile_dispatch.py): with the
+   clew presentation master switch on but NO clew feed present, it must WARN on
+   stderr and still exit 0 (a decorative layer never aborts a compile).
+
+2. The flag→env contract in the three compile_*.sh scripts: ``--clew-overlay``
+   exports ``SCITEX_WRITER_CLEW_PRESENTATION=on`` (the master switch the
+   presentation layer already consumes).
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_RENDER_CLEW = _REPO_ROOT / "scripts/shell/modules/render_clew.sh"
+
+_STUB = "#!/usr/bin/env python3\nimport sys\nsys.exit(0)\n"
+
+
+def _sandbox_render_clew(tmp_path: Path) -> Path:
+    """A sandbox holding the REAL render_clew.sh + no-op stub sub-tools."""
+    modules = tmp_path / "scripts" / "shell" / "modules"
+    modules.mkdir(parents=True)
+    (modules / "render_clew.sh").write_bytes(_RENDER_CLEW.read_bytes())
+    pydir = tmp_path / "scripts" / "python"
+    pydir.mkdir(parents=True)
+    for name in ("render_clew_toggles.py", "render_clew.py"):
+        (pydir / name).write_text(_STUB)
+    return tmp_path
+
+
+def _run_render_clew(root: Path) -> subprocess.CompletedProcess:
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "PROJECT_ROOT": str(root),
+        "SCITEX_WRITER_PYTHON": sys.executable,
+        "SCITEX_WRITER_CLEW_PRESENTATION": "on",
+        # Point the clew CLI at a name that does not exist so the export step is
+        # skipped and only the missing-feed degrade path is exercised.
+        "SCITEX_WRITER_CLEW_BIN": "__no_such_clew_bin__",
+    }
+    return subprocess.run(
+        ["bash", str(root / "scripts/shell/modules/render_clew.sh")],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_missing_feed_overlay_exits_zero(tmp_path):
+    # Arrange: overlay requested (master switch on) but no clew feed on disk.
+    root = _sandbox_render_clew(tmp_path)
+    # Act
+    result = _run_render_clew(root)
+    # Assert
+    assert result.returncode == 0
+
+
+def test_missing_feed_overlay_warns_on_stderr(tmp_path):
+    # Arrange
+    root = _sandbox_render_clew(tmp_path)
+    # Act
+    result = _run_render_clew(root)
+    # Assert
+    assert "no clew feed found" in result.stderr
+
+
+def test_present_feed_overlay_does_not_warn(tmp_path):
+    # Arrange: a non-empty clew feed exists, so no missing-feed warning fires.
+    root = _sandbox_render_clew(tmp_path)
+    feed = root / ".scitex/clew/runtime/claims.json"
+    feed.parent.mkdir(parents=True)
+    feed.write_text('{"claims": []}\n')
+    # Act
+    result = _run_render_clew(root)
+    # Assert
+    assert "no clew feed found" not in result.stderr
+
+
+@pytest.mark.parametrize(
+    "script",
+    ["compile_manuscript.sh", "compile_revision.sh", "compile_supplementary.sh"],
+)
+def test_flag_exports_master_switch(script):
+    # Arrange
+    text = (_REPO_ROOT / "scripts/shell" / script).read_text(encoding="utf-8")
+    # Act
+    wired = (
+        "--clew-overlay) clew_overlay=true" in text
+        and "export SCITEX_WRITER_CLEW_PRESENTATION=on" in text
+    )
+    # Assert
+    assert wired
+
+
+# EOF


### PR DESCRIPTION
Minor release 2.26.0 — clew provenance overlay (--clew-overlay): color claim spans by clew verification verdict with a 4-state legend, graceful degradation. Feature #262, bump #263.