### PR TITLE
chore(django): SCITEX_WRITER_ prefix for the Django env vars (audit §6a)

### DIFF
--- a/src/scitex_writer/_django/_server.py
+++ b/src/scitex_writer/_django/_server.py
@@ -49,6 +49,9 @@ def run(
     if not project_path.exists():
         raise FileNotFoundError(f"Project directory not found: {project_path}")
 
+    os.environ["SCITEX_WRITER_WORKING_DIR"] = str(project_path)
+    # Deprecated unprefixed spelling — kept for one cycle so external
+    # launchers/readers keep working while they migrate.
     os.environ["WRITER_WORKING_DIR"] = str(project_path)
     os.environ["SCITEX_WORKING_DIR"] = str(project_path)
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "scitex_writer._django.settings")

--- a/src/scitex_writer/_django/settings.py
+++ b/src/scitex_writer/_django/settings.py
@@ -20,7 +20,13 @@ from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent
 
-SECRET_KEY = os.environ.get("WRITER_DJANGO_SECRET", secrets.token_urlsafe(32))
+# Fleet env-var convention is SCITEX_WRITER_<X>; the unprefixed
+# WRITER_DJANGO_SECRET spelling is honoured for one deprecation cycle.
+SECRET_KEY = (
+    os.environ.get("SCITEX_WRITER_DJANGO_SECRET")
+    or os.environ.get("WRITER_DJANGO_SECRET")
+    or secrets.token_urlsafe(32)
+)
 DEBUG = os.environ.get("DJANGO_DEBUG", "true").lower() == "true"
 ALLOWED_HOSTS = ["127.0.0.1", "localhost", "0.0.0.0", "testserver"]
 

--- a/src/scitex_writer/_django/views.py
+++ b/src/scitex_writer/_django/views.py
@@ -34,9 +34,15 @@ logger = logging.getLogger(__name__)
 
 
 def _get_project(request):
-    """Resolve the current project from ?working_dir= or WRITER_WORKING_DIR."""
-    working_dir = request.GET.get("working_dir") or os.environ.get(
-        "WRITER_WORKING_DIR", ""
+    """Resolve the current project from ?working_dir= or SCITEX_WRITER_WORKING_DIR.
+
+    The unprefixed WRITER_WORKING_DIR spelling is honoured for one
+    deprecation cycle (fleet env-var convention is SCITEX_WRITER_<X>).
+    """
+    working_dir = (
+        request.GET.get("working_dir")
+        or os.environ.get("SCITEX_WRITER_WORKING_DIR", "")
+        or os.environ.get("WRITER_WORKING_DIR", "")
     )
     if not working_dir:
         return None


### PR DESCRIPTION
## Summary
- `SCITEX_WRITER_DJANGO_SECRET` / `SCITEX_WRITER_WORKING_DIR` become the canonical names (fleet `SCITEX_WRITER_<X>` convention, audit-cli §6a).
- Back-compat for one deprecation cycle: readers fall back to the old unprefixed spellings; `_server.run` sets both.
- Card: writer-preexisting-audit-findings-20260706 (finding #1; finding #2 was already verified as a stale-venv artifact, no source change).

## Test plan
- [x] `scitex-dev ecosystem audit-all scitex-writer` against the branch: no §6a errors
- [x] `_django.settings` imports, SECRET_KEY resolves
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)