### PR TITLE
feat(clew): source-link emission + PDF hover tooltips on provenance marks

### DIFF
--- a/00_shared/latex_styles/clew_presentation.tex
+++ b/00_shared/latex_styles/clew_presentation.tex
@@ -50,6 +50,12 @@
 \IfFileExists{fontawesome5.sty}{\RequirePackage{fontawesome5}}{%
   \providecommand{\faCheckCircle}{[ok]}%
   \providecommand{\faExclamationTriangle}{[!]}}
+%% \pdftooltip (pdfcomment) renders the per-claim provenance tooltip on each
+%% marker. packages.tex loads pdfcomment BEFORE this style, so the real macro
+%% wins; this \providecommand is a FALLBACK so a standalone / pdfcomment-less
+%% compile degrades to the plain visible content instead of an undefined-macro
+%% error (tooltip silently dropped, marker still renders).
+\providecommand{\pdftooltip}[2]{#1}
 
 %% --- opt-in toggles (default false; clew_rendered.tex flips per config) ---
 \newif\ifclewpresmarkers
@@ -133,10 +139,35 @@
 \tl_new:N \l__clew_key_tl
 \tl_new:N \l__clew_hex_tl
 \tl_new:N \l__clew_val_tl
+\tl_new:N \l__clew_tip_tl
 \cs_new_protected:Npn \__clew_key:n #1 {
   \str_set:Nn \l_tmpa_str {#1}
   \regex_replace_all:nnN { [^a-zA-Z0-9] } {} \l_tmpa_str
   \tl_set:Nx \l__clew_key_tl { \str_use:N \l_tmpa_str }
+}
+%% \__clew_tip:nn {sanitized-key} {visible-content}: wrap the visible marker
+%% content in a \pdftooltip whose text is the claim's provenance -- its status
+%% and, when a source pointer was emitted, "status --- source: <link>". GRACEFUL
+%% degradation (mirrors the existing \cs_if_exist fallbacks): when clew@status@
+%% <key> is undefined (clew off / no data) the content renders with NO tooltip;
+%% when status IS defined but clew@link@<key> is not (claim has no link) the
+%% tooltip shows status only. #1 is passed the key tl, expanded inside the :c/:x
+%% csname lookups -- the same \use:c mechanism as \clewval/\clewmark.
+\cs_new_protected:Npn \__clew_tip:nn #1#2 {
+  \cs_if_exist:cTF { clew@status@ #1 } {
+    \tl_set:Nv \l__clew_tip_tl { clew@status@ #1 }
+    \cs_if_exist:cT { clew@link@ #1 } {
+      \tl_put_right:Nn \l__clew_tip_tl { ~---~source:~ }
+      %% :Nv (value-expansion, NOT :Nx) keeps the link's \_ / \# / \% escape
+      %% tokens INTACT so hyperref's \pdfstringdef converts them to the literal
+      %% char; x-expanding them here shatters \_ into low-level tokens ->
+      %% "Token not allowed in a PDF string" -> the char is dropped from the tip.
+      \tl_put_right:Nv \l__clew_tip_tl { clew@link@ #1 }
+    }
+    \pdftooltip {#2} { \tl_use:N \l__clew_tip_tl }
+  } {
+    #2
+  }
 }
 %% \clewval{id}: substitute the registered value (always); decorate if markers on.
 %% \legacy_if:nTF tests the LaTeX2e \ifclewpresmarkers newif from expl3.
@@ -151,7 +182,8 @@
       %% mid-value. Passing the bare \use:c macro gave \uwave one unbreakable
       %% chunk -> right-margin overflow (whereas \clewmark's literal #2 wraps).
       \tl_set:Nv \l__clew_val_tl { clew@val@ \l__clew_key_tl }
-      \exp_args:NV \clewDecorate \l__clew_val_tl
+      \__clew_tip:nn { \l__clew_key_tl }
+        { \exp_args:NV \clewDecorate \l__clew_val_tl }
     } {
       \use:c { clew@val@ \l__clew_key_tl }
     }
@@ -167,7 +199,7 @@
     \cs_if_exist:cTF { clew@hex@ \l__clew_key_tl } {
       \tl_set:Nx \l__clew_hex_tl { \use:c { clew@hex@ \l__clew_key_tl } }
       \definecolor { clewVerdict } { HTML } { \l__clew_hex_tl }
-      \clewDecorate {#2}
+      \__clew_tip:nn { \l__clew_key_tl } { \clewDecorate {#2} }
     } {
       #2
     }
@@ -186,7 +218,7 @@
     \cs_if_exist:cTF { clew@hex@ \l__clew_key_tl } {
       \tl_set:Nx \l__clew_hex_tl { \use:c { clew@hex@ \l__clew_key_tl } }
       \definecolor { clewVerdict } { HTML } { \l__clew_hex_tl }
-      \clewDecorate { \cite {#1} }
+      \__clew_tip:nn { \l__clew_key_tl } { \clewDecorate { \cite {#1} } }
     } {
       \cite {#1}
     }
@@ -204,7 +236,7 @@
     \cs_if_exist:cTF { clew@hex@ \l__clew_key_tl } {
       \tl_set:Nx \l__clew_hex_tl { \use:c { clew@hex@ \l__clew_key_tl } }
       \definecolor { clewVerdict } { HTML } { \l__clew_hex_tl }
-      \clewFigChip
+      \__clew_tip:nn { \l__clew_key_tl } { \clewFigChip }
     } { }
   } { }
 }

--- a/00_shared/latex_styles/packages.tex
+++ b/00_shared/latex_styles/packages.tex
@@ -55,6 +55,7 @@
 \usepackage[numbers]{natbib}  % numbers: numeric citations [1], [2]
 \setcitestyle{sort=false}     % Preserve citation order as written
 \usepackage{hyperref}
+\usepackage{pdfcomment}  % hyperref-compatible static-PDF tooltips (\pdftooltip) for clew provenance marks; survives pdflatex + tectonic, no shell-escape
 \usepackage{xurl}  % break long URLs / DOIs at any character so they wrap instead of overflowing the margin
 %% expansion=false is REQUIRED: font expansion is FATAL on non-scalable fonts
 %% (e.g. elsarticle) -- "pdfTeX error (font expansion): auto expansion is only

--- a/demo/clew_demo.tex
+++ b/demo/clew_demo.tex
@@ -14,6 +14,7 @@
 \usepackage{graphicx}
 \usepackage{xcolor}
 \usepackage{hyperref}
+\usepackage{pdfcomment}  % static-PDF tooltips (\pdftooltip) for the clew marks
 
 %% writer RENDERING layer (macros + toggles default off + \providecolor fallbacks)
 \input{00_shared/latex_styles/clew_presentation.tex}

--- a/demo/clew_rendered.sample.tex
+++ b/demo/clew_rendered.sample.tex
@@ -25,6 +25,7 @@
 \@namedef{clew@val@abstractstrongestpatients}{strongest patients: P03 AUC 0.82, P13 0.71, P11 0.66}
 \@namedef{clew@hex@abstractstrongestpatients}{2DA44E}
 \@namedef{clew@status@abstractstrongestpatients}{verified}
+\@namedef{clew@link@abstractstrongestpatients}{scripts/analysis/patient\_ranking.py}
 
 %% results_prospective_repro [verified]
 \@namedef{clew@val@resultsprospectiverepro}{13/15 reproduce prospectively; exact binomial p=0.0037; permutation p=0.0045}
@@ -45,11 +46,13 @@
 \@namedef{clew@val@resultsperpatientauc}{per-patient median prospective ROC-AUC 0.651, 11/15 $>$0.60}
 \@namedef{clew@hex@resultsperpatientauc}{2DA44E}
 \@namedef{clew@status@resultsperpatientauc}{verified}
+\@namedef{clew@link@resultsperpatientauc}{scripts/eval/prospective\_auc.py}
 
 %% methods_sequential_predictor [suspect -> suspect/amber color]
 \@namedef{clew@val@methodssequentialpredictor}{sequential predictor: 1452 held-out scores/arm; cohort-mean repro clinical\_only 0.686, plus\_sle 0.626}
 \@namedef{clew@hex@methodssequentialpredictor}{D29922}
 \@namedef{clew@status@methodssequentialpredictor}{suspect}
+\@namedef{clew@link@methodssequentialpredictor}{scripts/models/sequential\_predictor.py}
 
 %% discussion_effect_sizes [exception -> exception color]
 \@namedef{clew@val@discussioneffectsizes}{effect sizes small (within Cliff's $|\delta|<$0.147); Spearman $+$0.21}

--- a/scripts/python/render_clew.py
+++ b/scripts/python/render_clew.py
@@ -21,6 +21,8 @@
 #            \@namedef{clew@val@<id>}{value}      (id sanitized to [a-zA-Z0-9])
 #            \@namedef{clew@hex@<id>}{6hex}
 #            \@namedef{clew@status@<id>}{status}
+#            \@namedef{clew@link@<id>}{link}      (source path/URL, LaTeX-escaped;
+#                                                  emitted only when non-empty)
 #            \makeatother
 #
 #          Claim VALUES are emitted VERBATIM -- clew provides display-ready
@@ -114,6 +116,42 @@ def _claim_value(claim):
         "rendered_value",
         "text",
     )
+    return "" if v is None else str(v)
+
+
+# LaTeX special characters -> their escaped, display-safe forms. Unlike claim
+# VALUES (which clew emits display-ready and we pass verbatim), the link is a
+# RAW filesystem path / URL (contains _ # % ~ & $ { } etc.), so it MUST be made
+# LaTeX-safe before emission -- a bare `%` would comment out the line, a bare
+# `_` errors outside math, etc. This is the "escape consistent with how the file
+# handles other non-verbatim text" the contract calls for.
+_LATEX_ESCAPES = {
+    "\\": r"\textbackslash{}",
+    "&": r"\&",
+    "%": r"\%",
+    "$": r"\$",
+    "#": r"\#",
+    "_": r"\_",
+    "{": r"\{",
+    "}": r"\}",
+    "~": r"\textasciitilde{}",
+    "^": r"\textasciicircum{}",
+}
+
+
+def _latex_escape(text):
+    """Escape LaTeX-special characters in ``text`` (char-by-char, no re-scan of
+    the replacements) so an arbitrary path/URL is safe to emit into a TeX macro
+    body and to feed hyperref's \\pdfstringdef for the PDF tooltip string."""
+    return "".join(_LATEX_ESCAPES.get(ch, ch) for ch in text)
+
+
+def _claim_link(claim):
+    """The resolvable source pointer for a claim: ``link`` (clew's per-entry
+    source pointer -- a source_file path for value/figure claims, a scholar/doi
+    URL for citation claims), falling back to ``source_file``. Mirrors the
+    _first(...) accessor pattern. Empty string when the claim has no link."""
+    v = _first(claim, "link", "source_file")
     return "" if v is None else str(v)
 
 
@@ -255,6 +293,11 @@ def render_clew_tex(data):
         if color:
             lines.append(f"\\@namedef{{clew@hex@{cid}}}{{{color}}}")
         lines.append(f"\\@namedef{{clew@status@{cid}}}{{{verdict}}}")
+        # Source pointer (LaTeX-escaped): emitted only when the claim carries a
+        # non-empty link, so a link-less claim's tooltip degrades to status-only.
+        link = _claim_link(claim)
+        if link:
+            lines.append(f"\\@namedef{{clew@link@{cid}}}{{{_latex_escape(link)}}}")
         lines.append("")
 
     lines.append("\\makeatother")

--- a/tests/scripts/python/test_clew_demo_compile.py
+++ b/tests/scripts/python/test_clew_demo_compile.py
@@ -45,12 +45,17 @@ def _decode_tu(raw):
     return out
 
 
-@pytest.fixture(scope="module")
-def compiled_demo(tmp_path_factory):
-    """Compile demo/clew_demo.tex twice (hyperref) into a tmp dir; return the
+@pytest.fixture
+def compiled_demo(tmp_path):
+    """Compile demo/clew_demo.tex twice (hyperref) into a tmp dir; yield the
     return code plus the decompressed PDF bytes so the annotation checks can
-    inspect the tooltip widgets without depending on stream compression."""
-    out_dir = tmp_path_factory.mktemp("clewdemo")
+    inspect the tooltip widgets without depending on stream compression.
+
+    Function-scoped and yield-based on purpose: it mutates state (runs
+    pdflatex, writes files) and acquires an external resource (subprocess),
+    so a session/module fixture returning the artifact would violate
+    STX-TQ004/TQ005. tmp_path auto-cleans after each test."""
+    out_dir = tmp_path
     cmd = [
         "pdflatex",
         "-interaction=nonstopmode",
@@ -69,7 +74,7 @@ def compiled_demo(tmp_path_factory):
         expanded = out_dir / "expanded.pdf"
         doc.save(str(expanded), expand=255, deflate=False)
         raw = expanded.read_bytes()
-    return {"returncode": proc.returncode, "pdf": pdf, "raw": raw}
+    yield {"returncode": proc.returncode, "pdf": pdf, "raw": raw}
 
 
 class TestClewDemoTooltips:

--- a/tests/scripts/python/test_clew_demo_compile.py
+++ b/tests/scripts/python/test_clew_demo_compile.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: the clew tooltip smoke -- compile demo/clew_demo.tex under
+# pdflatex and assert the produced PDF carries pdfcomment \pdftooltip
+# annotations (the static-PDF provenance tooltips).
+#
+# Style: no mocks (STX-NM002) -- a REAL pdflatex compile of the REAL demo;
+# one behavioral assert per test (STX-TQ007); explicit AAA markers (STX-TQ002).
+#
+# pdfcomment's \pdftooltip emits a form-field WIDGET annotation whose /TU
+# ("user name") carries the tooltip text -- the standard mechanism for
+# static-PDF tooltips that Adobe Reader / pdf.js surface on hover. It is
+# tectonic-safe by construction (no shell-escape, hyperref-only); this smoke
+# uses pdflatex because tectonic is not present in every environment.
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+DEMO_TEX = ROOT_DIR / "demo" / "clew_demo.tex"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("pdflatex") is None, reason="pdflatex not available"
+)
+
+
+def _decode_tu(raw):
+    """Return the decoded /TU tooltip strings from a decompressed PDF byte
+    stream (literal ``(...)`` or UTF-16BE hex ``<...>`` PDF-string forms)."""
+    out = []
+    for m in re.findall(rb"/TU\s*(<[0-9A-Fa-f]+>|\([^)]*\))", raw):
+        if m.startswith(b"<"):
+            out.append(
+                bytes.fromhex(m[1:-1].decode())
+                .decode("utf-16-be", "replace")
+                .replace("﻿", "")
+            )
+        else:
+            out.append(m[1:-1].decode("latin1"))
+    return out
+
+
+@pytest.fixture(scope="module")
+def compiled_demo(tmp_path_factory):
+    """Compile demo/clew_demo.tex twice (hyperref) into a tmp dir; return the
+    return code plus the decompressed PDF bytes so the annotation checks can
+    inspect the tooltip widgets without depending on stream compression."""
+    out_dir = tmp_path_factory.mktemp("clewdemo")
+    cmd = [
+        "pdflatex",
+        "-interaction=nonstopmode",
+        "-halt-on-error",
+        f"-output-directory={out_dir}",
+        str(DEMO_TEX),
+    ]
+    proc = None
+    for _ in range(2):
+        proc = subprocess.run(cmd, cwd=ROOT_DIR, capture_output=True, text=True)
+    pdf = out_dir / "clew_demo.pdf"
+    raw = b""
+    if pdf.exists():
+        fitz = pytest.importorskip("fitz")
+        doc = fitz.open(str(pdf))
+        expanded = out_dir / "expanded.pdf"
+        doc.save(str(expanded), expand=255, deflate=False)
+        raw = expanded.read_bytes()
+    return {"returncode": proc.returncode, "pdf": pdf, "raw": raw}
+
+
+class TestClewDemoTooltips:
+    def test_pdflatex_exits_clean(self, compiled_demo):
+        # Arrange
+        rc = compiled_demo["returncode"]
+        # Act
+        clean = rc == 0
+        # Assert
+        assert clean
+
+    def test_pdf_is_produced(self, compiled_demo):
+        # Arrange
+        pdf = compiled_demo["pdf"]
+        # Act
+        exists = pdf.exists()
+        # Assert
+        assert exists
+
+    def test_pdf_contains_tooltip_widget_annotations(self, compiled_demo):
+        # Arrange: pdfcomment \pdftooltip -> /Subtype/Widget annotations.
+        raw = compiled_demo["raw"]
+        # Act
+        match = re.search(rb"/Subtype\s*/Widget", raw)
+        # Assert
+        assert match is not None
+
+    def test_tooltip_text_carries_the_source_pointer(self, compiled_demo):
+        # Arrange
+        tooltips = _decode_tu(compiled_demo["raw"])
+        # Act: at least one tooltip shows "... source: <path>".
+        has_source = any("source:" in t for t in tooltips)
+        # Assert
+        assert has_source
+
+    def test_linkless_claim_tooltip_degrades_to_status_only(self, compiled_demo):
+        # Arrange: the exception claim has no link -> status-only tooltip.
+        tooltips = _decode_tu(compiled_demo["raw"])
+        # Act
+        status_only = "exception" in tooltips
+        # Assert
+        assert status_only
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))
+
+# EOF

--- a/tests/scripts/python/test_render_clew.py
+++ b/tests/scripts/python/test_render_clew.py
@@ -460,6 +460,96 @@ class TestClewVersion:
         assert "\\def\\clew@version" not in tex
 
 
+class TestClewLinkEmission:
+    """render_clew emits \\@namedef{clew@link@<id>}{<escaped-link>} for each
+    claim carrying a non-empty `link` (source_file path / citation URL). The
+    link is a RAW path/URL, so it is LaTeX-escaped (unlike the display-ready
+    value); a claim with no link emits no link macro (tooltip degrades to
+    status-only)."""
+
+    def test_emits_link_macro_from_link_field(self):
+        # Arrange
+        data = {
+            "claims": [
+                {
+                    "claim_id": "results_repro",
+                    "status": "verified",
+                    "value": "x",
+                    "link": "scripts/eval/repro.py",
+                }
+            ]
+        }
+        # Act
+        tex = render_clew_tex(data)
+        # Assert
+        assert "\\@namedef{clew@link@resultsrepro}{scripts/eval/repro.py}" in tex
+
+    def test_link_underscore_is_latex_escaped(self):
+        # Arrange: a raw path with an underscore must be escaped (\_), not raw.
+        data = {
+            "claims": [{"claim_id": "c", "status": "verified", "link": "a/foo_bar.py"}]
+        }
+        # Act
+        tex = render_clew_tex(data)
+        # Assert
+        assert "\\@namedef{clew@link@c}{a/foo\\_bar.py}" in tex
+
+    def test_link_percent_and_hash_are_latex_escaped(self):
+        # Arrange: `%` would comment out the line and `#` errors if emitted raw.
+        data = {
+            "claims": [{"claim_id": "c", "status": "verified", "link": "a/b%c#L3.py"}]
+        }
+        # Act
+        tex = render_clew_tex(data)
+        # Assert
+        assert "\\@namedef{clew@link@c}{a/b\\%c\\#L3.py}" in tex
+
+    def test_falls_back_to_source_file_when_no_link(self):
+        # Arrange: no `link`, but a `source_file` -- the accessor falls back.
+        data = {
+            "claims": [
+                {
+                    "claim_id": "c",
+                    "status": "verified",
+                    "source_file": "scripts/src.py",
+                }
+            ]
+        }
+        # Act
+        tex = render_clew_tex(data)
+        # Assert
+        assert "\\@namedef{clew@link@c}{scripts/src.py}" in tex
+
+    def test_no_link_macro_when_claim_has_no_link(self):
+        # Arrange: neither link nor source_file -> no clew@link macro at all.
+        data = {"claims": [{"claim_id": "c", "status": "verified", "value": "x"}]}
+        # Act
+        tex = render_clew_tex(data)
+        # Assert
+        assert "\\@namedef{clew@link@c}" not in tex
+
+    def test_citation_link_url_is_emitted(self):
+        # Arrange: citation claims carry a scholar/doi URL in `link`.
+        data = {
+            "claims": [
+                {
+                    "claim_id": "Kuhlmann2018",
+                    "claim_type": "citation",
+                    "status": "verified",
+                    "verified_at": "2026-07-01T00:00:00Z",
+                    "link": "https://doi.org/10.1093/brain/awx173",
+                }
+            ]
+        }
+        # Act
+        tex = render_clew_tex(data)
+        # Assert
+        assert (
+            "\\@namedef{clew@link@Kuhlmann2018}{https://doi.org/10.1093/brain/awx173}"
+            in tex
+        )
+
+
 if __name__ == "__main__":
     import pytest
 


### PR DESCRIPTION
## Summary
Adds a "live-paper feel" to the STATIC PDF: hovering a clew-marked claim now shows its provenance — verification status plus the resolvable source pointer. Two coupled parts:

### PART B — clew@link emission (`scripts/python/render_clew.py`)
- Emits `\@namedef{clew@link@<id>}{<link>}` for each claim with a non-empty `link` (value/figure = source_file path; citation = scholar/doi URL), read via a `_first("link", "source_file")` accessor mirroring the existing pattern.
- The link is a RAW filesystem path / URL, so it is **LaTeX-escaped** char-by-char (`_ # % ~ & $ { } ^ \`) — a bare `%` would comment out the line, a bare `_` errors. VALUE emission is unchanged (stays verbatim, per the file's convention).
- A link-less claim emits **no** link macro (tooltip degrades to status-only).
- Output-contract docstring updated to list `clew@link`.

### PART C — PDF tooltips (`00_shared/latex_styles/` + demo)
- `pdfcomment` added after `hyperref` in `packages.tex` (hyperref-compatible static-PDF tooltips; survives pdflatex + tectonic; no shell-escape).
- Each clew marker wraps its visible content in `\pdftooltip` via a new expl3 helper `\__clew_tip:nn`, **threaded from the `\clewval` / `\clewmark` / `\clewcite` / `\clewfig` call sites** (where the claim id is in scope), not inside `\clewDecorate`.
- Tip text = `status --- source: <link>`; **status-only** when the claim has no link; and **no tooltip at all** when status is undefined (`\cs_if_exist` guards mirror the existing fallback pattern — never an undefined-macro error, never breaks a non-clew compile).
- A `\providecommand{\pdftooltip}` fallback keeps pdfcomment-less compiles safe.
- Value-expansion (`:Nv`, not `:Nx`) preserves the link's escape tokens so hyperref's `\pdfstringdef` converts `\_`→`_` cleanly (no "Token not allowed" warnings, real underscores in the tooltip).
- Demo sample (`demo/clew_rendered.sample.tex`) gains `clew@link` lines for a few claims (realistic source paths); `clew_demo.tex` loads pdfcomment.

## Tooltip mechanism / verification
pdfcomment's `\pdftooltip` emits a `/Subtype/Widget` form-field annotation whose `/TU` carries the tooltip text (border width 0, no visible box) — the standard static-PDF tooltip that Adobe Reader / pdf.js surface on hover. The demo compiles clean under pdflatex (2 passes, exit 0) and the PDF carries 5 tooltip widgets with the expected text, e.g. `verified — source: scripts/eval/prospective_auc.py`, plus two status-only tooltips (`unverified`, `exception`) demonstrating graceful degradation.

**Viewer caveat:** hover tooltips are viewer-dependent — Adobe Reader and pdf.js render them; some lightweight viewers do not. The mark itself always renders (colored wavy underline); the tooltip is invisible until hover.

## Tests
- `test_render_clew.py`: +6 link-emission/escaping cases (link field, `_`/`%`/`#` escaping, `source_file` fallback, absent-link → no macro, citation URL).
- `test_clew_demo_compile.py` (new): pdflatex compile smoke — clean exit, `/Subtype/Widget` tooltip annotations present, a `/TU` source pointer present, status-only degradation. Skips if pdflatex/fitz unavailable.
- Touched + related suites green: `42 passed` (render_clew + demo compile), `35 passed` (clew intro/gitroot/toggles/overlay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)