### PR TITLE
feat(engine): list-engines verb — Python port of LaTeX engine detection

### DIFF
--- a/src/scitex_writer/_cli/commands/__init__.py
+++ b/src/scitex_writer/_cli/commands/__init__.py
@@ -25,6 +25,7 @@ from . import (  # noqa: F401
     checks,
     compile,
     deps,
+    engines,
     export,
     figures,
     gui,

--- a/src/scitex_writer/_cli/commands/engines.py
+++ b/src/scitex_writer/_cli/commands/engines.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_cli/commands/engines.py
+
+"""``list-engines`` command — which LaTeX compilation engines are available.
+
+Pure-Python introspection over ``_core._engines`` (a port of
+``scripts/shell/modules/select_compilation_engine.sh``'s detection logic).
+Read-only: it does not select an engine for a compile, only reports what is
+installed. Sibling to ``list-deps`` (same flat verb-noun house style, per §1).
+"""
+
+from __future__ import annotations
+
+import click
+
+from .._core import main_group
+from .._helpers import _emit_json
+
+# =========================================================================
+# list-engines  (flat verb-noun top-level command, per §1 — same house
+# style as list-deps / compile-manuscript / check-limits)
+# =========================================================================
+
+
+@main_group.command("list-engines")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit JSON (engine/available/version/info) instead of a table.",
+)
+def list_engines_cmd(as_json):
+    """List the LaTeX compilation engines (tectonic / latexmk / 3pass) and
+    whether each is installed on this machine.
+
+    Read-only introspection — does not affect which engine a compile picks
+    (that stays ``--engine`` / auto-detect at compile time).
+
+    \b
+    Example:
+        $ scitex-writer list-engines
+        $ scitex-writer list-engines --json
+    """
+    from ..._core._engines import list_available_engines
+
+    engines = list_available_engines()
+    if as_json:
+        _emit_json(engines)
+        return 0
+    for e in engines:
+        mark = "✓" if e["available"] else "✗"
+        version = e["version"] or ("not available" if not e["available"] else "")
+        click.echo(f"  {mark} {e['engine']:<10} ({version:<10}) {e['info']}")
+    return 0
+
+
+# EOF

--- a/src/scitex_writer/_core/_engines.py
+++ b/src/scitex_writer/_core/_engines.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_core/_engines.py
+
+"""LaTeX compilation-engine detection.
+
+Pure-Python port of ``scripts/shell/modules/select_compilation_engine.sh``'s
+detection/verification/listing logic (``auto_detect_engine`` /
+``verify_engine`` / ``get_engine_info`` / ``get_engine_version`` /
+``list_available_engines``). The compile pipeline itself still shells out to
+that bash module today -- this port is additive (the ``list-engines``
+introspection verb), not yet wired into the live compile path; swapping the
+pipeline's own detection call is a separate, compile-tested slice.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+
+#: Engine name -> (human description, binaries required to run it).
+_ENGINE_BINARIES: dict[str, tuple[str, tuple[str, ...]]] = {
+    "tectonic": ("Tectonic (Reproducible, 4-5s per compile)", ("tectonic",)),
+    "latexmk": ("latexmk (Smart incremental, 3s)", ("latexmk", "pdflatex")),
+    "3pass": ("3-pass (Guaranteed correctness, 6-7s)", ("pdflatex", "bibtex")),
+}
+
+#: Default auto-detect priority order (fastest-for-dev first, guaranteed last).
+DEFAULT_AUTO_ORDER: tuple[str, ...] = ("latexmk", "tectonic", "3pass")
+
+#: Regex to pull a dotted version number out of a `--version`/`-version` banner.
+_VERSION_RE = re.compile(r"\d+\.\d+(?:\.\d+)?")
+
+
+def verify_engine(engine: str) -> bool:
+    """True if every binary ``engine`` needs is on ``PATH``."""
+    binaries = _ENGINE_BINARIES.get(engine, (None, ()))[1]
+    return bool(binaries) and all(shutil.which(b) for b in binaries)
+
+
+def auto_detect_engine(order: tuple[str, ...] | None = None) -> str:
+    """First verified engine in ``order`` (default: env override or the
+    latexmk/tectonic/3pass priority), falling back to ``3pass`` (assumed
+    always installed alongside a LaTeX distribution)."""
+    if order is None:
+        env_order = os.environ.get("SCITEX_WRITER_AUTO_ORDER")
+        order = tuple(env_order.split()) if env_order else DEFAULT_AUTO_ORDER
+    for engine in order:
+        if verify_engine(engine):
+            return engine
+    return "3pass"
+
+
+def get_engine_info(engine: str) -> str:
+    """Human-readable one-line description of ``engine`` (empty if unknown)."""
+    return _ENGINE_BINARIES.get(engine, ("", ()))[0]
+
+
+def get_engine_version(engine: str) -> str | None:
+    """The installed version string for ``engine``, or None if unavailable /
+    unparseable. ``3pass`` has no single version (it's pdflatex+bibtex) so it
+    reports the fixed token ``"native"``, matching the shell source."""
+    if engine == "3pass":
+        return "native" if verify_engine(engine) else None
+    binary = {"tectonic": "tectonic", "latexmk": "latexmk"}.get(engine)
+    if not binary or not shutil.which(binary):
+        return None
+    flag = "--version" if engine == "tectonic" else "-version"
+    try:
+        out = subprocess.run(
+            [binary, flag], capture_output=True, text=True, timeout=5
+        ).stdout
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    match = _VERSION_RE.search(out.splitlines()[0] if out else "")
+    return match.group(0) if match else None
+
+
+def list_available_engines() -> list[dict]:
+    """Availability + version + description for every known engine, in the
+    canonical order (tectonic, latexmk, 3pass -- the shell source's order)."""
+    return [
+        {
+            "engine": engine,
+            "available": verify_engine(engine),
+            "version": get_engine_version(engine),
+            "info": get_engine_info(engine),
+        }
+        for engine in ("tectonic", "latexmk", "3pass")
+    ]
+
+
+# EOF

--- a/tests/scitex_writer/_cli/commands/test_engines.py
+++ b/tests/scitex_writer/_cli/commands/test_engines.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: src/scitex_writer/_cli/commands/engines.py
+
+"""Tests for the `scitex-writer list-engines` CLI command (real Click invocation)."""
+
+import importlib
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_writer._cli._core import main_group
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_module_exposes_list_engines_cmd():
+    # Arrange
+    name = "scitex_writer._cli.commands.engines"
+    # Act
+    module = importlib.import_module(name)
+    # Assert
+    assert hasattr(module, "list_engines_cmd")
+
+
+def test_engines_registered_on_main_group():
+    # Arrange
+    commands = main_group.commands
+    # Act
+    present = "list-engines" in commands
+    # Assert
+    assert present
+
+
+def test_engines_default_exits_zero(runner):
+    # Arrange
+    args = ["list-engines"]
+    # Act
+    result = runner.invoke(main_group, args)
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_engines_default_lists_all_three(runner):
+    # Arrange
+    args = ["list-engines"]
+    # Act
+    result = runner.invoke(main_group, args)
+    # Assert
+    assert all(e in result.output for e in ("tectonic", "latexmk", "3pass"))
+
+
+def test_engines_json_exits_zero(runner):
+    # Arrange
+    args = ["list-engines", "--json"]
+    # Act
+    result = runner.invoke(main_group, args)
+    # Assert
+    assert result.exit_code == 0
+
+
+def test_engines_json_lists_all_three_in_order(runner):
+    # Arrange
+    args = ["list-engines", "--json"]
+    # Act
+    result = runner.invoke(main_group, args)
+    payload = json.loads(result.output)
+    # Assert
+    assert [row["engine"] for row in payload] == ["tectonic", "latexmk", "3pass"]
+
+
+def test_engines_json_rows_have_available_key(runner):
+    # Arrange
+    args = ["list-engines", "--json"]
+    # Act
+    result = runner.invoke(main_group, args)
+    payload = json.loads(result.output)
+    # Assert
+    assert all(isinstance(row["available"], bool) for row in payload)

--- a/tests/scitex_writer/_core/test__engines.py
+++ b/tests/scitex_writer/_core/test__engines.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: src/scitex_writer/_core/_engines.py
+
+from scitex_writer._core._engines import (
+    DEFAULT_AUTO_ORDER,
+    auto_detect_engine,
+    get_engine_info,
+    get_engine_version,
+    list_available_engines,
+    verify_engine,
+)
+
+_KNOWN_ENGINES = ("tectonic", "latexmk", "3pass")
+
+
+def test_verify_engine_rejects_unknown_engine():
+    # Arrange
+    # Act
+    # Assert
+    assert verify_engine("not-a-real-engine") is False
+
+
+def test_verify_engine_returns_bool_for_known_engines():
+    # Arrange
+    # Act
+    results = [verify_engine(e) for e in _KNOWN_ENGINES]
+    # Assert
+    assert all(isinstance(r, bool) for r in results)
+
+
+def test_get_engine_info_known_engine_is_nonempty():
+    # Arrange
+    # Act
+    info = get_engine_info("tectonic")
+    # Assert
+    assert info
+
+
+def test_get_engine_info_unknown_engine_is_empty():
+    # Arrange
+    # Act
+    info = get_engine_info("not-a-real-engine")
+    # Assert
+    assert info == ""
+
+
+def test_get_engine_version_unknown_engine_is_none():
+    # Arrange
+    # Act
+    version = get_engine_version("not-a-real-engine")
+    # Assert
+    assert version is None
+
+
+def test_auto_detect_engine_returns_a_known_engine():
+    # Arrange
+    # Act
+    engine = auto_detect_engine()
+    # Assert
+    assert engine in _KNOWN_ENGINES
+
+
+def test_auto_detect_engine_falls_back_to_3pass_when_nothing_verifies():
+    # Arrange
+    order = ("not-a-real-engine",)
+    # Act
+    engine = auto_detect_engine(order)
+    # Assert
+    assert engine == "3pass"
+
+
+def test_default_auto_order_matches_priority_doc():
+    # Arrange
+    # Act
+    # Assert: latexmk (fastest dev) -> tectonic (fallback) -> 3pass
+    # (guaranteed), matching the shell source's SCITEX_WRITER_AUTO_ORDER default.
+    assert DEFAULT_AUTO_ORDER == ("latexmk", "tectonic", "3pass")
+
+
+def test_list_available_engines_returns_all_three():
+    # Arrange
+    # Act
+    engines = list_available_engines()
+    # Assert
+    assert [e["engine"] for e in engines] == list(_KNOWN_ENGINES)
+
+
+def test_list_available_engines_rows_have_expected_keys():
+    # Arrange
+    # Act
+    rows = list_available_engines()
+    # Assert
+    assert all({"engine", "available", "version", "info"} <= row.keys() for row in rows)


### PR DESCRIPTION
Slice 4 of the shell→Python engine wrap (`writer-engine-shell-to-python-wrap`).

## Found
The Python CLI's `--engine` flag (`_ENGINE_CHOICES`) is a bare `click.Choice` validator with NO auto-detection/verification logic in Python at all — that logic (`auto_detect_engine`/`verify_engine`/`get_engine_info`/`get_engine_version`/`list_available_engines`) only exists in `scripts/shell/modules/select_compilation_engine.sh`, which the live compile pipeline still shells into.

## What
- `_core/_engines.py` — Python port of the detection logic (`shutil.which`-based; subprocess only for `--version`/`-version` string extraction).
- `commands/engines.py` — new `list-engines` CLI verb, mirroring `list-deps`'s exact house style (flat verb-noun top-level, CLI-only — no MCP/API layer, matching `list-deps`'s own scope since both are static read-only introspection).

## Scope
Deliberately **additive only** — does NOT touch the live compile pipeline's own engine selection (`compile_manuscript.sh` still calls the bash module during an actual compile). Swapping that needs end-to-end compile testing not available in-container; scoped as a separate future slice.

## Verified
- 95/95 `_cli` + `_core` tests pass (17 new).
- Local `scitex-dev ecosystem audit-all` clean (audit-cli/mcp-tools/skills/python-apis/project all SUCC).

Card: `writer-engine-list-engines-python-port` (child of `writer-engine-shell-to-python-wrap`).