### PR TITLE
feat(editor): annotation review UI — modes, domain buttons, comment box, voice, markdown (ADR 0001)

### DIFF
--- a/src/scitex_writer/_django/frontend/src/annotation-ui.ts
+++ b/src/scitex_writer/_django/frontend/src/annotation-ui.ts
@@ -1,0 +1,276 @@
+/**
+ * App-level annotation UI for the interactive paper editor (ADR 0001, slice 2).
+ *
+ * The pen loop (L1 viewer → AnnotationStore) is the neutral core; THIS is the
+ * writer-app-specific chrome that makes it a research-review tool, kept out of
+ * `@scitex/ui` L1 on purpose (scitex-ui's #274 guidance — the domain categories
+ * are paper-review semantics, not a generic PDF concern):
+ *   - a mode switch (Read / Markup / Review),
+ *   - domain-category buttons (Claim / Issue / Citation-needed / Figure-check …),
+ *   - pen-tool buttons (highlight / box / circle / arrow / freehand),
+ *   - a per-comment box with OS voice → text (loosely-coupled Web Speech),
+ *   - Markdown export of the comment thread.
+ *
+ * It drives the viewer through a narrow structural interface (AnnotationController)
+ * so the two stay decoupled — the UI never imports the PDF component.
+ */
+
+import {
+  ANNOTATION_CATEGORIES,
+  type Annotation,
+  type AnnotationCategory,
+  type AnnotationTool,
+  CATEGORY_LABELS,
+  type EditorMode,
+} from "./annotations";
+import { createVoiceInput } from "./voice-input";
+
+/** The slice of PDFViewer the annotation UI drives (structural — keeps them decoupled). */
+export interface AnnotationController {
+  setCategory(category: AnnotationCategory): void;
+  setTool(tool: AnnotationTool): void;
+  setMode(mode: EditorMode): void;
+  annotations(): Annotation[];
+  setAnnotationText(id: string, text: string): void;
+  removeAnnotation(id: string): void;
+  exportMarkdown(title?: string): string;
+}
+
+export interface AnnotationUIOptions {
+  toolbar: HTMLElement;
+  panel: HTMLElement;
+  controller: AnnotationController;
+}
+
+export interface AnnotationUIHandle {
+  /** Wire to the viewer's onAnnotate — registers a freshly created mark. */
+  onAnnotate(annotation: Annotation): void;
+}
+
+interface ModeSpec {
+  mode: EditorMode;
+  icon: string;
+  label: string;
+}
+interface ToolSpec {
+  tool: AnnotationTool;
+  icon: string;
+  label: string;
+}
+
+const MODES: readonly ModeSpec[] = [
+  { mode: "read", icon: "fa-book-open", label: "Read" },
+  { mode: "markup", icon: "fa-pen-nib", label: "Markup" },
+  { mode: "review", icon: "fa-comments", label: "Review" },
+];
+
+const PEN_TOOLS: readonly ToolSpec[] = [
+  { tool: "highlight", icon: "fa-highlighter", label: "Highlight" },
+  { tool: "box", icon: "fa-vector-square", label: "Box" },
+  { tool: "circle", icon: "fa-circle-notch", label: "Circle" },
+  { tool: "arrow", icon: "fa-arrow-right", label: "Arrow" },
+  { tool: "freehand", icon: "fa-pen", label: "Freehand" },
+];
+
+/** FontAwesome glyph per domain category (FA6 — the template already loads it). */
+const CATEGORY_ICONS: Record<AnnotationCategory, string> = {
+  highlight: "fa-highlighter",
+  claim: "fa-flag",
+  question: "fa-circle-question",
+  issue: "fa-triangle-exclamation",
+  "citation-needed": "fa-quote-left",
+  "figure-check": "fa-image",
+  "method-check": "fa-flask",
+};
+
+function iconButton(icon: string, title: string): HTMLButtonElement {
+  const b = document.createElement("button");
+  b.type = "button";
+  b.className = "btn btn-icon btn-sm annot-btn";
+  b.title = title;
+  b.setAttribute("aria-label", title);
+  b.innerHTML = `<i class="fas ${icon}"></i>`;
+  return b;
+}
+
+export function mountAnnotationUI(opts: AnnotationUIOptions): AnnotationUIHandle {
+  const { toolbar, panel, controller } = opts;
+  let activeField: HTMLTextAreaElement | null = null;
+  let activeMic: HTMLElement | null = null;
+
+  const voice = createVoiceInput({
+    onResult: (text, isFinal) => {
+      if (!activeField || !isFinal) return;
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      const sep =
+        activeField.value && !activeField.value.endsWith(" ") ? " " : "";
+      activeField.value = activeField.value + sep + trimmed;
+      activeField.dispatchEvent(new Event("input", { bubbles: true }));
+    },
+    onStateChange: (listening) => {
+      activeMic?.classList.toggle("listening", listening);
+    },
+  });
+
+  // --- toolbar ---
+  toolbar.classList.add("annot-toolbar");
+  toolbar.replaceChildren();
+
+  const modeGroup = document.createElement("div");
+  modeGroup.className = "annot-group annot-modes";
+  const modeButtons = new Map<EditorMode, HTMLButtonElement>();
+  for (const spec of MODES) {
+    const b = iconButton(spec.icon, `${spec.label} mode`);
+    b.append(document.createTextNode(` ${spec.label}`));
+    b.addEventListener("click", () => setMode(spec.mode));
+    modeButtons.set(spec.mode, b);
+    modeGroup.appendChild(b);
+  }
+
+  const catGroup = document.createElement("div");
+  catGroup.className = "annot-group annot-cats";
+  const catButtons = new Map<AnnotationCategory, HTMLButtonElement>();
+  for (const category of ANNOTATION_CATEGORIES) {
+    const b = iconButton(CATEGORY_ICONS[category], CATEGORY_LABELS[category]);
+    b.dataset.category = category;
+    b.addEventListener("click", () => setCategory(category));
+    catButtons.set(category, b);
+    catGroup.appendChild(b);
+  }
+
+  const toolGroup = document.createElement("div");
+  toolGroup.className = "annot-group annot-tools";
+  const toolButtons = new Map<AnnotationTool, HTMLButtonElement>();
+  for (const spec of PEN_TOOLS) {
+    const b = iconButton(spec.icon, spec.label);
+    b.addEventListener("click", () => setTool(spec.tool));
+    toolButtons.set(spec.tool, b);
+    toolGroup.appendChild(b);
+  }
+
+  const exportBtn = iconButton("fa-file-arrow-down", "Export comments as Markdown");
+  exportBtn.classList.add("annot-export");
+  exportBtn.addEventListener("click", exportMarkdown);
+
+  toolbar.append(modeGroup, catGroup, toolGroup, exportBtn);
+
+  // --- panel ---
+  panel.classList.add("annot-panel");
+
+  function setMode(next: EditorMode): void {
+    controller.setMode(next);
+    for (const [mode, b] of modeButtons) b.classList.toggle("active", mode === next);
+    toolbar.dataset.mode = next;
+    panel.dataset.mode = next;
+    if (next !== "markup") voice.stop();
+  }
+
+  function setCategory(next: AnnotationCategory): void {
+    controller.setCategory(next);
+    for (const [category, b] of catButtons)
+      b.classList.toggle("active", category === next);
+  }
+
+  function setTool(next: AnnotationTool): void {
+    controller.setTool(next);
+    for (const [tool, b] of toolButtons) b.classList.toggle("active", tool === next);
+  }
+
+  function exportMarkdown(): void {
+    const md = controller.exportMarkdown();
+    const blob = new Blob([md], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "review-comments.md";
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+
+  function renderPanel(focusId?: string): void {
+    const items = controller.annotations();
+    panel.replaceChildren();
+    if (items.length === 0) {
+      const empty = document.createElement("p");
+      empty.className = "annot-empty";
+      empty.textContent =
+        "No comments yet. Mark the PDF in Markup mode to start.";
+      panel.appendChild(empty);
+      return;
+    }
+    for (const annotation of items) {
+      panel.appendChild(renderRow(annotation, annotation.id === focusId));
+    }
+  }
+
+  function renderRow(annotation: Annotation, focus: boolean): HTMLElement {
+    const row = document.createElement("div");
+    row.className = "annot-row";
+    row.dataset.category = annotation.category;
+
+    const head = document.createElement("div");
+    head.className = "annot-row-head";
+    const badge = document.createElement("span");
+    badge.className = "annot-badge";
+    badge.innerHTML = `<i class="fas ${CATEGORY_ICONS[annotation.category]}"></i> ${
+      CATEGORY_LABELS[annotation.category]
+    }`;
+    const page = document.createElement("span");
+    page.className = "annot-page";
+    page.textContent = `p.${annotation.page}`;
+    const del = iconButton("fa-trash", "Delete comment");
+    del.classList.add("annot-del");
+    del.addEventListener("click", () => {
+      controller.removeAnnotation(annotation.id);
+      renderPanel();
+    });
+    head.append(badge, page, del);
+
+    const body = document.createElement("div");
+    body.className = "annot-row-body";
+    const textarea = document.createElement("textarea");
+    textarea.className = "annot-text";
+    textarea.rows = 2;
+    textarea.placeholder = "Comment… (dictate with OS voice input or the mic)";
+    textarea.value = annotation.text;
+    textarea.addEventListener("input", () =>
+      controller.setAnnotationText(annotation.id, textarea.value),
+    );
+    textarea.addEventListener("focus", () => {
+      activeField = textarea;
+    });
+    body.appendChild(textarea);
+
+    if (voice.supported) {
+      const mic = iconButton("fa-microphone", "Dictate this comment");
+      mic.classList.add("annot-mic");
+      mic.addEventListener("click", () => {
+        activeField = textarea;
+        activeMic = mic;
+        textarea.focus();
+        voice.toggle();
+      });
+      body.appendChild(mic);
+    }
+
+    row.append(head, body);
+    if (focus) {
+      queueMicrotask(() => textarea.focus());
+    }
+    return row;
+  }
+
+  setMode("markup");
+  setCategory("highlight");
+  setTool("highlight");
+  renderPanel();
+
+  return {
+    onAnnotate(annotation) {
+      renderPanel(annotation.id);
+    },
+  };
+}

--- a/src/scitex_writer/_django/frontend/src/index.ts
+++ b/src/scitex_writer/_django/frontend/src/index.ts
@@ -15,6 +15,7 @@ import type { SectionEntry } from "./api";
 import { SectionTabs } from "./sections";
 import { countWords, mountToolbar } from "./toolbar";
 import { PDFViewer } from "./pdf-viewer";
+import { type AnnotationUIHandle, mountAnnotationUI } from "./annotation-ui";
 import { CompileController } from "./compile";
 import { InsertPanel } from "./insert-panel";
 import { DetailsPanel } from "./details-panel";
@@ -77,10 +78,29 @@ async function bootstrap(): Promise<void> {
       })
     : null;
 
-  // PDF viewer
+  // PDF viewer + annotation UI (ADR 0001). The viewer produces marks into its
+  // AnnotationStore; the UI (mode switch, domain buttons, comment box, voice,
+  // markdown export) drives it and renders the comment thread. onAnnotate is
+  // forwarded through a mutable handle so the two can be wired in either order.
   const pdfContainer = root.querySelector<HTMLElement>("#pdf-container");
-  const pdf = pdfContainer ? new PDFViewer({ container: pdfContainer }) : null;
+  let annotationUI: AnnotationUIHandle | null = null;
+  const pdf = pdfContainer
+    ? new PDFViewer({
+        container: pdfContainer,
+        onAnnotate: (annotation) => annotationUI?.onAnnotate(annotation),
+      })
+    : null;
   pdf?.renderPlaceholder();
+
+  const annotToolbar = root.querySelector<HTMLElement>("#annot-toolbar");
+  const annotPanel = root.querySelector<HTMLElement>("#annot-panel");
+  if (pdf && annotToolbar && annotPanel) {
+    annotationUI = mountAnnotationUI({
+      toolbar: annotToolbar,
+      panel: annotPanel,
+      controller: pdf,
+    });
+  }
 
   // Details right panel (Hints / Compilation / Overleaf / Prism / Project /
   // Shortcuts). Hint rows with a source location become click-to-jump anchors:

--- a/src/scitex_writer/_django/frontend/src/pdf-viewer.ts
+++ b/src/scitex_writer/_django/frontend/src/pdf-viewer.ts
@@ -28,6 +28,7 @@ import {
   type AnnotationCategory,
   AnnotationStore,
   type AnnotationTool,
+  type EditorMode,
 } from "./annotations";
 
 interface PDFViewerOptions {
@@ -147,6 +148,20 @@ export class PDFViewer {
   setTool(tool: AnnotationTool): void {
     const t = TOOL_ANN_TO_L1[tool];
     if (t) this.api.setTool(t);
+  }
+
+  /**
+   * Editor mode (ADR 0001 §2): Read/Review disable pen editing, Markup enables
+   * it. Marks keep rendering in every mode — only the pen overlay's
+   * interactivity toggles, via L1's `setInteractive` (scitex-ui-pdf-viewer-l1).
+   * Guarded with `?.` so this is a no-op until that L1 method lands, keeping the
+   * mode switch shippable in the meantime.
+   */
+  setMode(mode: EditorMode): void {
+    const interactive = mode === "markup";
+    (
+      this.api as { setInteractive?: (enabled: boolean) => void }
+    ).setInteractive?.(interactive);
   }
 
   annotations(): Annotation[] {

--- a/src/scitex_writer/_django/frontend/src/voice-input.ts
+++ b/src/scitex_writer/_django/frontend/src/voice-input.ts
@@ -1,0 +1,108 @@
+/**
+ * OS / browser voice → text — a loosely-coupled Web Speech wrapper (ADR 0001).
+ *
+ * Deliberately ZERO PDF/annotation coupling: it only turns speech into text and
+ * hands it to a callback. That keeps it a cheap future promotion into
+ * `@scitex/ui` L1 if hub ever wants dictation (scitex-ui's guidance on #274) —
+ * for now it lives writer-side with no second consumer (YAGNI).
+ *
+ * OS-level dictation already types into any <textarea>; this only adds an in-app
+ * mic button for browsers exposing SpeechRecognition, and degrades to
+ * `supported = false` (button hidden) everywhere else — it never throws.
+ */
+
+interface SpeechRecognitionAlternativeLike {
+  transcript: string;
+}
+interface SpeechRecognitionResultLike {
+  0: SpeechRecognitionAlternativeLike;
+  isFinal: boolean;
+}
+interface SpeechRecognitionEventLike {
+  resultIndex: number;
+  results: {
+    length: number;
+    [index: number]: SpeechRecognitionResultLike;
+  };
+}
+interface SpeechRecognitionLike {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null;
+  onend: (() => void) | null;
+  onerror: (() => void) | null;
+}
+type SpeechRecognitionCtor = new () => SpeechRecognitionLike;
+
+export interface VoiceInputOptions {
+  /** Fired per recognition chunk; `isFinal` marks a committed phrase. */
+  onResult: (text: string, isFinal: boolean) => void;
+  /** Fired whenever listening starts/stops (incl. auto-stop). */
+  onStateChange?: (listening: boolean) => void;
+  lang?: string;
+}
+
+export interface VoiceInputHandle {
+  readonly supported: boolean;
+  readonly listening: boolean;
+  toggle(): void;
+  stop(): void;
+}
+
+function resolveCtor(): SpeechRecognitionCtor | null {
+  const w = window as unknown as {
+    SpeechRecognition?: SpeechRecognitionCtor;
+    webkitSpeechRecognition?: SpeechRecognitionCtor;
+  };
+  return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
+}
+
+export function createVoiceInput(opts: VoiceInputOptions): VoiceInputHandle {
+  const Ctor = resolveCtor();
+  let rec: SpeechRecognitionLike | null = null;
+  let listening = false;
+
+  const setListening = (value: boolean): void => {
+    if (listening === value) return;
+    listening = value;
+    opts.onStateChange?.(value);
+  };
+
+  const stop = (): void => {
+    rec?.stop();
+    setListening(false);
+  };
+
+  const start = (): void => {
+    if (!Ctor) return;
+    rec = new Ctor();
+    rec.lang = opts.lang ?? navigator.language ?? "en-US";
+    rec.continuous = true;
+    rec.interimResults = true;
+    rec.onresult = (event) => {
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i];
+        opts.onResult(result[0].transcript, result.isFinal);
+      }
+    };
+    rec.onend = () => setListening(false);
+    rec.onerror = () => setListening(false);
+    rec.start();
+    setListening(true);
+  };
+
+  return {
+    supported: Ctor !== null,
+    get listening() {
+      return listening;
+    },
+    toggle() {
+      if (listening) stop();
+      else start();
+    },
+    stop,
+  };
+}

--- a/src/scitex_writer/_django/static/writer/css/annotations.css
+++ b/src/scitex_writer/_django/static/writer/css/annotations.css
@@ -1,0 +1,159 @@
+/* Annotation / review UI — interactive paper editor (ADR 0001, slice 2).
+ *
+ * Kept in its own file (not editor.css) so the review-tool chrome — mode
+ * switch, domain buttons, comment thread — is a focused, self-contained module,
+ * matching the writer app's CSS-variable palette (var(--accent) etc.).
+ */
+
+/* The PDF view stacks: annotation toolbar, the viewer (flex-grow), comment
+ * panel. Only #pdf-view flips to a flex column — bib/claims views stay block. */
+#pdf-view.active {
+  display: flex;
+  flex-direction: column;
+}
+#pdf-view > .pdf-container {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.annot-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  padding: 4px 8px;
+  background: var(--toolbar-bg);
+  border-bottom: 1px solid var(--border-color);
+}
+.annot-group {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding-right: 6px;
+  border-right: 1px solid var(--border-color);
+}
+.annot-group:last-of-type {
+  border-right: none;
+}
+.annot-modes .annot-btn {
+  font-size: 12px;
+}
+.annot-btn.active {
+  background: var(--accent);
+  color: #fff;
+}
+.annot-btn.active:hover {
+  color: #fff;
+}
+.annot-export {
+  margin-left: auto;
+}
+
+.annot-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 0 0 auto;
+  max-height: 38%;
+  overflow-y: auto;
+  padding: 6px;
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border-color);
+}
+#annot-panel[data-mode="read"] {
+  display: none;
+}
+.annot-empty {
+  padding: 12px;
+  color: var(--text-muted);
+  font-size: 12px;
+  text-align: center;
+}
+.annot-row {
+  padding: 6px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-left: 3px solid var(--annot-accent, var(--accent));
+  border-radius: 4px;
+}
+.annot-row[data-category="claim"] {
+  --annot-accent: #3b82f6;
+}
+.annot-row[data-category="question"] {
+  --annot-accent: #8b5cf6;
+}
+.annot-row[data-category="issue"] {
+  --annot-accent: #ef4444;
+}
+.annot-row[data-category="citation-needed"] {
+  --annot-accent: #f59e0b;
+}
+.annot-row[data-category="figure-check"] {
+  --annot-accent: #14b8a6;
+}
+.annot-row[data-category="method-check"] {
+  --annot-accent: #22c55e;
+}
+.annot-row[data-category="highlight"] {
+  --annot-accent: #eab308;
+}
+.annot-row-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.annot-badge {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.annot-badge i {
+  color: var(--annot-accent, var(--accent));
+}
+.annot-page {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.annot-del {
+  margin-left: auto;
+}
+.annot-row-body {
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+}
+.annot-text {
+  flex: 1;
+  min-height: 40px;
+  padding: 4px 6px;
+  resize: vertical;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 13px;
+}
+.annot-text:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+}
+.annot-mic.listening {
+  color: #ef4444;
+  animation: annot-pulse 1s infinite;
+}
+@keyframes annot-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .annot-mic.listening {
+    animation: none;
+  }
+}

--- a/src/scitex_writer/_django/templates/writer/editor.html
+++ b/src/scitex_writer/_django/templates/writer/editor.html
@@ -21,6 +21,7 @@
           href="{% static 'writer/favicon-180x180.png' %}">
     <link rel="stylesheet" href="{% static 'writer/assets/index.css' %}">
     <link rel="stylesheet" href="{% static 'writer/css/editor.css' %}">
+    <link rel="stylesheet" href="{% static 'writer/css/annotations.css' %}">
 {% endblock %}
 {% block worktree_title_full %}Project files{% endblock %}
 {% block worktree_data_attrs %}data-working-dir="{{ project_dir|default:'' }}"{% endblock %}
@@ -143,12 +144,16 @@
                 </div>
                 <div class="preview-content" id="preview-content">
                     <div class="preview-view active" id="pdf-view">
+                        <div class="annot-toolbar" id="annot-toolbar"></div>
                         <div class="pdf-container" id="pdf-container">
                             <div class="pdf-placeholder" id="pdf-placeholder">
                                 <p>No PDF available.</p>
                                 <p class="hint">Click Compile to generate.</p>
                             </div>
                         </div>
+                        <aside class="annot-panel"
+                               id="annot-panel"
+                               aria-label="Review comments"></aside>
                     </div>
                     <div class="preview-view" id="bib-view">
                         <div class="bib-list" id="bib-list">


### PR DESCRIPTION
Slice 2 of the interactive paper editor (ADR 0001), on top of the merged L1 pane-swap (#274) and annotation model (#273).

## What
App-level review chrome that drives the existing `PDFViewer` surface (`setCategory`/`setTool`/`setMode`/`annotations`/`setAnnotationText`/`exportMarkdown`). Kept **writer-app-specific** per scitex-ui's #274 guidance — the domain categories are paper-review semantics, not a generic PDF concern.

- **`annotation-ui.ts`** — mode switch (Read / Markup / Review), domain-category buttons (Claim / Issue / Citation-needed / Figure-check / Method-check / Question / Highlight), pen-tool buttons, per-comment box, Markdown export of the comment thread.
- **`voice-input.ts`** — loosely-coupled Web Speech → text wrapper (zero PDF/annotation coupling → cheap future L1 promotion if hub asks); degrades to a hidden mic when `SpeechRecognition` is absent. OS-level dictation types into the plain textarea regardless.
- **`pdf-viewer.ts`** — `setMode()` toggles pen interactivity via L1 `setInteractive`, guarded with `?.` so it is a no-op until [scitex-ui adds that method](https://github.com/) (marks always render; only editing toggles).
- **`index.ts`** — wire `onAnnotate` → UI, mount the toolbar/panel.
- **`editor.html` + `annotations.css`** — DOM hosts + a focused new stylesheet (deliberately NOT appended to the already-over-limit `editor.css` monolith).

## Verification
- `tsc --noEmit` (frontend typecheck) — **green** in-container.
- Runtime/visual verification needs the app running (L1 DOM + placeholder interplay) — to be exercised next.

## Follow-up
- Wire `setMode` to L1 `setInteractive` once scitex-ui merges it (tracked on `scitex-ui-pdf-viewer-l1`).

Card: `writer-editor-mvp-pane-wiring`.