### PR TITLE
fix: bind registry_path before legacy-builds migration in register_build (was NameError)

### DIFF
--- a/scripts/python/_build_id.py
+++ b/scripts/python/_build_id.py
@@ -74,6 +74,7 @@ def register_build(
         # Canonical location per PS-102: regenerable data under runtime/
         registry_dir = project_root / ".scitex" / "writer" / "runtime" / "builds"
         registry_dir.mkdir(parents=True, exist_ok=True)
+        registry_path = registry_dir / "builds.json"
 
         # Back-compat: migrate legacy builds/ -> runtime/builds/ (one-time)
         legacy = project_root / ".scitex" / "writer" / "builds"
@@ -88,7 +89,6 @@ def register_build(
                 legacy.rmdir()  # succeeds only if empty after migration
             except OSError:
                 pass
-        registry_path = registry_dir / "builds.json"
 
         entry = {
             "build_id": build_id,

--- a/tests/scripts/python/test_build_id.py
+++ b/tests/scripts/python/test_build_id.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 # Test file for: _build_id.py (inject_build_metadata \begin{document} anchoring)
 
+import json
 import sys
 from pathlib import Path
 
@@ -9,7 +10,7 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
 
-from _build_id import inject_build_metadata  # noqa: E402
+from _build_id import inject_build_metadata, register_build  # noqa: E402
 
 # A preamble comment whose text contains \begin{document} (e.g. clew's
 # "overridable before \begin{document})"), appearing BEFORE the real marker.
@@ -102,3 +103,21 @@ def test_writer_version_sanitized():
     out = inject_build_metadata(_CONTENT, "abc123", writer_version="2.26.0}\\evil")
     # Assert
     assert "\\def\\writer@version{2.26.0evil}" in out
+
+
+def test_legacy_builds_migrated_to_runtime(tmp_path):
+    # Arrange: a project_root with a legacy .scitex/writer/builds/builds.json.
+    legacy_dir = tmp_path / ".scitex" / "writer" / "builds"
+    legacy_dir.mkdir(parents=True)
+    legacy_record = {"builds": [{"build_id": "legacy1", "doc_type": "manuscript"}]}
+    (legacy_dir / "builds.json").write_text(json.dumps(legacy_record))
+    # Act: register a new build (previously raised NameError, silently swallowed).
+    register_build("new123", "manuscript", Path("out.tex"), project_root=tmp_path)
+    # Assert: legacy record survives in the runtime location.
+    runtime_json = (
+        tmp_path / ".scitex" / "writer" / "runtime" / "builds" / "builds.json"
+    )
+    migrated_ids = [
+        b["build_id"] for b in json.loads(runtime_json.read_text())["builds"]
+    ]
+    assert "legacy1" in migrated_ids


### PR DESCRIPTION
## Problem
In \`scripts/python/_build_id.py\`, \`register_build()\` referenced the local \`registry_path\` inside the legacy→runtime migration branch (\`registry_path.exists()\`, \`legacy_json.rename(registry_path)\`) BEFORE \`registry_path = registry_dir / "builds.json"\` was assigned (that assignment lived after the block).

Result: when a project has a legacy \`.scitex/writer/builds/\` dir, the migration raised \`NameError: name 'registry_path' is not defined\`. Because the whole body is a best-effort \`try/except\` returning \`None\`, the error was silently swallowed — the legacy \`builds.json\` was never migrated and the build record was lost for that call.

## Fix (minimal, root-cause)
Move the \`registry_path = registry_dir / "builds.json"\` assignment to immediately after \`registry_dir.mkdir(...)\`, so it is bound before any use. Removed the now-duplicate later assignment. No other logic changed.

## Test
Added \`test_legacy_builds_migrated_to_runtime\` to \`tests/scripts/python/test_build_id.py\`: sets up a tmp project_root with a legacy \`.scitex/writer/builds/builds.json\` sample record, calls \`register_build()\`, and asserts the legacy record now lives in the runtime location \`.scitex/writer/runtime/builds/builds.json\` (fails with NameError on the old code).

Full file: 10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)