### PR TITLE
fix(build): anchor sdist excludes — wheels ship _dataclasses/config (2.26.1)

### DIFF
--- a/.github/ci/build-in-sif.sh
+++ b/.github/ci/build-in-sif.sh
@@ -67,3 +67,24 @@ test -n "$(ls -A dist 2>/dev/null)" || {
     echo "::error::python -m build produced no artifacts in dist/"
     exit 1
 }
+
+# Post-build import gate: install the freshly built wheel into a CLEAN venv and
+# import the public entrypoint. `python -m build` builds the wheel FROM the
+# sdist, so an sdist `exclude` that drops a packaged submodule (the 2.18.0–
+# 2.26.0 _dataclasses/config outage: `import scitex_writer.writer` →
+# ModuleNotFoundError on clean installs) fails HERE, before the artifact is
+# uploaded and long before publish. A clean venv (not the build --target) is
+# used so nothing on PYTHONPATH masks a missing packaged file.
+WHEEL="$(ls dist/*.whl 2>/dev/null | head -1)"
+test -n "$WHEEL" || {
+    echo "::error::no wheel in dist/ to verify"
+    exit 1
+}
+CLEANVENV="$TMPDIR/wheelcheck-venv"
+rm -rf "$CLEANVENV"
+"$PY" -m venv "$CLEANVENV"
+"$CLEANVENV/bin/python" -m pip install --upgrade pip >/dev/null
+"$CLEANVENV/bin/python" -m pip install "$WHEEL"
+"$CLEANVENV/bin/python" -c "import scitex_writer.writer; print('wheel import OK:', '$WHEEL')"
+# Name the exact submodule the outage dropped so a regression is unambiguous.
+"$CLEANVENV/bin/python" -c "from scitex_writer._dataclasses.config import WriterConfig; print('WriterConfig OK')"

--- a/.github/workflows/sdist-wheel-import-on-ubuntu-py3-12.yml
+++ b/.github/workflows/sdist-wheel-import-on-ubuntu-py3-12.yml
@@ -1,0 +1,53 @@
+name: sdist-wheel-import
+
+# Catches "the SDIST drops a packaged submodule, so the wheel built FROM it
+# imports fine from the source tree but ModuleNotFoundErrors on a clean
+# install" — the 2.18.0–2.26.0 outage where an unanchored `exclude = ["config"]`
+# stripped scitex_writer/_dataclasses/config/ from every published wheel.
+#
+# The companion `import-smoke` uses `pip install -e .`, which installs from the
+# SOURCE TREE (where the excluded files still exist) and therefore CANNOT catch
+# a broken sdist. This job builds the sdist, builds a wheel FROM that sdist, and
+# imports the wheel in a CLEAN venv — the only place the exclude actually bites.
+#
+# GitHub-hosted (like import-smoke); the self-hosted release pipeline enforces
+# the same gate inside its SIF (build-in-sif.sh) so a tag can never publish a
+# wheel that fails this check.
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+
+jobs:
+  sdist-wheel-import:
+    name: sdist-wheel-import-on-ubuntu-py3-12
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist, then a wheel FROM the sdist
+        run: |
+          python -m pip install --upgrade pip build
+          rm -rf dist
+          # `python -m build` builds the sdist, then builds the wheel from that
+          # sdist in isolation — so an sdist exclude that drops files also drops
+          # them from the wheel, exactly reproducing the published-wheel bug.
+          python -m build --outdir dist
+          echo "=== built artifacts ==="
+          ls -l dist
+      - name: Install the wheel into a clean venv and import the entrypoint
+        run: |
+          python -m venv /tmp/clean
+          /tmp/clean/bin/pip install --upgrade pip
+          # Install the BUILT wheel (not `-e .`) so only what the sdist shipped
+          # is importable.
+          /tmp/clean/bin/pip install dist/*.whl
+          /tmp/clean/bin/python -c "import scitex_writer.writer; print('import scitex_writer.writer OK')"
+          # Guard the exact submodule the outage dropped, so a regression is
+          # named rather than surfacing as a generic ImportError elsewhere.
+          /tmp/clean/bin/python -c "from scitex_writer._dataclasses.config import WriterConfig; print('WriterConfig OK')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to SciTeX Writer will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.26.1] - 2026-07-08
+
+### Fixed
+- **Broken wheels 2.18.0–2.26.0: `import scitex_writer.writer` failed on clean installs.** The sdist `exclude` pattern `"config"` was unanchored, so hatchling (gitignore semantics) also dropped `src/scitex_writer/_dataclasses/config/` — every published wheel since 2.18.0 shipped without `WriterConfig`, raising `ModuleNotFoundError` on a fresh `pip install`. Anchored all `exclude` patterns to the repo root (`"config"` → `"/config"`, etc.) so they only match the intended top-level scratch dirs. Surfaced during a scitex.ai prod outage (hub visitor-slot clones); reported by scitex-hub.
+
+### Added
+- **Release CI gate: wheel-from-sdist import smoke.** The publish workflow now builds the sdist, builds a wheel *from that sdist*, installs it into a clean venv, and asserts `import scitex_writer.writer` — so a wheel missing packaged submodules can never publish again. (The pre-existing `import-smoke` used `pip install -e .`, which installs from the source tree and structurally cannot catch a broken sdist.)
+
 ## [2.26.0] - 2026-07-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.26.0"
+version = "2.26.1"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"
@@ -119,13 +119,20 @@ include = [
     "LICENSE",
     "pyproject.toml",
 ]
+# Anchor every pattern to the repo root with a leading "/". Hatchling
+# treats an UNANCHORED name as gitignore-style "match at ANY depth", so a
+# bare "config" also excluded src/scitex_writer/_dataclasses/config/ — which
+# shipped every wheel 2.18.0–2.26.0 without WriterConfig and broke
+# `import scitex_writer.writer` on clean installs (prod outage 2026-07-08).
+# These are all top-level scratch dirs; anchoring keeps them out of the
+# sdist without reaching into the package tree.
 exclude = [
-    "00_shared",
-    "01_manuscript",
-    "02_supplementary",
-    "03_revision",
-    ".scitex",
-    "config",
+    "/00_shared",
+    "/01_manuscript",
+    "/02_supplementary",
+    "/03_revision",
+    "/.scitex",
+    "/config",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Why (priority-9 prod outage, reported by scitex-hub)

Every published wheel **2.18.0–2.26.0** ships **zero** files under `scitex_writer/_dataclasses/config/`, yet `_dataclasses/__init__.py` does `from .config import WriterConfig`. So `import scitex_writer.writer` raises `ModuleNotFoundError` on a clean `pip install`. This took down scitex.ai prod (hub visitor-slot template clones failed → all 16 slots quarantined; hub mitigated by pinning `==2.17.5`).

**Root cause:** release commit 4f69fe8 (v2.18.0) added `exclude = [..., "config"]` under `[tool.hatch.build.targets.sdist]`. Hatchling uses gitignore semantics, so the unanchored `config` also matched `src/scitex_writer/_dataclasses/config/` at depth. `python -m build` builds the wheel *from* the sdist → the wheel inherits the missing files.

## Fix

- **Anchor every sdist `exclude`** to the repo root (`"config"` → `"/config"`, etc.) so they match only the intended top-level scratch dirs, never the package tree.
- **Bump 2.26.0 → 2.26.1** + CHANGELOG.
- **Release/tag gate** (`build-in-sif.sh`): after build, install the freshly built wheel into a **clean venv** and import `scitex_writer.writer` + `WriterConfig` — a wheel missing a packaged submodule now fails **before publish**.
- **PR gate** (new `sdist-wheel-import` workflow, GitHub-hosted, on PRs to main/develop): build sdist → wheel-from-sdist → clean venv → import. The existing `import-smoke` uses `pip install -e .` (source tree) and *structurally cannot* catch a broken sdist.

## Verified locally (sac-scitex)

- Buggy `main` sdist: `_dataclasses/config/` **absent**.
- Fixed 2.26.1 sdist: ships all three `_dataclasses/config/` files.
- Clean-venv install of the 2.26.1 sdist: `import scitex_writer.writer` **OK**, `WriterConfig` **OK**.

Closes the hub-reported outage. On merge, cut tag `v2.26.1` to publish; hub bumps its pin off `==2.17.5`.