### PR TITLE
fix(gui): register scitex-ui element-inspector context processor in the standalone editor

### DIFF
--- a/src/scitex_writer/_django/settings.py
+++ b/src/scitex_writer/_django/settings.py
@@ -53,6 +53,14 @@ TEMPLATES = [
         "OPTIONS": {
             "context_processors": [
                 "django.template.context_processors.request",
+                # Enables scitex-ui's element inspector (Alt+I / Ctrl+I) in the
+                # standalone editor: sets `stx_element_inspector_enabled` so the
+                # shared shell's `_element_inspector.html` partial injects the
+                # inspector script (gated on DEBUG/staff, and DEBUG defaults on
+                # for the local `scitex-writer gui` server). Without this the
+                # partial emits only its placeholder comment and Alt+I/Ctrl+I
+                # are no-ops.
+                "scitex_ui.context_processors.element_inspector",
             ],
         },
     },


### PR DESCRIPTION
The `scitex-writer gui` standalone server never loaded the shared element inspector (Alt+I / Ctrl+I no-ops): its settings.py TEMPLATES context_processors listed only `request`, so `stx_element_inspector_enabled` was always falsy and scitex-ui's `_element_inspector.html` partial emitted only its placeholder comment.

Fix: register `scitex_ui.context_processors.element_inspector`. DEBUG already defaults on for the local GUI server, so the CP sets the flag truthy and the partial injects the inspector CSS/JS.

**Verified** (served page, before → after): line was only `<!-- Element inspector … -->`; now also emits `/static/scitex_ui/css/utils/element-inspector.css` + `/static/scitex_ui/js/utils/element-inspector.js`.

Pairs with scitex-ui's Ctrl+I→toggle rebind (their #54) so Ctrl+I opens the inspector (Alt+I toggles). scitex-ui is also adding an ElementInspectorMiddleware as the ecosystem-wide zero-friction path; this explicit CP registration remains the correct immediate fix for the editor.

Operator incident (2026-07-09). Card: writer-cli-verb-standardization sibling / gui.