### PR TITLE
chore(ci): migrate 4 workflows to org-level reusable callers (scitex-ai/.github)

### DIFF
--- a/.github/workflows/auto-merge-to-develop.yaml
+++ b/.github/workflows/auto-merge-to-develop.yaml
@@ -1,9 +1,10 @@
 name: auto-merge-to-develop
-# Merge green PRs that TARGET develop, the moment their checks complete.
+# PILOT: org-level reusable-workflow caller (scitex-ai/.github, 2026-07-10).
+# Triggers/permissions preserved verbatim from the prior local file.
 # GitHub reads check_suite-triggered workflows from the DEFAULT branch (main),
-# so this file lives on main but acts ONLY on PRs whose base is develop.
-# codecov + readthedocs checks are ignored (advisory). Fail-safe: if a merge
-# is blocked by branch policy the PR simply stays open.
+# so this file must stay on main, acting only on PRs whose base is develop
+# (unchanged from before). Reusable job body is byte-identical to the prior
+# local logic — mechanical extraction, no behavior change.
 on:
   check_suite:
     types: [completed]
@@ -14,36 +15,6 @@ permissions:
   pull-requests: write
 
 jobs:
-  automerge:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.check_suite.conclusion == 'success' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: merge green PRs targeting develop
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.check_suite.head_sha }}
-        run: |
-          set -uo pipefail
-          if [ -n "${HEAD_SHA:-}" ]; then
-            prs=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" --jq '.[] | select(.state=="open") | .number' 2>/dev/null || true)
-          else
-            prs=$(gh pr list --repo "$REPO" --base develop --state open --json number --jq '.[].number' 2>/dev/null || true)
-          fi
-          [ -z "${prs:-}" ] && { echo "no open PRs"; exit 0; }
-          for pr in $prs; do
-            base=$(gh pr view "$pr" --repo "$REPO" --json baseRefName --jq .baseRefName 2>/dev/null || echo "")
-            [ "$base" = "develop" ] || { echo "skip #$pr (base=$base, not develop)"; continue; }
-            draft=$(gh pr view "$pr" --repo "$REPO" --json isDraft --jq .isDraft 2>/dev/null || echo true)
-            [ "$draft" = "true" ] && continue
-            pending=$(gh pr view "$pr" --repo "$REPO" --json statusCheckRollup --jq '
-              [ .statusCheckRollup[]
-                | select(((.name // .context // "") | ascii_downcase | test("codecov|readthedocs")) | not)
-                | (.conclusion // .state // "")
-                | select(. != "SUCCESS" and . != "NEUTRAL" and . != "SKIPPED" and . != "") ] | length' 2>/dev/null || echo 1)
-            if [ "$pending" = "0" ]; then
-              gh pr merge "$pr" --repo "$REPO" --merge --admin --delete-branch && echo "MERGED #$pr -> develop" || echo "blocked #$pr"
-            else
-              echo "PR #$pr not green ($pending) — skip"
-            fi
-          done
+  call:
+    uses: scitex-ai/.github/.github/workflows/auto-merge-to-develop.yml@main
+    secrets: inherit

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,4 +1,10 @@
 name: CLA Assistant
+# PILOT: org-level reusable-workflow caller (scitex-ai/.github, 2026-07-10).
+# Triggers/permissions preserved verbatim. owner_allowlist overridden to keep
+# writer's extra allowlisted contributor (LLEmacs) — the reusable default is
+# "bot*,ywatanabe1989" only. Net addition vs before: the reusable workflow
+# also adds an owner-bypass job (direct pushes by owner_login auto-pass
+# CLAssistant) that writer's prior file didn't have.
 
 on:
   issue_comment:
@@ -13,21 +19,8 @@ permissions:
   statuses: write
 
 jobs:
-  CLAssistant:
-    runs-on: ubuntu-latest
-    steps:
-      - name: CLA Assistant
-        uses: contributor-assistant/github-action@v2.6.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-        with:
-          path-to-signatures: "signatures/cla.json"
-          path-to-document: "https://github.com/ywatanabe1989/scitex-writer/blob/main/CLA.md"
-          branch: "cla-signatures"
-          allowlist: bot*,ywatanabe1989,LLEmacs
-          custom-allsigned-prcomment: |
-            Thank you for signing the SciTeX CLA. Your contribution can now be reviewed.
-          custom-notsigned-prcomment: |
-            Please sign the [SciTeX CLA](https://github.com/ywatanabe1989/scitex-writer/blob/main/CLA.md) before your contribution can be merged.
-            Comment `I have read and agree to the SciTeX CLA.` to sign.
+  call:
+    uses: scitex-ai/.github/.github/workflows/cla.yml@main
+    with:
+      owner_allowlist: "bot*,ywatanabe1989,LLEmacs"
+    secrets: inherit

--- a/.github/workflows/import-smoke-on-ubuntu-py3-12.yml
+++ b/.github/workflows/import-smoke-on-ubuntu-py3-12.yml
@@ -1,11 +1,11 @@
 name: import-smoke
 
-# Catches "wheel installs but `import scitex_writer` blows up at runtime"
-# — separate from the full pytest suite so a broken entry-point fails
-# fast without paying for the matrix. Companion to `tests` — confirms
-# the bare package (no extras) is `pip install -e .`-able and
-# `import scitex_writer` succeeds. Catches `[project] dependencies`
-# drift that the test matrix masks because it installs `[all,dev]`.
+# PILOT: org-level reusable-workflow caller (scitex-ai/.github, 2026-07-10).
+# Catches "wheel installs but `import scitex_writer` blows up at runtime" —
+# unchanged purpose, triggers preserved verbatim. Reusable job runs on the
+# fleet-standard self-hosted Spartan runner (was ubuntu-latest here).
+#
+# New required-status-check context: "install-check / import-smoke-on-ubuntu-py3-12"
 
 on:
   push:
@@ -18,17 +18,5 @@ on:
 
 jobs:
   install-check:
-    name: import-smoke-on-ubuntu-py3-12
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install (no extras)
-        run: |
-          python -m venv .venv
-          .venv/bin/pip install --upgrade pip
-          .venv/bin/pip install -e .
-      - name: Import smoke
-        run: .venv/bin/python -c "import scitex_writer; print(scitex_writer.__version__)"
+    uses: scitex-ai/.github/.github/workflows/import-smoke.yml@main
+    secrets: inherit

--- a/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
+++ b/.github/workflows/pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
@@ -1,5 +1,16 @@
 name: tests
 
+# PILOT: org-level reusable-workflow caller (scitex-ai/.github, 2026-07-10).
+# Triggers preserved verbatim from the prior local file. The reusable job
+# runs on the fleet-standard self-hosted Spartan runner (was GitHub-hosted
+# ubuntu-latest here) — an implicit side effect of adopting the reusable
+# workflow, confirmed with scitex-dev (matches existing doctrine: CI belongs
+# on Spartan, we don't pay for hosted runners). Codecov upload is carried
+# inside the reusable job (CODECOV_TOKEN via secrets: inherit).
+#
+# New required-status-check context: "test / pytest-matrix-on-ubuntu-py<X.YY>"
+# (scitex-dev patches branch protection to match as part of this migration).
+
 on:
   push:
     branches: [main, develop]
@@ -11,40 +22,5 @@ on:
 
 jobs:
   test:
-    name: pytest-matrix-on-ubuntu-py${{ matrix.python-version }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11", "3.12", "3.13"]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          # Fallback chain: prefer [all,dev] so optional-dep code paths
-          # get exercised. Falls back to [dev] then plain editable so a
-          # packaging hiccup doesn't strand CI.
-          pip install -e ".[all,dev]" || pip install -e ".[dev]" || pip install -e .
-      - name: Run tests
-        run: |
-          pytest tests/ --cov=src/scitex_writer --cov-report=xml --cov-report=term
-      - name: Upload coverage to Codecov
-        if: always() && matrix.python-version == '3.12'
-        # Per-job HOME so the matrix legs never race on the shared
-        # ~/.gitconfig that codecov-action writes (`safe.directory`);
-        # disable_safe_directory because each job already has an
-        # isolated HOME and the codecov step owns the checkout. Carried
-        # over from io's PR #22 codecov-race fix.
-        env:
-          HOME: ${{ runner.temp }}/codecov-home-${{ matrix.python-version }}
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          fail_ci_if_error: false
-          disable_safe_directory: true
+    uses: scitex-ai/.github/.github/workflows/pytest-matrix.yml@main
+    secrets: inherit


### PR DESCRIPTION
Fleet-standard rollout (scitex-dev, ~25+ repos migrated tonight; scitex-stats #69/#70 is the reference). Replaces PR #144 (closed as superseded — full local-file copies are exactly the content-drift pattern this standard fixes).

## Migrated (confirmed mechanically identical)
- pytest-matrix-on-ubuntu-py3-11-3-12-3-13.yml
- import-smoke-on-ubuntu-py3-12.yml
- auto-merge-to-develop.yaml
- cla.yml (`owner_allowlist` overridden to keep writer's extra allowlisted contributor, `LLEmacs`)

## Deliberately NOT migrated — real writer-specific behavior
- **quality-audit**: writer's job uses `--new-only --since <base>` (ratchets pre-existing debt); the reusable version runs a full strict audit with no ratcheting. Confirmed today's full audit is clean, but the ratchet is a future safety margin, not just today's status.
- **rtd-sphinx-build**: writer's job has an infinite-loop guard, PR-only `-W` strict mode, and a bot auto-commit-back step keeping `_sphinx_html/` fresh — none of which the generic reusable version replicates.
- Also untouched (confirmed writer-specific): `sdist-wheel-import-on-ubuntu-py3-12.yml` (this session's packaging regression gate), `newb-docs-quality-on-ubuntu-latest.yml`, `pypi-publish-and-github-release-on-tag.yml`.

## Runner note
The reusable pytest-matrix/import-smoke workflows hardcode `runs-on: [self-hosted, ..., spartan-cpu]` — adopting them implicitly performs the self-hosted-runner migration too (matches existing doctrine: CI on Spartan, no paid hosted runners).

## Why draft
Org-scoped self-hosted runners (scitex-ai org, spartan-cpu label) don't exist yet — confirmed with scitex-dev, resolving a process blocker on their end. Until then these jobs would queue with no runner to pick them up. Files are correct and ready for review now; holding merge until scitex-dev confirms org runners are live AND patches develop/main branch protection for the new required-status-check contexts (their offer, to avoid a branch-protection API race).