### PR TITLE
feat(clew): `\hypertarget{clew-<id>}` anchors on `\clewval`/`\clewmark`

### DIFF
--- a/00_shared/latex_styles/clew_presentation.tex
+++ b/00_shared/latex_styles/clew_presentation.tex
@@ -177,10 +177,29 @@
     #2
   }
 }
+%% \__clew_anchor:nn {sanitized-key} {raw-id}: emit the live-paper PDF anchor
+%% \hypertarget{clew-<raw-id>}{} at the claim's FIRST occurrence only. The
+%% scitex-live-paper web overlay computes its destination as 'clew-'+claim.id
+%% (byte-for-byte the claims.json id, per the 2026-07-04 contract), so the
+%% DESTINATION carries the RAW id while the one-shot flag reuses the sanitized
+%% csname key (clew@anchored@<key>) -- the same raw-dest/sanitized-lookup split
+%% \__clew_tip already relies on. Later references still color/tooltip but do
+%% not re-anchor (hyperref would warn on duplicate destinations). Namespace
+%% clew- is distinct from the legacy vclaim- anchors; both coexist. Degrades
+%% to nothing when hyperref is absent.
+\cs_new_protected:Npn \__clew_anchor:nn #1#2 {
+  \cs_if_exist:NT \hypertarget {
+    \cs_if_exist:cF { clew@anchored@ #1 } {
+      \cs_new_eq:cN { clew@anchored@ #1 } \prg_do_nothing:
+      \hypertarget { clew- \tl_to_str:n {#2} } {}
+    }
+  }
+}
 %% \clewval{id}: substitute the registered value (always); decorate if markers on.
 %% \legacy_if:nTF tests the LaTeX2e \ifclewpresmarkers newif from expl3.
 \NewDocumentCommand \clewval { m } {
   \__clew_key:n {#1}
+  \__clew_anchor:nn { \l__clew_key_tl } {#1}
   \cs_if_exist:cTF { clew@val@ \l__clew_key_tl } {
     \legacy_if:nTF { clewpresmarkers } {
       \tl_set:Nx \l__clew_hex_tl { \use:c { clew@hex@ \l__clew_key_tl } }
@@ -203,6 +222,7 @@
 %% \clewmark{id}{text}: mark author-supplied text/prose (decoration only).
 \NewDocumentCommand \clewmark { m m } {
   \__clew_key:n {#1}
+  \__clew_anchor:nn { \l__clew_key_tl } {#1}
   \legacy_if:nTF { clewpresmarkers } {
     \cs_if_exist:cTF { clew@hex@ \l__clew_key_tl } {
       \tl_set:Nx \l__clew_hex_tl { \use:c { clew@hex@ \l__clew_key_tl } }

--- a/tests/scripts/python/test_clew_presentation_anchors.py
+++ b/tests/scripts/python/test_clew_presentation_anchors.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scripts/python/test_clew_presentation_anchors.py
+
+"""Contract tests for the live-paper PDF anchors in clew_presentation.tex.
+
+The scitex-live-paper overlay locates a claim in the compiled PDF via the
+named destination ``clew-<raw claim id>`` (2026-07-04 contract). These tests
+pin the macro-source contract textually: the anchor helper exists, both
+location-marking macros (\\clewval and \\clewmark) emit it, the destination
+carries the RAW id under the ``clew-`` namespace, and re-anchoring is
+one-shot per claim. The compile behaviour itself is exercised by the
+existing pdflatex overlay smokes.
+"""
+
+from pathlib import Path
+
+import pytest
+
+_STYLES_TEX = (
+    Path(__file__).parents[3] / "00_shared" / "latex_styles" / "clew_presentation.tex"
+)
+
+
+@pytest.fixture
+def presentation_source():
+    return _STYLES_TEX.read_text()
+
+
+def test_anchor_helper_is_defined(presentation_source):
+    # Arrange
+    helper = r"\cs_new_protected:Npn \__clew_anchor:nn"
+    # Act
+    present = helper in presentation_source
+    # Assert
+    assert present
+
+
+def test_clewval_and_clewmark_both_emit_anchor(presentation_source):
+    # Arrange
+    call = r"\__clew_anchor:nn { \l__clew_key_tl } {#1}"
+    # Act
+    call_count = presentation_source.count(call)
+    # Assert
+    assert call_count == 2
+
+
+def test_destination_uses_clew_namespace_with_raw_id(presentation_source):
+    # Arrange
+    destination = r"\hypertarget { clew- \tl_to_str:n {#2} } {}"
+    # Act
+    present = destination in presentation_source
+    # Assert
+    assert present
+
+
+def test_anchor_is_one_shot_per_claim_id(presentation_source):
+    # Arrange
+    flag = "clew@anchored@"
+    # Act
+    present = flag in presentation_source
+    # Assert
+    assert present
+
+
+def test_anchor_degrades_without_hyperref(presentation_source):
+    # Arrange
+    guard = r"\cs_if_exist:NT \hypertarget"
+    # Act
+    present = guard in presentation_source
+    # Assert
+    assert present


### PR DESCRIPTION
## Summary
- New `\__clew_anchor:nn` in `clew_presentation.tex`: emits `\hypertarget{clew-<raw id>}{}` at each claim's first occurrence, from both `\clewval` and `\clewmark`.
- Raw id in the destination (live-paper computes `'clew-'+claim.id` byte-for-byte); sanitized csname key only for the one-shot `clew@anchored@` flag — the same raw/sanitized split `\__clew_tip` uses.
- One-shot per id (no hyperref duplicate-destination warnings); degrades to nothing when hyperref is absent; `clew-` namespace coexists with legacy `vclaim-`.
- `\clewcite`/`\clewfig` intentionally unanchored pending live-paper's decision on hover targets.
- Card: writer-clew-macros-hypertarget-anchors (scitex-live-paper contract 2026-07-04).

## Test plan
- [x] 5 contract tests on the macro source (helper defined / both macros call it / raw-id clew- destination / one-shot flag / hyperref guard)
- [ ] CI (incl. the real-pdflatex clew overlay smokes, which parse this file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)