### PR TITLE
feat(compile): fail-loud guard for contents/latex_styles divergence

### DIFF
--- a/src/scitex_writer/_compile/_validator.py
+++ b/src/scitex_writer/_compile/_validator.py
@@ -36,6 +36,9 @@ def validate_before_compile(project_dir: Path, doc_type: str = "manuscript") -> 
        configured severity. ``off``/``warn`` never block; ``error`` raises
        before any pdflatex work. Mirrors the shell compile gate so the API and
        ``./compile.sh`` paths enforce identically.
+    4. ``contents/latex_styles`` must resolve into ``00_shared/latex_styles``
+       (manuscript/supplementary). A local COPY silently breaks the claims/clew
+       provenance render (``\\IfFileExists`` paths go stale) — always an error.
 
     Parameters
     ----------
@@ -47,12 +50,14 @@ def validate_before_compile(project_dir: Path, doc_type: str = "manuscript") -> 
     Raises
     ------
     RuntimeError
-        If structure verification fails, a limit is exceeded under strict, or a
-        provenance check is at error severity with a violation.
+        If structure verification fails, a limit is exceeded under strict, a
+        provenance check is at error severity with a violation, or
+        ``contents/latex_styles`` has diverged from ``00_shared``.
     """
     verify_tree_structure(project_dir)
     _validate_limits(Path(project_dir), doc_type)
     _validate_provenance(Path(project_dir))
+    _validate_styles_symlink(Path(project_dir), doc_type)
 
 
 def _validate_limits(project_dir: Path, doc_type: str) -> None:
@@ -139,6 +144,54 @@ def _validate_provenance(project_dir: Path, runners=None) -> None:
                 f"{name} check failed at error severity — fix the violation or "
                 "lower its level (off/warn).\n" + findings
             )
+
+
+# Doc types whose contents/latex_styles is canonically a SYMLINK into
+# 00_shared. Revision is exempt: the template ships it a real local dir.
+_STYLES_SYMLINK_DOC_DIRS = {
+    "manuscript": "01_manuscript",
+    "supplementary": "02_supplementary",
+}
+
+
+def _validate_styles_symlink(project_dir: Path, doc_type: str) -> None:
+    """Fail loud when ``contents/latex_styles`` no longer resolves into
+    ``00_shared/latex_styles``.
+
+    Root cause of the neurovista provenance incident (2026-07-08): the symlink
+    was replaced by a local COPY, so the style files' relative ``../../00_shared``
+    paths went stale and every claims/clew ``\\IfFileExists`` include silently
+    skipped — provenance rendering vanished with zero diagnostics. This guard
+    turns that silent divergence into an immediate, actionable compile error.
+    """
+    doc_dir = _STYLES_SYMLINK_DOC_DIRS.get(doc_type)
+    if doc_dir is None:
+        return
+    styles = project_dir / doc_dir / "contents" / "latex_styles"
+    shared = project_dir / "00_shared" / "latex_styles"
+    if not shared.is_dir():
+        # Non-canonical layout (no 00_shared) — nothing to diverge from.
+        return
+    fix_hint = (
+        f"Fix:\n"
+        f"  rm -rf {styles}\n"
+        f"  ln -s ../../00_shared/latex_styles {styles}"
+    )
+    if styles.is_symlink() and not styles.exists():
+        raise RuntimeError(
+            f"{doc_dir}/contents/latex_styles is a BROKEN symlink "
+            f"(-> {styles.readlink()}). {fix_hint}"
+        )
+    if not styles.exists():
+        # Missing entirely is the tree-structure check's concern.
+        return
+    if styles.resolve() != shared.resolve():
+        raise RuntimeError(
+            f"{doc_dir}/contents/latex_styles must resolve into "
+            f"00_shared/latex_styles, but resolves to {styles.resolve()} — "
+            "a local copy here silently breaks claims/clew provenance "
+            f"rendering (stale ../../00_shared paths). {fix_hint}"
+        )
 
 
 __all__ = ["validate_before_compile"]

--- a/tests/scitex_writer/_compile/test__validator.py
+++ b/tests/scitex_writer/_compile/test__validator.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from scitex_writer._compile._validator import (
     _validate_provenance,
+    _validate_styles_symlink,
     validate_before_compile,
 )
 
@@ -67,6 +68,103 @@ class TestValidateProvenance:
         runners = [("media-provenance", _StubRunner(missing))]
         # Act
         result = _validate_provenance(Path("/tmp/whatever"), runners=runners)
+        # Assert
+        assert result is None
+
+
+def _make_project(tmp_path, doc_dir="01_manuscript", styles="symlink"):
+    """Build a minimal project layout for the styles-symlink guard.
+
+    ``styles``: "symlink" (canonical), "copy" (diverged local dir),
+    "broken" (dangling symlink), or "absent".
+    """
+    shared = tmp_path / "00_shared" / "latex_styles"
+    shared.mkdir(parents=True)
+    contents = tmp_path / doc_dir / "contents"
+    contents.mkdir(parents=True)
+    target = contents / "latex_styles"
+    if styles == "symlink":
+        target.symlink_to("../../00_shared/latex_styles")
+    elif styles == "copy":
+        target.mkdir()
+    elif styles == "broken":
+        target.symlink_to("../../00_shared/no_such_dir")
+    return tmp_path
+
+
+class TestValidateStylesSymlink:
+    """Test suite for the contents/latex_styles divergence guard."""
+
+    def test_canonical_symlink_passes(self, tmp_path):
+        """The template-canonical symlink into 00_shared does not raise."""
+        # Arrange
+        project = _make_project(tmp_path, styles="symlink")
+        # Act
+        result = _validate_styles_symlink(project, "manuscript")
+        # Assert
+        assert result is None
+
+    def test_local_copy_raises_runtime_error(self, tmp_path):
+        """A real local dir (the neurovista divergence) aborts the compile."""
+        # Arrange
+        project = _make_project(tmp_path, styles="copy")
+        # Act
+        # Assert
+        with pytest.raises(RuntimeError):
+            _validate_styles_symlink(project, "manuscript")
+
+    def test_local_copy_error_names_the_fix(self, tmp_path):
+        """The divergence error carries the actionable ln -s hint."""
+        # Arrange
+        project = _make_project(tmp_path, styles="copy")
+        # Act
+        with pytest.raises(RuntimeError) as excinfo:
+            _validate_styles_symlink(project, "manuscript")
+        # Assert
+        assert "ln -s ../../00_shared/latex_styles" in str(excinfo.value)
+
+    def test_broken_symlink_raises_runtime_error(self, tmp_path):
+        """A dangling latex_styles symlink aborts the compile."""
+        # Arrange
+        project = _make_project(tmp_path, styles="broken")
+        # Act
+        # Assert
+        with pytest.raises(RuntimeError):
+            _validate_styles_symlink(project, "manuscript")
+
+    def test_supplementary_copy_raises_runtime_error(self, tmp_path):
+        """The guard also covers 02_supplementary."""
+        # Arrange
+        project = _make_project(tmp_path, doc_dir="02_supplementary", styles="copy")
+        # Act
+        # Assert
+        with pytest.raises(RuntimeError):
+            _validate_styles_symlink(project, "supplementary")
+
+    def test_revision_doc_type_is_exempt(self, tmp_path):
+        """Revision ships a real local styles dir in the template — no raise."""
+        # Arrange
+        project = _make_project(tmp_path, doc_dir="03_revision", styles="copy")
+        # Act
+        result = _validate_styles_symlink(project, "revision")
+        # Assert
+        assert result is None
+
+    def test_absent_styles_path_is_skipped(self, tmp_path):
+        """Missing latex_styles is the tree check's concern, not this guard's."""
+        # Arrange
+        project = _make_project(tmp_path, styles="absent")
+        # Act
+        result = _validate_styles_symlink(project, "manuscript")
+        # Assert
+        assert result is None
+
+    def test_project_without_00_shared_is_skipped(self, tmp_path):
+        """A layout with no 00_shared has nothing to diverge from — no raise."""
+        # Arrange
+        (tmp_path / "01_manuscript" / "contents" / "latex_styles").mkdir(parents=True)
+        # Act
+        result = _validate_styles_symlink(tmp_path, "manuscript")
         # Assert
         assert result is None
 

--- a/tests/scitex_writer/_compile/test__validator.py
+++ b/tests/scitex_writer/_compile/test__validator.py
@@ -118,10 +118,9 @@ class TestValidateStylesSymlink:
         # Arrange
         project = _make_project(tmp_path, styles="copy")
         # Act
-        with pytest.raises(RuntimeError) as excinfo:
-            _validate_styles_symlink(project, "manuscript")
         # Assert
-        assert "ln -s ../../00_shared/latex_styles" in str(excinfo.value)
+        with pytest.raises(RuntimeError, match=r"ln -s \.\./\.\./00_shared/latex_styles"):
+            _validate_styles_symlink(project, "manuscript")
 
     def test_broken_symlink_raises_runtime_error(self, tmp_path):
         """A dangling latex_styles symlink aborts the compile."""


### PR DESCRIPTION
## Summary
- Pre-compile check (in `_compile/_validator.py`): `contents/latex_styles` for manuscript/supplementary must resolve into `00_shared/latex_styles`; a local copy or broken symlink raises immediately with the exact `ln -s` fix.
- Durable engine-side guard for the neurovista provenance incident (silent `\IfFileExists` skips from a diverged copy); pairs with the plain-`\input` fix as the two-sided defense.
- Revision doc type exempt (template ships a real local dir there); missing dir remains the tree-structure check's concern.
- Card: writer-styles-contents-symlink-failloud.

## Test plan
- [x] 8 new tests (canonical pass / copy raises / hint text / broken symlink / supplementary / revision exempt / absent skipped / no-00_shared skipped) — 14/14 green locally
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)