### PR TITLE
feat(django): SCITEX_APP_MODE tab-title marker (standalone vs hub)

### DIFF
--- a/src/scitex_writer/_django/settings.py
+++ b/src/scitex_writer/_django/settings.py
@@ -30,6 +30,12 @@ SECRET_KEY = (
 DEBUG = os.environ.get("DJANGO_DEBUG", "true").lower() == "true"
 ALLOWED_HOSTS = ["127.0.0.1", "localhost", "0.0.0.0", "testserver"]
 
+# "hub" | "standalone" — the browser tab alone must distinguish the two
+# (operator request; scitex-hub PR #357 reads the same setting and defaults
+# to "hub"). These settings only boot the STANDALONE server
+# (`scitex-writer gui`), so standalone is the default here.
+SCITEX_APP_MODE = os.environ.get("SCITEX_APP_MODE", "standalone")
+
 INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.staticfiles",

--- a/src/scitex_writer/_django/views.py
+++ b/src/scitex_writer/_django/views.py
@@ -53,6 +53,20 @@ def _get_project(request):
         return None
 
 
+def _app_label(base: str) -> str:
+    """Tab title per the fleet SCITEX_APP_MODE convention.
+
+    The operator wants the browser tab alone to distinguish hub-embedded
+    from standalone. scitex-hub reads the same setting and defaults to
+    "hub" (hub PR #357); these settings only boot the standalone server,
+    so writer defaults to "standalone" and appends the marker.
+    """
+    from django.conf import settings as django_settings
+
+    mode = getattr(django_settings, "SCITEX_APP_MODE", "standalone")
+    return f"{base} (standalone)" if mode == "standalone" else base
+
+
 def editor_page(request):
     """Serve the editor shell page."""
     project = _get_project(request)
@@ -61,7 +75,7 @@ def editor_page(request):
         "writer/editor.html",
         {
             "app_name": "writer",
-            "app_label": "SciTeX Writer",
+            "app_label": _app_label("Writer — SciTeX"),
             "project_dir": project_dir,
             "dark_mode": project.dark_mode if project else False,
         },
@@ -152,7 +166,7 @@ def viewer_page(request):
         "writer/viewer.html",
         {
             "app_name": "writer",
-            "app_label": "SciTeX Writer — Viewer",
+            "app_label": _app_label("Writer Viewer — SciTeX"),
             "project_dir": project_dir,
         },
         request=request,

--- a/tests/scitex_writer/_django/test_views.py
+++ b/tests/scitex_writer/_django/test_views.py
@@ -562,6 +562,27 @@ def test_editor_page_renders_scitex_writer_in_body_and_writer_css_editor_css_in_
     body = resp.content.decode()
     # Act
     # Assert
-    assert ('SciTeX Writer' in body) and ('writer/css/editor.css' in body or 'editor.css' in body)
+    assert ('Writer — SciTeX' in body) and ('writer/css/editor.css' in body or 'editor.css' in body)
+
+
+def test_editor_tab_title_marks_standalone_mode(project_dir):
+    # Arrange
+    rf = RequestFactory()
+    request = rf.get(f"/?working_dir={project_dir}")
+    resp = views.editor_page(request)
+    # Act
+    body = resp.content.decode()
+    # Assert
+    assert 'Writer — SciTeX (standalone)' in body
+
+
+def test_app_label_omits_marker_in_hub_mode():
+    # Arrange
+    from django.test import override_settings
+    # Act
+    with override_settings(SCITEX_APP_MODE="hub"):
+        label = views._app_label("Writer — SciTeX")
+    # Assert
+    assert label == "Writer — SciTeX"
 
 


### PR DESCRIPTION
## Summary
- New `SCITEX_APP_MODE` setting (`hub` | `standalone`) in writer's Django settings, defaulting to `standalone` (these settings only boot the `scitex-writer gui` server); env-overridable. Counterpart of scitex-hub PR #357, which defaults to `hub`.
- Tab titles adopt the hub's central naming policy with the mode marker: `Writer — SciTeX (standalone)` on :5050, `Writer — SciTeX` embedded (viewer: `Writer Viewer — SciTeX`). Operator request via Telegram 1026 (tab-only distinction), relayed by scitex-hub.
- Tests updated + 2 new (standalone marker present; hub mode omits it). 36/36 green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)