### PR TITLE
feat(colophon): stamp live scitex-writer version in the clew colophon

### DIFF
--- a/00_shared/latex_styles/clew_presentation.tex
+++ b/00_shared/latex_styles/clew_presentation.tex
@@ -80,7 +80,11 @@
 \providecolor{clewException}{HTML}{8250DF}
 
 %% --- signature config (overridable before \begin{document}) ---
-\providecommand{\clewSigText}{Compiled by SciTeX Writer.}
+%% No trailing period so the tool version reads cleanly after it ("... SciTeX
+%% Writer v2.26.0"), symmetric with \clewAttestText. The " vX.Y.Z" suffix is
+%% appended by \writerVersionSuffix (see \clewSignature below), mirroring how
+%% \clewVersionSuffix appends the clew version to the attestation line.
+\providecommand{\clewSigText}{Compiled by SciTeX Writer}
 \providecommand{\clewSigURL}{https://github.com/ywatanabe1989/scitex-writer}
 \providecommand{\clewBadgeURL}{https://github.com/ywatanabe1989/scitex-clew}
 \providecommand{\clewSigIcon}{docs/scitex-icon-navy-inverted.png}
@@ -232,16 +236,28 @@
   \expandafter\IfFileExists\expandafter{\clew@sigiconpath}%
     {\raisebox{-0.25em}{\includegraphics[height=1em]{\clew@sigiconpath}}\,}{}%
   \endgroup}
-%% "Compiled by SciTeX Writer." -> writer repo, right-aligned.
+%% "Compiled by SciTeX Writer vX.Y.Z" -> writer repo, right-aligned. The version
+%% suffix MIRRORS the clew attestation line: \writerVersionSuffix appends
+%% " vX.Y.Z" from \writer@version (stamped by the compile pipeline at compile
+%% time), or nothing when unavailable (graceful fallback to a version-less line).
 \newcommand{\clewSignature}{%
   \par\vspace{0.8em}%
   {\footnotesize\color{gray}\raggedleft
-    \href{\clewSigURL}{\clewColophonIcon\clewSigText}\par}}
+    \href{\clewSigURL}{\clewColophonIcon\clewSigText\writerVersionSuffix}\par}}
 %% Tool-version suffix: " vX.Y.Z" when render_clew stamped \clew@version (from
 %% the clew export or `clew --version`); nothing when absent. \@empty test =
 %% the \providecommand{}{} fallback below.
 \newcommand{\clewVersionSuffix}{%
   \ifx\clew@version\@empty\else\ v\clew@version\fi}
+%% Writer tool-version suffix: the WRITER analog of \clewVersionSuffix. " vX.Y.Z"
+%% when the compile stamped \writer@version (compile_tex_structure.py injects the
+%% LIVE scitex-writer version via resolve_writer_version()); nothing when absent,
+%% so a standalone/pipeline-less compile degrades to "Compiled by SciTeX Writer"
+%% and NEVER breaks. Clew stamps the version that AUDITED the doc; writer stamps
+%% the version that COMPILED it -- the freshest source, not the stale vendored
+%% \ScitexWriterVersion.
+\newcommand{\writerVersionSuffix}{%
+  \ifx\writer@version\@empty\else\ v\writer@version\fi}
 %% "Provenance audited by SciTeX Clew vX.Y.Z" -> clew repo, right-aligned, same snake.
 \newcommand{\clewAttestation}{%
   {\footnotesize\color{gray}\raggedleft
@@ -303,6 +319,10 @@
 \providecommand{\clew@verified}{0}
 \providecommand{\clew@allverified}{0}
 \providecommand{\clew@version}{}
+%% Writer version fallback (empty): the compile pipeline \def's this to the LIVE
+%% scitex-writer version before \begin{document}; empty here so a standalone
+%% compile still renders "Compiled by SciTeX Writer" without a version.
+\providecommand{\writer@version}{}
 
 \makeatother
 %% EOF

--- a/scripts/python/_build_id.py
+++ b/scripts/python/_build_id.py
@@ -126,13 +126,41 @@ def register_build(
 BUILD_BLOCK_SENTINEL = "% --- scitex-writer build identifier "
 
 
-def inject_build_metadata(content: str, build_id: str) -> str:
+def _writer_version_def(writer_version: Optional[str]) -> str:
+    r"""``\def\writer@version{X}`` line (with trailing newline) for the LIVE
+    scitex-writer version, or '' when unavailable.
+
+    Mirrors clew's ``\def\clew@version`` in clew_rendered.tex: stamps the
+    version that COMPILED the document into a macro the clew presentation-layer
+    colophon reads, so it renders "Compiled by SciTeX Writer vX.Y.Z" (parallel
+    to clew's "Provenance audited by SciTeX Clew vX.Y.Z"). Fail-safe: '' when
+    the version is empty/"unknown" so the colophon degrades to a version-less
+    line and the compile is never broken. Sanitized to LaTeX-safe [0-9A-Za-z.-]
+    (never trust the string blindly), same posture as render_clew's version read.
+    """
+    v = "" if writer_version is None else str(writer_version).strip()
+    if not v or v.lower() == "unknown":
+        return ""
+    v = re.sub(r"[^0-9A-Za-z.\-]", "", v)
+    if not v:
+        return ""
+    return "\\def\\writer@version{" + v + "}\n"
+
+
+def inject_build_metadata(
+    content: str, build_id: str, writer_version: Optional[str] = None
+) -> str:
     r"""Inject ``\hypersetup{pdfsubject=build:...}`` before ``\begin{document}``.
 
     hyperref finalizes PDF /Info at ``\begin{document}``, so the metadata
     must appear before then. Also exposes ``\scitexBuildID`` and
     ``\scitexBuildIDFootnote`` macros so document templates can opt into
     a tiny footer, colophon, or watermark without further changes here.
+
+    When ``writer_version`` is given, ALSO stamps ``\def\writer@version{X}`` in
+    the same ``\makeatletter`` block so the clew presentation-layer colophon can
+    append " vX.Y.Z" to "Compiled by SciTeX Writer" (mirrors clew's
+    ``\clew@version``). Always-on + fail-safe (see ``_writer_version_def``).
     """
     # Match the REAL document-body marker at line start, not a \begin{document}
     # appearing inside a comment (e.g. clew_presentation.tex's "overridable
@@ -163,6 +191,7 @@ def inject_build_metadata(content: str, build_id: str) -> str:
         + "pdfkeywords={scitex-writer}}%\n"
         + "  }{}%\n"
         + "}\n"
+        + _writer_version_def(writer_version)
         + "% "
         + "-" * 76
         + "\n"

--- a/scripts/python/_theme.py
+++ b/scripts/python/_theme.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
+# File: scripts/python/_theme.py
+# Purpose: Theme (light/dark) resolution for the compile flow. Extracted from
+#          compile_tex_structure.py to keep that orchestrator under the line
+#          limit; pure helpers, no public-API change.
+
+import os
+import sys
+from pathlib import Path
+
+
+def read_config_theme(base_tex: Path) -> str:
+    """Read ``theme:`` from config/config_<doctype>.yaml — returns 'light' or 'dark'.
+
+    The project root is the parent of the document dir holding base.tex (e.g.
+    ``<root>/01_manuscript/base.tex`` -> ``<root>``), matching how the
+    dark_mode.tex path is resolved in the compile flow.
+
+    Fail loud (SystemExit) on an invalid theme value so a typo cannot silently
+    render the wrong theme. A missing file / missing PyYAML / unreadable YAML
+    degrade to 'light' (the knob simply has no effect).
+    """
+    doc_type = os.getenv("SCITEX_WRITER_DOC_TYPE", "manuscript")
+    config_path = (
+        base_tex.resolve().parent.parent / "config" / f"config_{doc_type}.yaml"
+    )
+    if not config_path.exists():
+        return "light"
+    try:
+        import yaml
+    except ImportError:
+        return "light"
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError:
+        return "light"
+    theme = data.get("theme", "light")
+    theme = "light" if theme is None else str(theme).strip().lower()
+    if theme not in ("light", "dark"):
+        print(
+            f"ERROR: Invalid theme '{theme}' in {config_path.name} — "
+            f"must be 'light' or 'dark'.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    return theme
+
+
+def resolve_dark_mode(explicit_flag: bool, base_tex: Path) -> bool:
+    """Resolve effective dark mode with precedence.
+
+    ``--dark-mode`` flag > ``SCITEX_WRITER_DARK_MODE`` env > config ``theme:``
+    > light. Only a *set* (non-empty) env var short-circuits the config, so
+    ``theme: dark`` takes effect when no flag/env is supplied.
+    """
+    if explicit_flag:
+        return True
+    env = os.getenv("SCITEX_WRITER_DARK_MODE")
+    if env is not None and env.strip() != "":
+        return env.strip().lower() == "true"
+    return read_config_theme(base_tex) == "dark"
+
+
+__all__ = ["read_config_theme", "resolve_dark_mode"]
+
+# EOF

--- a/scripts/python/compile_tex_structure.py
+++ b/scripts/python/compile_tex_structure.py
@@ -34,6 +34,8 @@ from _signature_footer import (  # noqa: E402
 )
 from _tectonic_compat import apply_tectonic_compat  # noqa: E402
 from _tex_signature import generate_signature  # noqa: E402
+from _theme import read_config_theme as _read_config_theme  # noqa: E402,F401
+from _theme import resolve_dark_mode as _resolve_dark_mode  # noqa: E402
 
 # Unique marker for the inlined dark-mode block; also used as the idempotency
 # sentinel so a repeated flatten does not stack a second copy.
@@ -249,8 +251,11 @@ def compile_tex_structure(
         )
         return False
 
-    # Inject PDF metadata + \scitexBuildID macro before \begin{document}
-    expanded_content = inject_build_metadata(expanded_content, build_id)
+    # Inject PDF metadata + \scitexBuildID macro (+ the LIVE \writer@version for
+    # the clew colophon "Compiled by SciTeX Writer vX.Y.Z") before \begin{document}
+    expanded_content = inject_build_metadata(
+        expanded_content, build_id, writer_version=resolve_writer_version()
+    )
 
     # Prepend signature (now includes Build ID line)
     signature = generate_signature(source_file=base_tex, build_id=build_id)
@@ -399,58 +404,6 @@ def compile_tex_structure(
         return False
 
 
-def _read_config_theme(base_tex: Path) -> str:
-    """Read ``theme:`` from config/config_<doctype>.yaml — returns 'light' or 'dark'.
-
-    The project root is the parent of the document dir holding base.tex (e.g.
-    ``<root>/01_manuscript/base.tex`` -> ``<root>``), matching how the
-    dark_mode.tex path is resolved above.
-
-    Fail loud (SystemExit) on an invalid theme value so a typo cannot silently
-    render the wrong theme. A missing file / missing PyYAML / unreadable YAML
-    degrade to 'light' (the knob simply has no effect).
-    """
-    doc_type = os.getenv("SCITEX_WRITER_DOC_TYPE", "manuscript")
-    config_path = (
-        base_tex.resolve().parent.parent / "config" / f"config_{doc_type}.yaml"
-    )
-    if not config_path.exists():
-        return "light"
-    try:
-        import yaml
-    except ImportError:
-        return "light"
-    try:
-        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
-    except yaml.YAMLError:
-        return "light"
-    theme = data.get("theme", "light")
-    theme = "light" if theme is None else str(theme).strip().lower()
-    if theme not in ("light", "dark"):
-        print(
-            f"ERROR: Invalid theme '{theme}' in {config_path.name} — "
-            f"must be 'light' or 'dark'.",
-            file=sys.stderr,
-        )
-        raise SystemExit(2)
-    return theme
-
-
-def _resolve_dark_mode(explicit_flag: bool, base_tex: Path) -> bool:
-    """Resolve effective dark mode with precedence.
-
-    ``--dark-mode`` flag > ``SCITEX_WRITER_DARK_MODE`` env > config ``theme:``
-    > light. Only a *set* (non-empty) env var short-circuits the config, so
-    ``theme: dark`` takes effect when no flag/env is supplied.
-    """
-    if explicit_flag:
-        return True
-    env = os.getenv("SCITEX_WRITER_DARK_MODE")
-    if env is not None and env.strip() != "":
-        return env.strip().lower() == "true"
-    return _read_config_theme(base_tex) == "dark"
-
-
 def main():
     """Command-line interface."""
     import os
@@ -489,7 +442,7 @@ def main():
         or os.getenv("SCITEX_WRITER_SELECTED_ENGINE", "") == "tectonic"
     )
     # Project root holds ./config.yaml (same tier the _severity resolver reads).
-    # It is base_tex's document-dir parent, matching _read_config_theme above.
+    # It is base_tex's document-dir parent, matching _theme.read_config_theme.
     project_dir = args.base_tex.resolve().parent.parent
     signature_footer = resolve_signature_footer_enabled(
         args.signature_footer, project_dir

--- a/tests/scripts/python/test_build_id.py
+++ b/tests/scripts/python/test_build_id.py
@@ -25,7 +25,9 @@ _CONTENT = (
 
 def test_comment_with_begin_document_is_untouched():
     # Arrange
-    original_comment = "%% --- signature config (overridable before \\begin{document}) ---"
+    original_comment = (
+        "%% --- signature config (overridable before \\begin{document}) ---"
+    )
     # Act
     out = inject_build_metadata(_CONTENT, "abc123")
     # Assert
@@ -52,7 +54,9 @@ def test_metadata_injected_before_real_begin_not_in_comment():
 
 def test_noop_when_only_commented_begin_document():
     # Arrange
-    only_comment = "\\documentclass{article}\n% see \\begin{document} note\nno real marker\n"
+    only_comment = (
+        "\\documentclass{article}\n% see \\begin{document} note\nno real marker\n"
+    )
     # Act
     out = inject_build_metadata(only_comment, "abc123")
     # Assert
@@ -66,3 +70,35 @@ def test_idempotent_on_repeated_injection():
     twice = inject_build_metadata(once, "abc123")
     # Assert: no second block stacked, output unchanged the second time.
     assert (twice == once) and (twice.count("scitex-writer build identifier") == 1)
+
+
+def test_writer_version_stamped_when_provided():
+    # Arrange: a live writer version, mirroring clew's \def\clew@version.
+    # Act
+    out = inject_build_metadata(_CONTENT, "abc123", writer_version="2.26.0")
+    # Assert
+    assert "\\def\\writer@version{2.26.0}" in out
+
+
+def test_writer_version_absent_when_none():
+    # Arrange: no version supplied (default) -> colophon degrades gracefully.
+    # Act
+    out = inject_build_metadata(_CONTENT, "abc123")
+    # Assert
+    assert "\\def\\writer@version" not in out
+
+
+def test_writer_version_absent_when_unknown():
+    # Arrange: an "unknown" version must NOT be stamped (fail-safe).
+    # Act
+    out = inject_build_metadata(_CONTENT, "abc123", writer_version="unknown")
+    # Assert
+    assert "\\def\\writer@version" not in out
+
+
+def test_writer_version_sanitized():
+    # Arrange: a hostile version string is stripped to LaTeX-safe [0-9A-Za-z.-].
+    # Act
+    out = inject_build_metadata(_CONTENT, "abc123", writer_version="2.26.0}\\evil")
+    # Assert
+    assert "\\def\\writer@version{2.26.0evil}" in out


### PR DESCRIPTION
## What

The compiled-PDF clew colophon rendered **"Compiled by SciTeX Writer."** with no version, while the sibling attestation line carries one (**"Provenance audited by SciTeX Clew v0.8.0"**). This adds the writer version in the same `vX.Y.Z` form, mirroring the clew mechanism.

Result (rendered demo, light + dark):

```
🐍 Compiled by SciTeX Writer v2.26.0
🐍 Provenance audited by SciTeX Clew v0.8.0
```

## Version source (the key decision)

Uses the **live** `resolve_writer_version()` (env `SCITEX_WRITER_VERSION` → `VERSION` file → `pyproject.toml [project] version`) — the version that **COMPILED** the doc (2.26.0), stamped at compile time. This is the same resolver the visible signature footer already uses, and the writer analog of how clew stamps its version at export time.

It deliberately does **not** use the static `\ScitexWriterVersion` in `00_shared/scitex_writer_version.tex`, which is a stale vendored stamp (2.13.4) written by `update-project`, not the running version.

## How (mirrors clew's `\clew@version`)

- **`clew_presentation.tex`**: drop the trailing period from `\clewSigText` and append a new `\writerVersionSuffix` (the writer analog of `\clewVersionSuffix`), gated on a `\writer@version` macro. `\providecommand{\writer@version}{}` fallback → graceful version-less "Compiled by SciTeX Writer" when unavailable; **never breaks the compile**.
- **`_build_id.inject_build_metadata`**: stamps `\def\writer@version{X}` inside its always-on `\makeatletter` pre-`\begin{document}` block (the same idiom that already injects the build id / pdf metadata), mirroring `render_clew`'s `\def\clew@version`. Version is sanitized to LaTeX-safe `[0-9A-Za-z.-]`; empty/`unknown` injects nothing.
- **`compile_tex_structure.py`**: passes `writer_version=resolve_writer_version()`.
- **`_theme.py`** (new): the `compile_tex_structure.py` orchestrator was already 1 line over the 512-line cap, so the cohesive `theme:`/dark-mode resolvers were extracted here (thin re-export keeps all call sites + tests unchanged).

## Dark mode (operator's ダークモード ask)

**Already legible — no fix needed.** On the `#1E1E1E` dark background, the colophon (both lines), all four clew overlay hexes, and the legend clear the WCAG 3.0 graphical-contrast floor; verified-green / suspect-amber / colophon-gray clear ≥4.2. Rendered dark PNG confirms (red/purple are muted but readable). Not overengineered — clew owns the palette per the scope boundary.

## Tests

4 new asserts in `test_build_id.py` (real inputs, one assert each): version stamped when provided, absent when `None`, absent when `unknown`, sanitized against injection. `76 passed`.