### PR TITLE
fix(clew): fail-loud when clew provenance wording is missing, not invented

### DIFF
--- a/00_shared/latex_styles/clew_presentation.tex
+++ b/00_shared/latex_styles/clew_presentation.tex
@@ -104,12 +104,20 @@
 \providecommand{\clewAttestText}{Provenance audited by SciTeX Clew}
 \providecommand{\clewAttestURL}{https://github.com/ywatanabe1989/scitex-clew}
 %% Clew explainer body (clew provides the CONTENT; writer provides the section
-%% layout). Sensible writer-side default until clew emits its own.
+%% layout). FAIL-LOUD default (operator incident 2026-07-07): a writer-invented
+%% prose default here once rendered into the PDF unannounced -- a No-Silent-
+%% Fallback violation (and its wording had Clew as the grammatical subject
+%% when the manuscript should be, per operator feedback). Do NOT invent
+%% replacement prose; when clew hasn't supplied its own \clewExplainerBody
+%% (via clew_rendered.tex), show a visible pending-marker + compile warning
+%% instead of guessing text on clew's behalf.
 \providecommand{\clewExplainerBody}{%
-  SciTeX Clew links every reported value to the analysis output that produced
-  it and re-verifies that link when this document is compiled. Marked values
-  carry a wavy underline coloured by verification status, plus optional
-  provenance badges.}
+  \PackageWarningNoLine{scitex-writer}{%
+    Clew provenance wording (\string\clewExplainerBody) not supplied --
+    rendering a pending-marker instead of inventing prose on clew's behalf.
+    Provide it via clew_rendered.tex (scitex-clew's export step) to show the
+    real explanation}%
+  \textit{Provenance wording pending from SciTeX Clew.}}
 
 %% Marker composition: highlight (tint of verdict) + wavy underline (verdict).
 %% ALL-LETTER names (no @): these are called from the expl3 \clewval/\clewmark


### PR DESCRIPTION
Operator incident (2026-07-07, valid): the "Provenance marks" intro/explainer section shipped a writer-invented `\clewExplainerBody` default ("SciTeX Clew links every reported value…") that silently rendered unapproved prose into the PDF whenever clew hadn't supplied its own wording via `clew_rendered.tex` — a No-Silent-Fallback violation. It also had Clew as the grammatical subject when the manuscript should be, per the operator's framing feedback.

## Fix
The default no longer invents replacement prose. When clew's wording is absent, it emits a `\PackageWarningNoLine` at compile time plus a visible **"Provenance wording pending from SciTeX Clew."** marker in the PDF, instead of guessing text on clew's behalf. Once `clew_rendered.tex` `\renewcommand`s `\clewExplainerBody` with the real (clew-authored) copy, this default is never invoked.

## Scope
Only the fail-loud **mechanism** — not new wording. The actual canonical copy is still pending from scitex-clew (blocked externally). Tracked on card `writer-clew-presentation-redesign-20260707`.

## Verification
No LaTeX engine available in-container to compile-smoke this .tex file (known constraint). Brace-balance manually verified (5 opens / 5 closes, correctly nested). CI's TeX-compile gate is the real check — holding this PR unmerged until CI confirms green.