### PR TITLE
feat(clew): per-page bottom-right Writer footer + top-of-doc provenance intro (redesign A/B, stage 1)

### DIFF
--- a/00_shared/latex_styles/clew_presentation.tex
+++ b/00_shared/latex_styles/clew_presentation.tex
@@ -58,6 +58,9 @@
 \newif\ifclewpreslegend
 \newif\ifclewpresattest      % "Provenance checked by SciTeX Clew." line
 \newif\ifclewpresexplainer   % renderable clew explainer section
+\newif\ifclewpresintro       % top-of-document "Provenance marks" intro section
+                             % (auto-injected after \end{frontmatter} by the
+                             % compile pipeline). Replaces the old bottom legend.
 \newif\ifclewpreslegendfirst % opt-in: emit \clewLegend at the TOP of page 1
                              % (config key legend_first). Independent of
                              % \ifclewpreslegend (end-of-doc) and NOT in the
@@ -297,19 +300,56 @@
       \end{minipage}}\par\medskip
   \fi}
 
-%% Auto-placement: badge (+ opt-in legend_first) at top; legend, signature +
-%% attestation at the end.
-%% Manual macros (\clewVerifiedBadge, \clewExplainer, ...) stay available for
-%% explicit placement.
+%% --- clew provenance INTRO section (replaces the old bottom legend) ---
+%% A top-of-document boxed callout that EXPLAINS the four provenance statuses
+%% with a worked, self-demonstrating example of each -- reusing \clewLabel so
+%% each status word is shown in its own marker color/wavy underline, plus the
+%% \clewExplainerBody prose. This is the explainer content PROMOTED to a
+%% document-start section: the compile pipeline auto-injects \clewIntro right
+%% after \end{frontmatter} (else after \begin{document}) when the `intro`
+%% toggle is on, so a reader meets the legend at the TOP of the paper instead
+%% of a cryptic key buried at the bottom. Gated by the toggle so an explicit
+%% call is a no-op when off. Dependency-light (no tcolorbox) -- same layout
+%% family as \clewExplainer so the demo compiles unchanged.
+\newcommand{\clewIntro}{%
+  \ifclewpresintro
+    \par\medskip\noindent
+    \fcolorbox{gray}{gray!6!white}{%
+      \begin{minipage}{\dimexpr\linewidth-2\fboxsep-2\fboxrule\relax}
+        \small
+        {\bfseries Provenance marks}\par\smallskip
+        \clewExplainerBody\par\smallskip
+        \begin{itemize}\setlength{\itemsep}{2pt}\setlength{\parsep}{0pt}%
+          \item \clewLabel{clewVerified}{verified} --
+                the value matches the analysis output that produced it.
+          \item \clewLabel{clewSuspect}{suspect} --
+                the source drifted since it was last checked; re-verify.
+          \item \clewLabel{clewUnverified}{failed} --
+                the value does not match its recorded source.
+          \item \clewLabel{clewException}{exception} --
+                verification could not be run for this value.
+        \end{itemize}
+      \end{minipage}}\par\medskip
+  \fi}
+
+%% Auto-placement: badge (+ opt-in legend_first) at top; attestation at the end.
+%% Manual macros (\clewVerifiedBadge, \clewExplainer, \clewLegend, \clewIntro,
+%% \clewSignature, ...) stay available for explicit placement.
 %% legend_first reuses \clewLegend UNCHANGED, auto-placed at page-1 top (before
-%% the badge). Opt-in and NOT in the master set, so it never double-renders with
-%% the end-of-doc \ifclewpreslegend.
+%% the badge). Opt-in and NOT in the master set, so it never double-renders.
+%%
+%% NOTE (redesign A/B): the Writer signature is NO LONGER auto-placed here.
+%% \clewSignature stays defined for back-compat, but the "Compiled by SciTeX
+%% Writer vX" mark now renders as a PER-PAGE bottom-right footer, injected by
+%% the compile pipeline (signature_footer.tex) when the `signature` toggle (or
+%% the standalone SCITEX_WRITER_SIGNATURE_FOOTER opt-in) is on -- decoupled from
+%% this bottom colophon. Likewise the bottom \clewLegend is REPLACED by the
+%% top-of-document \clewIntro section (auto-injected by the pipeline); the
+%% macro stays defined for back-compat but is not auto-placed.
 \AtBeginDocument{%
   \ifclewpreslegendfirst\clewLegend\fi
   \ifclewpresbadge\par\noindent\clewVerifiedBadge\par\fi}
 \AtEndDocument{%
-  \ifclewpreslegend\clewLegend\fi
-  \ifclewpressignature\clewSignature\fi
   \ifclewpresattest\clewAttestation\fi}
 
 %% Safe fallbacks: if clew_rendered.tex was NOT input (no claims / layer off),

--- a/00_shared/latex_styles/signature_footer.tex
+++ b/00_shared/latex_styles/signature_footer.tex
@@ -15,7 +15,7 @@
 %% The __SCITEX_WRITER_VERSION__ token is substituted with the resolved writer
 %% version before this block is inlined (see _signature_footer.py).
 %%
-%% Rendering: an absolute bottom-centre overlay stamped on EVERY shipped page
+%% Rendering: an absolute bottom-RIGHT overlay stamped on EVERY shipped page
 %% via \AtBeginShipout (from atbegshi, always available -- hyperref loads it in
 %% packages.tex) + a TikZ overlay node anchored to the physical page (tikz is
 %% loaded in packages.tex). This is deliberately pagestyle-agnostic: it does
@@ -23,13 +23,18 @@
 %% existing page numbers / journal headers are preserved. The "current page"
 %% reference settles after the usual 2 compile passes (the default multi-pass
 %% build does this; a single-pass draft may misposition on the first run).
+%%
+%% Anchored bottom-RIGHT (not bottom-centre): the elsarticle \ps@pprintTitle
+%% footer centres \thepage at the bottom of the page, so a bottom-centre node
+%% would collide with the page number. anchor=south east inset from the page's
+%% south-east corner keeps the two clear of each other.
 
 \AtBeginShipout{%
   \AtBeginShipoutUpperLeft{%
     \begin{tikzpicture}[remember picture, overlay]%
-      \node[anchor=south, yshift=4pt,
+      \node[anchor=south east,
             font=\ttfamily\scriptsize, text=gray]
-        at (current page.south)
+        at ([xshift=-8mm, yshift=4pt]current page.south east)
         {Compiled by SciTeX Writer v__SCITEX_WRITER_VERSION__};%
     \end{tikzpicture}%
   }%

--- a/scripts/python/compile_tex_structure.py
+++ b/scripts/python/compile_tex_structure.py
@@ -48,6 +48,17 @@ DARK_MODE_SENTINEL = "% Dark mode styling (inlined at compile time)"
 CITATION_BANNER_ARTIFACT = ".scitex/writer/.citation_banner.tex"
 CITATION_BANNER_SENTINEL = "scitex-writer citation banner"
 
+# Idempotency sentinel for the auto-injected clew "Provenance marks" intro
+# section (\clewIntro), placed near document start (after \end{frontmatter},
+# else after \begin{document}) when the clew `intro` toggle is active.
+CLEW_INTRO_SENTINEL = "% SciTeX clew intro section (inlined at compile time)"
+
+# Line-anchored detectors for the clew presentation toggles that the flattened
+# content carries (the toggles file is \input via packages.tex, so a
+# \clewpres<name>true line lands in expanded_content when the toggle is on).
+_CLEW_SIGNATURE_TOGGLE_RE = re.compile(r"(?m)^\s*\\clewpressignaturetrue\b")
+_CLEW_INTRO_TOGGLE_RE = re.compile(r"(?m)^\s*\\clewpresintrotrue\b")
+
 
 def _is_style_input(input_file: str) -> bool:
     r"""True if an \input target is a preamble style file (latex_styles/)."""
@@ -363,23 +374,50 @@ def compile_tex_structure(
                 count=1,
             )
 
-    # Inject the OPT-IN visible signature footer before \begin{document} (same
-    # idiom as dark mode). Default OFF -> no injection -> default compiles stay
-    # byte-identical. Idempotent via the sentinel. DISTINCT from the always-on
-    # invisible pdfcreator metadata (00_shared/scitex_writer_version.tex).
-    if signature_footer and SIGNATURE_FOOTER_SENTINEL not in expanded_content:
+    # Inject the OPT-IN per-page bottom-right signature footer before
+    # \begin{document}. Enabled when EITHER the standalone opt-in
+    # (`signature_footer`) OR the clew-presentation `signature` toggle is active
+    # (redesign: one unified knob). DRY single-stamp: the SENTINEL guard inlines
+    # the block AT MOST ONCE even when BOTH sources are on. DISTINCT from the
+    # always-on invisible pdfcreator metadata (scitex_writer_version.tex).
+    clew_signature_on = bool(_CLEW_SIGNATURE_TOGGLE_RE.search(expanded_content))
+    if (signature_footer or clew_signature_on) and (
+        SIGNATURE_FOOTER_SENTINEL not in expanded_content
+    ):
         styles_dir = base_tex.parent.parent / "00_shared" / "latex_styles"
         version = resolve_writer_version()
         footer_injection = build_footer_injection(styles_dir, version)
         if footer_injection:
             if verbose:
-                print(f"Signature footer: enabled (scitex-writer v{version})")
+                src = "opt-in" if signature_footer else "clew signature toggle"
+                print(f"Signature footer: enabled via {src} (v{version})")
             expanded_content = re.sub(
                 r"(?m)^([ \t]*)\\begin\{document\}",
                 lambda m: footer_injection + m.group(0),
                 expanded_content,
                 count=1,
             )
+
+    # Inject the clew "Provenance marks" INTRO section near document start when
+    # the clew `intro` toggle is active: anchor on \end{frontmatter}, else fall
+    # back to just after \begin{document}. Idempotent via the sentinel; gated on
+    # the toggle so it is a no-op for a non-clew doc (\clewIntro undefined there).
+    if _CLEW_INTRO_TOGGLE_RE.search(expanded_content) and (
+        CLEW_INTRO_SENTINEL not in expanded_content
+    ):
+        intro_injection = "\n" + CLEW_INTRO_SENTINEL + "\n\\clewIntro\n"
+        if re.search(r"(?m)^([ \t]*)\\end\{frontmatter\}", expanded_content):
+            anchor = r"(?m)^([ \t]*)\\end\{frontmatter\}"
+        else:
+            anchor = r"(?m)^([ \t]*)\\begin\{document\}"
+        if verbose:
+            print(f"Clew intro: injected (anchor {anchor})")
+        expanded_content = re.sub(
+            anchor,
+            lambda m: m.group(0) + intro_injection,
+            expanded_content,
+            count=1,
+        )
 
     # Write output
     try:

--- a/scripts/python/render_clew_toggles.py
+++ b/scripts/python/render_clew_toggles.py
@@ -49,13 +49,15 @@ _KNOWN = (
     "signature",
     "attest",
     "legend_first",
+    "intro",
 )
-# The co-author-facing "full set" a master ON enables. `legend_first` is
-# DELIBERATELY excluded: master-on already enables end-of-doc `legend`, so
-# adding `legend_first` too would render the legend twice (page-1 top AND
-# end-of-doc). It is opt-in ONLY (a mapping key or the env master cannot turn
-# it on) so an author enables it knowingly.
-_MASTER_SET = ("markers", "badge", "legend", "explainer", "signature")
+# The co-author-facing "full set" a master ON enables. The redesign A/B swap:
+# the top-of-document `intro` section REPLACES the bottom `legend` in the master
+# set (legend stays a KNOWN opt-in key + \clewLegend stays defined for
+# back-compat, just no longer part of master-on). `legend_first` is DELIBERATELY
+# excluded: it would double-render the legend against an explicit end-of-doc
+# `legend`; it is opt-in ONLY so an author enables it knowingly.
+_MASTER_SET = ("markers", "badge", "explainer", "signature", "intro")
 
 
 # Config key -> LaTeX \newif stem. A \newif control sequence cannot contain an

--- a/tests/scripts/python/test__signature_footer.py
+++ b/tests/scripts/python/test__signature_footer.py
@@ -354,4 +354,68 @@ def test_flatten_omits_footer_when_off(tmp_path):
     assert SIGNATURE_FOOTER_SENTINEL not in out_tex.read_text(encoding="utf-8")
 
 
+# ============================================================================
+# redesign A/B: bottom-right anchor + clew-signature-toggle drives the footer
+# ============================================================================
+
+
+def test_real_footer_style_is_anchored_bottom_right(tmp_path):
+    """The shipped footer style anchors its TikZ node at the page south-east."""
+    # Arrange
+    real_style = ROOT_DIR / "00_shared" / "latex_styles" / "signature_footer.tex"
+    _write(tmp_path / "signature_footer.tex", real_style.read_text(encoding="utf-8"))
+    # Act
+    injection = build_footer_injection(tmp_path, "4.2.0")
+    # Assert
+    assert "anchor=south east" in injection
+
+
+def test_real_footer_style_positions_at_page_south_east(tmp_path):
+    """The node is placed relative to `current page.south east` (not .south)."""
+    # Arrange
+    real_style = ROOT_DIR / "00_shared" / "latex_styles" / "signature_footer.tex"
+    _write(tmp_path / "signature_footer.tex", real_style.read_text(encoding="utf-8"))
+    # Act
+    injection = build_footer_injection(tmp_path, "4.2.0")
+    # Assert
+    assert "current page.south east" in injection
+
+
+def _make_project_with_preamble(tmp_path, preamble):
+    """Minimal project whose base.tex carries an extra preamble line."""
+    styles = tmp_path / "00_shared" / "latex_styles"
+    real_style = ROOT_DIR / "00_shared" / "latex_styles" / "signature_footer.tex"
+    _write(styles / "signature_footer.tex", real_style.read_text(encoding="utf-8"))
+    base_tex = tmp_path / "doc" / "base.tex"
+    _write(
+        base_tex,
+        "\\documentclass{article}\n"
+        + preamble
+        + "\n\\begin{document}\nHi\\end{document}\n",
+    )
+    return base_tex
+
+
+def test_clew_signature_toggle_triggers_footer(tmp_path):
+    """clew `signature` toggle ON (opt-in OFF) still injects the footer."""
+    # Arrange
+    base_tex = _make_project_with_preamble(tmp_path, "\\clewpressignaturetrue")
+    out_tex = tmp_path / "out.tex"
+    # Act
+    _flatten(base_tex, out_tex, signature_footer=False)
+    # Assert
+    assert SIGNATURE_FOOTER_SENTINEL in out_tex.read_text(encoding="utf-8")
+
+
+def test_footer_injected_once_when_both_sources_on(tmp_path):
+    """DRY: opt-in AND clew signature toggle both ON -> the block appears once."""
+    # Arrange
+    base_tex = _make_project_with_preamble(tmp_path, "\\clewpressignaturetrue")
+    out_tex = tmp_path / "out.tex"
+    # Act
+    _flatten(base_tex, out_tex, signature_footer=True)
+    # Assert
+    assert out_tex.read_text(encoding="utf-8").count(SIGNATURE_FOOTER_SENTINEL) == 1
+
+
 # EOF

--- a/tests/scripts/python/test_clew_intro_injection.py
+++ b/tests/scripts/python/test_clew_intro_injection.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: the clew redesign A/B injection + auto-placement decoupling.
+#
+# Covers Part B (the top-of-document "Provenance marks" \clewIntro section that
+# the compile pipeline auto-injects near document start when the clew `intro`
+# toggle is active) and the auto-placement decoupling in clew_presentation.tex
+# (\clewSignature + \clewLegend are NO LONGER auto-placed at \AtEndDocument).
+#
+# Style: no mocks (STX-NM002), one behavioral assert per test (STX-TQ007),
+# explicit AAA markers (STX-TQ002). Injection is exercised through the REAL
+# flattener on a REAL minimal project under tmp_path.
+
+import os
+import re
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from compile_tex_structure import (  # noqa: E402
+    CLEW_INTRO_SENTINEL,
+    compile_tex_structure,
+)
+
+CLEW_STYLE = ROOT_DIR / "00_shared" / "latex_styles" / "clew_presentation.tex"
+
+
+def _write(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _make_base(tmp_path, body):
+    """Minimal <root>/doc/base.tex; 00_shared/latex_styles present for fallback."""
+    styles = tmp_path / "00_shared" / "latex_styles"
+    _write(styles / "signature_footer.tex", "% footer\n")
+    base_tex = tmp_path / "doc" / "base.tex"
+    _write(base_tex, body)
+    return base_tex
+
+
+def _flatten(base_tex, out_tex):
+    saved = os.environ.get("PROJECT_ROOT")
+    os.environ["PROJECT_ROOT"] = str(base_tex.parent.parent)
+    try:
+        compile_tex_structure(base_tex=base_tex, output_tex=out_tex, verbose=False)
+    finally:
+        if saved is None:
+            os.environ.pop("PROJECT_ROOT", None)
+        else:
+            os.environ["PROJECT_ROOT"] = saved
+
+
+# ============================================================================
+# intro injection: gated on the toggle, anchored near document start
+# ============================================================================
+
+
+def test_intro_injected_after_begin_document(tmp_path):
+    """intro toggle ON, no frontmatter -> \\clewIntro lands after \\begin{document}."""
+    # Arrange
+    base = _make_base(
+        tmp_path,
+        "\\documentclass{article}\n\\clewpresintrotrue\n"
+        "\\begin{document}\nHi\\end{document}\n",
+    )
+    out = tmp_path / "out.tex"
+    # Act
+    _flatten(base, out)
+    # Assert
+    assert "\\clewIntro" in out.read_text(encoding="utf-8")
+
+
+def test_intro_carries_sentinel(tmp_path):
+    """The injected intro block carries its idempotency sentinel."""
+    # Arrange
+    base = _make_base(
+        tmp_path,
+        "\\documentclass{article}\n\\clewpresintrotrue\n"
+        "\\begin{document}\nHi\\end{document}\n",
+    )
+    out = tmp_path / "out.tex"
+    # Act
+    _flatten(base, out)
+    # Assert
+    assert CLEW_INTRO_SENTINEL in out.read_text(encoding="utf-8")
+
+
+def test_intro_anchored_after_frontmatter(tmp_path):
+    """With a frontmatter, the intro is injected AFTER \\end{frontmatter}."""
+    # Arrange
+    base = _make_base(
+        tmp_path,
+        "\\documentclass{elsarticle}\n\\clewpresintrotrue\n"
+        "\\begin{document}\n\\begin{frontmatter}\n\\end{frontmatter}\n"
+        "Body\\end{document}\n",
+    )
+    out = tmp_path / "out.tex"
+    # Act
+    _flatten(base, out)
+    text = out.read_text(encoding="utf-8")
+    # Assert: the intro call appears after the frontmatter close.
+    assert text.index("\\clewIntro") > text.index("\\end{frontmatter}")
+
+
+def test_intro_absent_when_toggle_off(tmp_path):
+    """No `intro` toggle -> no \\clewIntro injected (no-op for a non-intro doc)."""
+    # Arrange
+    base = _make_base(
+        tmp_path,
+        "\\documentclass{article}\n\\begin{document}\nHi\\end{document}\n",
+    )
+    out = tmp_path / "out.tex"
+    # Act
+    _flatten(base, out)
+    # Assert
+    assert CLEW_INTRO_SENTINEL not in out.read_text(encoding="utf-8")
+
+
+def test_intro_injected_once(tmp_path):
+    """The intro block is inlined at most once (idempotent)."""
+    # Arrange
+    base = _make_base(
+        tmp_path,
+        "\\documentclass{article}\n\\clewpresintrotrue\n"
+        "\\begin{document}\nHi\\end{document}\n",
+    )
+    out = tmp_path / "out.tex"
+    # Act
+    _flatten(base, out)
+    # Assert
+    assert out.read_text(encoding="utf-8").count(CLEW_INTRO_SENTINEL) == 1
+
+
+# ============================================================================
+# auto-placement decoupling in clew_presentation.tex (static-source checks)
+# ============================================================================
+
+
+def _at_end_document_block():
+    """The body of the \\AtEndDocument{...} block in clew_presentation.tex."""
+    src = CLEW_STYLE.read_text(encoding="utf-8")
+    m = re.search(r"\\AtEndDocument\{(.*?)\}", src, re.DOTALL)
+    return m.group(1) if m else ""
+
+
+def test_at_end_document_no_longer_places_signature():
+    """The Writer signature is no longer auto-placed at end of document."""
+    # Arrange
+    block = _at_end_document_block()
+    # Act
+    # Assert
+    assert "\\clewSignature" not in block
+
+
+def test_at_end_document_no_longer_places_legend():
+    """The bottom legend is no longer auto-placed at end of document."""
+    # Arrange
+    block = _at_end_document_block()
+    # Act
+    # Assert
+    assert "\\clewLegend" not in block
+
+
+def test_signature_macro_still_defined_for_backcompat():
+    """\\clewSignature stays DEFINED (back-compat) even though it is not placed."""
+    # Arrange
+    src = CLEW_STYLE.read_text(encoding="utf-8")
+    # Act
+    # Assert
+    assert "\\newcommand{\\clewSignature}" in src
+
+
+def test_legend_macro_still_defined_for_backcompat():
+    """\\clewLegend stays DEFINED (back-compat) even though it is not placed."""
+    # Arrange
+    src = CLEW_STYLE.read_text(encoding="utf-8")
+    # Act
+    # Assert
+    assert "\\newcommand{\\clewLegend}" in src
+
+
+def test_intro_macro_defined():
+    """The new \\clewIntro macro is defined in clew_presentation.tex."""
+    # Arrange
+    src = CLEW_STYLE.read_text(encoding="utf-8")
+    # Act
+    # Assert
+    assert "\\newcommand{\\clewIntro}" in src
+
+
+# EOF

--- a/tests/scripts/python/test_render_clew_toggles.py
+++ b/tests/scripts/python/test_render_clew_toggles.py
@@ -26,15 +26,24 @@ class TestResolveToggles:
         config_value = "on"
         # Act
         toggles = resolve_toggles(config_value, None)
-        # Assert: master set on, attest off.
+        # Assert: master set on (incl. redesign `intro`), attest off.
         assert (
             toggles["markers"]
             and toggles["badge"]
-            and toggles["legend"]
+            and toggles["intro"]
             and toggles["explainer"]
             and toggles["signature"]
             and not toggles["attest"]
         )
+
+    def test_master_on_enables_intro_not_legend(self):
+        # Arrange: the redesign A/B swap -- master ON drives the top-of-doc
+        # intro, NOT the old bottom legend.
+        config_value = "on"
+        # Act
+        toggles = resolve_toggles(config_value, None)
+        # Assert
+        assert toggles["intro"] and not toggles["legend"]
 
     def test_scalar_off_disables_everything(self):
         # Arrange


### PR DESCRIPTION
Stage 1 of the operator-requested clew/writer PDF presentation redesign. Writer and Clew were shown the same way in one bottom colophon block despite differing scopes; this splits them.

## Part A — Writer signature → per-page bottom-right footer (decoupled from clew)
- `signature_footer.tex`: TikZ overlay node re-anchored from bottom-centre (which collided with the elsarticle centred page number) to `anchor=south east` at `([xshift=-8mm, yshift=4pt]current page.south east)`. Same gray `\scriptsize\ttfamily` "Compiled by SciTeX Writer v<version>".
- `clew_presentation.tex`: `\clewSignature` auto-placement removed from `\AtEndDocument` (macro kept for back-compat).
- `compile_tex_structure.py`: **unified knob** — the footer is injected when EITHER the standalone `SCITEX_WRITER_SIGNATURE_FOOTER` opt-in OR the clew-presentation `signature` toggle is active. **DRY single-stamp**: the existing `SIGNATURE_FOOTER_SENTINEL` guard means the block is inlined at most once, even when both sources are on. Non-clew docs keep the standalone opt-in unchanged.

## Part B — clew intro section replaces the bottom legend
- `clew_presentation.tex`: new `\clewIntro` macro — a top-of-document boxed "Provenance marks" callout explaining all four statuses with self-demonstrating `\clewLabel` examples (verified/suspect/failed/exception) + the explainer body. Gated by a new `intro` toggle. `\clewLegend` auto-placement removed from `\AtEndDocument` (macro kept for back-compat).
- `compile_tex_structure.py`: auto-injects `\clewIntro` after `\end{frontmatter}` (fallback: after `\begin{document}`) when `intro` is active, idempotent via a sentinel.
- `render_clew_toggles.py`: `intro` added to `_KNOWN` and `_MASTER_SET`; `legend` dropped from `_MASTER_SET` (master-on now drives the top intro, not the bottom legend).

The Clew attestation line ("Provenance audited by SciTeX Clew vX") is left in place at document end per the operator.

## Tests
Real inputs, no mocks, one assert each. New `test_clew_intro_injection.py` (10) + additions to `test__signature_footer.py` and `test_render_clew_toggles.py`. **53 passed.**

## Demo
Flattened `demo/clew_demo`-derived throwaways through the real compile pipeline (footer + intro injected), pdflatex + pymupdf → light & dark PNGs confirming: badge + intro box at top, bottom-right per-page Writer footer clear of the centred page number, no bottom legend, attestation retained.

Note: Part C (tooltips) is a later stage, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)