### PR TITLE
feat(engine): pure-Python table pipeline — shell-port slice 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dev = [
     # _skills/general/01_ecosystem_02_dependency-and-version-pinning.md
     # `[dev]` extras completeness.
     "scitex-scholar",     # tested via [scholar] integration tests
+    "openpyxl",           # writes the .xlsx fixture for the tables xlsx stage
 ]
 docs = [
     "sphinx>=7.0",

--- a/src/scitex_writer/_cli/commands/tables.py
+++ b/src/scitex_writer/_cli/commands/tables.py
@@ -28,6 +28,7 @@ def tables_group(ctx):
     Example:
         $ scitex-writer tables list
         $ scitex-writer tables add results data.csv "Results summary"
+        $ scitex-writer tables render
         $ scitex-writer tables archive results
     """
     if ctx.invoked_subcommand is None:
@@ -106,6 +107,49 @@ def tables_add(name, csv_src, caption, label, project, doc_type, dry_run, yes, a
     click.echo(f"  CSV:     {result['csv_path']}")
     click.echo(f"  Caption: {result['caption_path']}")
     click.echo(f"  Label:   {result['label']}")
+    return 0
+
+
+@tables_group.command("render")
+@click.option("-p", "--project", default=".", help="Project path.")
+@click.option("-t", "--doc-type", type=_DOC_TYPE, default="manuscript")
+@click.option(
+    "--no-tables", is_flag=True, default=False, help="Skip all table processing."
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit JSON.")
+def tables_render(project, doc_type, no_tables, as_json):
+    """Render every CSV table to LaTeX and gather them into FINAL.tex.
+
+    The pure-Python table engine (port of process_tables.sh): refreshes CSVs from
+    newer Excel sources, writes a default caption where none exists, renders each
+    NN_*.csv through the single pandas backend, and gathers the results. With no
+    tables it emits a comment-only fallback header (never a placeholder float).
+
+    \b
+    Example:
+        $ scitex-writer tables render
+        $ scitex-writer tables render -t supplementary --json
+    """
+    from ... import tables
+
+    result = tables.render(project, doc_type, no_tables)
+    if as_json:
+        _emit_json(result)
+        return 0 if result.get("success") else 1
+    if not result.get("success"):
+        click.echo(f"Error: {result['error']}", err=True)
+        return 1
+    if result["skipped"]:
+        click.echo("Skipped all table processing (--no-tables).")
+        return 0
+    if result["fallback_header"]:
+        click.echo("No tables found: emitted comment-only fallback header.")
+        return 0
+    click.echo(
+        f"Compiled {result['tables_compiled']} tables "
+        f"(captions_created={result['captions_created']}, "
+        f"xlsx_converted={result['xlsx_converted']}) -> {result['compiled_file']}"
+    )
     return 0
 
 

--- a/src/scitex_writer/_dataclasses/__init__.py
+++ b/src/scitex_writer/_dataclasses/__init__.py
@@ -20,6 +20,7 @@ from .results import (
     CleanupResult,
     CompilationResult,
     LaTeXIssue,
+    TablesResult,
     WordCountResult,
 )
 
@@ -47,6 +48,7 @@ __all__ = [
     "CompilationResult",
     "WriterConfig",
     "LaTeXIssue",
+    "TablesResult",
     "WordCountResult",
     # Tree structures
     "ConfigTree",

--- a/src/scitex_writer/_dataclasses/results/_TablesResult.py
+++ b/src/scitex_writer/_dataclasses/results/_TablesResult.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_dataclasses/results/_TablesResult.py
+
+"""TablesResult - outcome of one run of the CSV -> LaTeX table pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class TablesResult:
+    """Result of processing every CSV table of one document type.
+
+    Counts are what ACTUALLY happened during this run, never a request total, and
+    are never negative. ``tables`` carries one entry per compiled table
+    (``{name, csv, tex, rows, columns, truncated, caption_generated}``).
+    ``fallback_header`` is True when NO real table existed and the comment-only
+    ``00_Tables_Header.tex`` was emitted instead (it renders no table float).
+    """
+
+    success: bool
+    """Whether the pipeline completed."""
+
+    tables_compiled: int = 0
+    """Number of CSV tables rendered into the compiled directory."""
+
+    captions_created: int = 0
+    """Number of default caption files written for tables lacking one."""
+
+    xlsx_converted: int = 0
+    """Number of Excel files converted to CSV before rendering."""
+
+    tables: List[dict] = field(default_factory=list)
+    """Per-table outcomes, ordered by table number."""
+
+    compiled_file: Optional[str] = None
+    """Absolute path of the gathered FINAL.tex (the file the manuscript inputs)."""
+
+    fallback_header: bool = False
+    """True when no real table existed: a comment-only header was emitted."""
+
+    skipped: bool = False
+    """True when the run was skipped outright (the shell's ``--no_tables``)."""
+
+    error: Optional[str] = None
+    """Actionable error message when ``success`` is False; else None."""
+
+    def to_dict(self) -> dict:
+        """Plain dict for JSON serialization across the CLI / MCP boundary."""
+        return {
+            "success": self.success,
+            "tables_compiled": self.tables_compiled,
+            "captions_created": self.captions_created,
+            "xlsx_converted": self.xlsx_converted,
+            "tables": self.tables,
+            "compiled_file": self.compiled_file,
+            "fallback_header": self.fallback_header,
+            "skipped": self.skipped,
+            "error": self.error,
+        }
+
+    def validate(self) -> None:
+        """Raise ValueError on an internally inconsistent result (fail-loud).
+
+        A success carries no error and only non-negative counts; a failure must
+        carry an error message; and a fallback header is only legitimate when no
+        table was compiled (the two are mutually exclusive by construction).
+        """
+        if self.success and self.error:
+            raise ValueError("TablesResult success=True but error is set")
+        if not self.success and not self.error:
+            raise ValueError("TablesResult success=False but no error message")
+        for name in ("tables_compiled", "captions_created", "xlsx_converted"):
+            value = getattr(self, name)
+            if not isinstance(value, int) or value < 0:
+                raise ValueError(
+                    f"TablesResult {name} must be a non-negative int, got {value!r}"
+                )
+        if self.fallback_header and self.tables_compiled:
+            raise ValueError(
+                "TablesResult fallback_header=True but tables_compiled="
+                f"{self.tables_compiled} (the fallback is the NO-tables branch)"
+            )
+
+    def __str__(self) -> str:
+        if not self.success:
+            return f"Tables FAILED: {self.error}"
+        if self.skipped:
+            return "Tables: skipped (--no-tables)"
+        if self.fallback_header:
+            return "Tables: none found -- comment-only fallback header emitted"
+        return (
+            f"Tables: compiled={self.tables_compiled}, "
+            f"captions_created={self.captions_created}, "
+            f"xlsx_converted={self.xlsx_converted}"
+        )
+
+
+__all__ = ["TablesResult"]
+
+# EOF

--- a/src/scitex_writer/_dataclasses/results/__init__.py
+++ b/src/scitex_writer/_dataclasses/results/__init__.py
@@ -8,6 +8,7 @@ from ._CompilationResult import CompilationResult
 from ._LaTeXIssue import LaTeXIssue
 from ._SaveSectionsResponse import SaveSectionsResponse
 from ._SectionReadResponse import SectionReadResponse
+from ._TablesResult import TablesResult
 from ._WordCountResult import WordCountResult
 
 __all__ = [
@@ -17,6 +18,7 @@ __all__ = [
     "LaTeXIssue",
     "SaveSectionsResponse",
     "SectionReadResponse",
+    "TablesResult",
     "WordCountResult",
 ]
 

--- a/src/scitex_writer/_mcp/handlers/__init__.py
+++ b/src/scitex_writer/_mcp/handlers/__init__.py
@@ -28,6 +28,7 @@ from ._export import export_manuscript
 from ._figures import convert_figure, list_figures, pdf_to_images
 from ._project import clone_project, get_pdf, get_project_info, list_document_types
 from ._tables import csv_to_latex, latex_to_csv
+from ._tables_pipeline import process as process_tables
 from ._update import update_project  # noqa: F401 -- now a package
 
 __all__ = [
@@ -57,6 +58,7 @@ __all__ = [
     "list_document_types",
     "list_figures",
     "pdf_to_images",
+    "process_tables",
     "remove_claim",
     "render_claims",
     "update_project",

--- a/src/scitex_writer/_mcp/handlers/_tables_pipeline.py
+++ b/src/scitex_writer/_mcp/handlers/_tables_pipeline.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_mcp/handlers/_tables_pipeline.py
+
+r"""The table pipeline: a pure-Python port of ``process_tables.sh``.
+
+Ports the shell module (plus its sourced ``03_csv2tex.src`` / ``04_gather.src``)
+stage for stage, reading the SAME config keys the shell read via ``yq``:
+``tables.dir``, ``tables.caption_media_dir``, ``tables.compiled_dir`` and
+``tables.compiled_file`` from ``config/config_<doc_type>.yaml``.
+
+Stages (``process`` runs them in order):
+
+1. ``init_tables``       -- clear ``compiled_dir/*.tex``, create the table dirs,
+                            truncate the gathered ``FINAL.tex``.
+2. ``xlsx2csv_convert``  -- refresh ``NN_*.csv`` from a newer ``NN_*.xlsx/.xls``.
+3. ``ensure_caption``    -- write a default ``NN_*.tex`` caption where none exists.
+4. ``csv2tex``           -- render each ``NN_*.csv`` through the ONE pandas
+                            backend (:mod:`scitex_writer._utils._csv_table`).
+5. ``gather_table_tex_files`` -- assemble ``FINAL.tex`` (+ ``_placeable/`` copies).
+
+Two behaviours the shell pinned and this port keeps:
+
+* the NO-tables fallback header emits **no table float** -- only LaTeX comments
+  (card writer-stray-table-zero-artifact: a placeholder float rendered as a
+  stray counter-numbered "Table 0" with a spurious ``tab:0_Tables_Header``
+  label);
+* an end-block ``\input`` is GUARDED by ``\ifcsname scitextabplaced@<n>``, so a
+  table placed inline with ``\scitextab{<n>}`` is not also duplicated at the end.
+
+Robust by construction: pathlib only (never shells out to find/rm/mv); every
+write target is resolved and asserted to live INSIDE the project root; fail-loud
+(explicit error dict + actionable hint) on a missing project dir / config.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+from ..._dataclasses import TablesResult
+from ..._utils._csv_table import MAX_ROWS, render_csv_table
+from ..utils import resolve_project_path
+
+DOC_DIRS = {
+    "manuscript": "01_manuscript",
+    "supplementary": "02_supplementary",
+    "revision": "03_revision",
+}
+
+_CFG_KEYS = {
+    "table_dir": ("tables", "dir"),
+    "caption_media_dir": ("tables", "caption_media_dir"),
+    "compiled_dir": ("tables", "compiled_dir"),
+    "compiled_file": ("tables", "compiled_file"),
+}
+
+HEADER_NAME = "00_Tables_Header.tex"
+
+# Comment-only fallback: NO renderable float, caption or label (see module doc).
+FALLBACK_HEADER = r"""%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% TABLES
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% No tables are present in this manuscript.
+%% The "Tables" \section*, \label{tables} and \pdfbookmark are emitted once by
+%% base.tex (single source of truth). This fallback header deliberately emits
+%% NO table float, caption or label, so an empty-tables manuscript never shows
+%% a stray placeholder "Table" (previously \label{tab:0_Tables_Header}).
+%%
+%% To add a table: place a CSV in caption_and_media/ named XX_description.csv,
+%% add a matching caption XX_description.tex, then reference it in the body as
+%% Table~\ref{tab:XX_description}.
+"""
+
+
+def _default_caption(rel_path: str) -> str:
+    """The placeholder caption written for a CSV that has none (shell parity)."""
+    return (
+        f"%% Edit this file: {rel_path}\n"
+        "\\caption{\\textbf{TABLE TITLE HERE}\\\\\n"
+        "\\smallskip\n"
+        f"TABLE CAPTION HERE. Edit this caption at \\url{{{rel_path}}}.\n"
+        "}\n"
+    )
+
+
+def _cfg_get(cfg: dict, path, default=None):
+    """Nested dict lookup by a key-tuple; ``default`` if any level is absent."""
+    cur = cfg
+    for key in path:
+        if not isinstance(cur, dict) or key not in cur:
+            return default
+        cur = cur[key]
+    return cur
+
+
+def _resolve(project_path: Path, rel) -> Optional[Path]:
+    """Resolve a config path (possibly ``./``-relative) against the project root."""
+    if not rel:
+        return None
+    rel = str(rel)
+    if rel.startswith("./"):
+        rel = rel[2:]
+    return (project_path / rel).resolve()
+
+
+def _within(boundary: Path, target: Path) -> bool:
+    """True iff ``target`` resolves to a path inside ``boundary`` (guard ``..``)."""
+    try:
+        target.resolve().relative_to(boundary)
+        return True
+    except ValueError:
+        return False
+
+
+def _numbered(directory: Path, suffix: str):
+    """Sorted ``NN*<suffix>`` entries of ``directory`` (the shell's ``[0-9]*`` glob)."""
+    if not directory.is_dir():
+        return []
+    return sorted(p for p in directory.glob(f"[0-9]*{suffix}") if p.is_file())
+
+
+def init_tables(
+    table_dir: Path, caption_media_dir: Path, compiled_dir: Path, compiled_file: Path
+) -> None:
+    """Stage 1: clear stale compiled tables and (re)create the table directories."""
+    if compiled_dir.is_dir():
+        for stale in compiled_dir.glob("*.tex"):
+            stale.unlink()
+    for directory in (table_dir, caption_media_dir, compiled_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+    compiled_file.parent.mkdir(parents=True, exist_ok=True)
+    compiled_file.write_text("\n", encoding="utf-8")
+
+
+def xlsx_to_csv(xlsx_file: Path, csv_file: Path) -> None:
+    """Convert one Excel file to CSV: pandas first, else the ``xlsx2csv`` binary.
+
+    Raises the underlying error when neither route works -- a table silently
+    missing from the PDF is worse than a loud failure.
+    """
+    try:
+        import pandas as pd
+
+        pd.read_excel(xlsx_file).to_csv(csv_file, index=False)
+        return
+    except Exception:
+        binary = shutil.which("xlsx2csv")
+        if binary is None:
+            raise
+        subprocess.run(
+            [binary, str(xlsx_file), str(csv_file)],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+
+def xlsx2csv_convert(caption_media_dir: Path) -> int:
+    """Stage 2: refresh each ``NN_*.csv`` whose Excel source is newer (or absent).
+
+    Returns the number of files converted.
+    """
+    converted = 0
+    excels = _numbered(caption_media_dir, ".xlsx") + _numbered(
+        caption_media_dir, ".xls"
+    )
+    for xlsx_file in sorted(excels):
+        csv_file = xlsx_file.with_suffix(".csv")
+        if csv_file.exists() and csv_file.stat().st_mtime >= xlsx_file.stat().st_mtime:
+            continue
+        xlsx_to_csv(xlsx_file, csv_file)
+        converted += 1
+    return converted
+
+
+def ensure_caption(caption_media_dir: Path, project_path: Path) -> int:
+    """Stage 3: write a default caption for every CSV lacking one.
+
+    A symlinked caption counts as present (the shell tested ``-f || -L``).
+    Returns the number of caption files created.
+    """
+    created = 0
+    for csv_file in _numbered(caption_media_dir, ".csv"):
+        caption_file = csv_file.with_suffix(".tex")
+        if caption_file.exists() or caption_file.is_symlink():
+            continue
+        try:
+            rel_path = str(caption_file.resolve().relative_to(project_path))
+        except ValueError:
+            rel_path = caption_file.name
+        caption_file.write_text(_default_caption(rel_path), encoding="utf-8")
+        created += 1
+    return created
+
+
+def csv2tex(
+    caption_media_dir: Path, compiled_dir: Path, max_rows: int = MAX_ROWS
+) -> list:
+    """Stage 4: render every ``NN_*.csv`` to ``compiled_dir/NN_*.tex``.
+
+    ONE backend (pandas) -- see :mod:`scitex_writer._utils._csv_table` for why the
+    shell's 4-way backend selection is gone. Returns one dict per table.
+    """
+    rendered = []
+    for csv_file in _numbered(caption_media_dir, ".csv"):
+        caption_file = csv_file.with_suffix(".tex")
+        has_caption = caption_file.exists() or caption_file.is_symlink()
+        caption = (
+            caption_file.read_text(encoding="utf-8").strip() if has_caption else None
+        )
+        compiled_file = compiled_dir / f"{csv_file.stem}.tex"
+        latex = render_csv_table(csv_file, caption=caption, max_rows=max_rows)
+        compiled_file.write_text(latex + "\n", encoding="utf-8")
+
+        import pandas as pd
+
+        frame = pd.read_csv(csv_file)
+        rendered.append(
+            {
+                "name": csv_file.stem,
+                "csv": str(csv_file),
+                "tex": str(compiled_file),
+                "rows": int(len(frame)),
+                "columns": int(len(frame.columns)),
+                "truncated": bool(len(frame) > max_rows),
+                "caption_generated": not has_caption,
+            }
+        )
+    return rendered
+
+
+def gather_table_tex_files(compiled_dir: Path, compiled_file: Path) -> dict:
+    """Stage 5: assemble ``FINAL.tex`` from the compiled tables.
+
+    With NO real table, writes the comment-only ``00_Tables_Header.tex`` fallback
+    (no float -- card writer-stray-table-zero-artifact) and inputs it. With real
+    tables, copies each into ``_placeable/<number>.tex`` (so the author may place
+    it inline with ``\\scitextab{<number>}``) and emits a GUARDED end-block
+    ``\\input`` so an inline-placed table is not duplicated.
+
+    Returns ``{"table_count": int, "fallback_header": bool}``.
+    """
+    real_tables = [p for p in _numbered(compiled_dir, ".tex") if p.name != HEADER_NAME]
+    has_real_tables = bool(real_tables)
+
+    lines = [
+        "% Auto-generated file containing all table inputs",
+        "% Generated by gather_table_tex_files()",
+        "",
+    ]
+
+    if not has_real_tables:
+        header_file = compiled_dir / HEADER_NAME
+        header_file.write_text(FALLBACK_HEADER, encoding="utf-8")
+        lines.append(f"\\input{{{header_file}}}")
+        lines.append("")
+        compiled_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return {"table_count": 0, "fallback_header": True}
+
+    placeable_dir = compiled_dir / "_placeable"
+    placeable_dir.mkdir(parents=True, exist_ok=True)
+    for table_tex in real_tables:
+        number = table_tex.stem.split("_", 1)[0]
+        shutil.copyfile(table_tex, placeable_dir / f"{number}.tex")
+        lines.append(f"% Table from: {table_tex.name}")
+        lines.append(
+            f"\\ifcsname scitextabplaced@{number}\\endcsname"
+            f"\\else\\input{{{table_tex}}}\\fi"
+        )
+        lines.append("")
+    compiled_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return {"table_count": len(real_tables), "fallback_header": False}
+
+
+def process(
+    project_dir: str,
+    doc_type: str = "manuscript",
+    no_tables: bool = False,
+    max_rows: int = MAX_ROWS,
+) -> dict:
+    """Run the whole table pipeline for ``doc_type`` and return its outcome.
+
+    Parameters
+    ----------
+    project_dir : str
+        Path to the scitex-writer project directory.
+    doc_type : str
+        One of 'manuscript' (default), 'supplementary', 'revision'.
+    no_tables : bool
+        Skip all table processing (the shell's ``--no_tables`` early exit).
+    max_rows : int
+        Data rows shown per table before truncation.
+
+    Returns
+    -------
+    dict
+        The serialized :class:`TablesResult`. On failure ``error`` carries an
+        actionable hint (fail-loud, never a silent no-op).
+    """
+    try:
+        if no_tables:
+            return TablesResult(success=True, skipped=True).to_dict()
+
+        if doc_type not in DOC_DIRS:
+            return {
+                "success": False,
+                "error": (
+                    f"Invalid doc_type '{doc_type}'. Must be one of: {tuple(DOC_DIRS)}"
+                ),
+            }
+
+        project_path = resolve_project_path(project_dir)
+        if not project_path.is_dir():
+            return {
+                "success": False,
+                "error": (
+                    f"Project directory not found: {project_path}. "
+                    f"Check the path passed as project_dir."
+                ),
+            }
+
+        config_path = project_path / "config" / f"config_{doc_type}.yaml"
+        if not config_path.exists():
+            return {
+                "success": False,
+                "error": (
+                    f"Config not found: {config_path}. "
+                    f"Run `scitex-writer update-project` or check --doc-type."
+                ),
+            }
+        try:
+            import yaml
+        except ImportError:
+            return {
+                "success": False,
+                "error": "PyYAML not installed. Fix: pip install pyyaml",
+            }
+        try:
+            cfg = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError as e:
+            return {"success": False, "error": f"{config_path} is not valid YAML: {e}"}
+
+        paths = {}
+        for name, key in _CFG_KEYS.items():
+            resolved = _resolve(project_path, _cfg_get(cfg, key))
+            if resolved is None:
+                return {
+                    "success": False,
+                    "error": (
+                        f"{'.'.join(key)} is missing in {config_path}; "
+                        f"cannot resolve the table {name.replace('_', ' ')}."
+                    ),
+                }
+            paths[name] = resolved
+
+        boundary = project_path.resolve()
+        if not all(_within(boundary, p) for p in paths.values()):
+            return {
+                "success": False,
+                "error": (
+                    "Refusing to run: a tables.* path resolves OUTSIDE the "
+                    f"project root {boundary} (config path escape via '..'?)."
+                ),
+            }
+
+        init_tables(
+            paths["table_dir"],
+            paths["caption_media_dir"],
+            paths["compiled_dir"],
+            paths["compiled_file"],
+        )
+        xlsx_converted = xlsx2csv_convert(paths["caption_media_dir"])
+        captions_created = ensure_caption(paths["caption_media_dir"], boundary)
+        tables = csv2tex(
+            paths["caption_media_dir"], paths["compiled_dir"], max_rows=max_rows
+        )
+        gathered = gather_table_tex_files(paths["compiled_dir"], paths["compiled_file"])
+
+        result = TablesResult(
+            success=True,
+            tables_compiled=gathered["table_count"],
+            captions_created=captions_created,
+            xlsx_converted=xlsx_converted,
+            tables=tables,
+            compiled_file=str(paths["compiled_file"]),
+            fallback_header=gathered["fallback_header"],
+        )
+        result.validate()
+        return result.to_dict()
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+__all__ = [
+    "csv2tex",
+    "ensure_caption",
+    "gather_table_tex_files",
+    "init_tables",
+    "process",
+    "xlsx2csv_convert",
+    "xlsx_to_csv",
+]
+
+# EOF

--- a/src/scitex_writer/_mcp/tools/tables.py
+++ b/src/scitex_writer/_mcp/tools/tables.py
@@ -11,11 +11,30 @@ from fastmcp import FastMCP
 
 from ..handlers import csv_to_latex as _csv_to_latex
 from ..handlers import latex_to_csv as _latex_to_csv
+from ..handlers._tables_pipeline import process as _process
 from ..utils import resolve_project_path
 
 
 def register_tools(mcp: FastMCP) -> None:
     """Register table tools."""
+
+    @mcp.tool()
+    def writer_tables_render(
+        project_dir: str,
+        doc_type: Literal["manuscript", "supplementary", "revision"] = "manuscript",
+        no_tables: bool = False,
+    ) -> dict:
+        """Run the table pipeline: CSV/XLSX -> LaTeX tables -> gathered FINAL.tex.
+
+        Refreshes CSVs from newer Excel sources, writes a default caption for any
+        table lacking one, renders every NN_*.csv through the single pandas
+        backend (whole-cell verbatim passthrough for cells carrying $ or \\), and
+        gathers the results. With no tables it emits a comment-only fallback
+        header -- never a placeholder float. no_tables=True skips everything.
+        Returns {success, tables_compiled, captions_created, xlsx_converted,
+        tables, compiled_file, fallback_header, skipped, error}.
+        """
+        return _process(project_dir, doc_type, no_tables)
 
     @mcp.tool()
     def writer_tables_csv_to_latex(

--- a/src/scitex_writer/_utils/_csv_table.py
+++ b/src/scitex_writer/_utils/_csv_table.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_utils/_csv_table.py
+
+r"""The single CSV -> LaTeX table backend of the writer engine (pandas).
+
+Absorbs ``scripts/python/csv_to_latex.py`` into the package and REPLACES the
+shell engine's 4-way backend selection (``csv2latex`` binary / python+pandas /
+python-basic / AWK fallback) with ONE pandas backend.
+
+Why one backend (card writer-csv-latex-verbatim-all-backends): the whole-cell
+verbatim passthrough -- a header/cell carrying ``$`` (math) or ``\`` (a LaTeX
+command) is emitted as authored, never escaped -- lived ONLY in the Python
+backend. Whenever the shell picked ``csv2latex`` (it is preferred when the
+binary is installed) or fell through to AWK, ``$p<0.001$`` was silently
+mangled/escaped. Collapsing to one backend makes the passthrough universal by
+construction: there is no other path left to lose it.
+
+Emitted structure (parity with the shell + the old Python script):
+``\pdfbookmark[2]{Table N --- Title}{table_<base>}`` -> ``table`` float ->
+``\footnotesize`` -> column-count-dependent ``\tabcolsep`` -> shrink-to-fit
+``\resizebox`` -> ``booktabs`` tabular (bold header, zebra ``\rowcolor``) ->
+caption (author's, or a generated default) -> ``\label{tab:<base>}`` emitted
+ONLY when the caption does not already carry one.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Optional, Union
+
+MAX_ROWS = 30
+"""Data rows shown before the table is truncated with an omitted-rows marker."""
+
+_TEXTBF_RE = re.compile(r"\\textbf\{([^}]*)\}")
+_CAPTION_HEAD_RE = re.compile(r"\\caption\{([^.]*)\.")
+
+_ESCAPES = (
+    ("\\", r"\textbackslash{}"),  # must be first
+    ("&", r"\&"),
+    ("%", r"\%"),
+    ("$", r"\$"),
+    ("#", r"\#"),
+    ("_", r"\_"),
+    ("{", r"\{"),
+    ("}", r"\}"),
+    ("~", r"\textasciitilde{}"),
+    ("^", r"\textasciicircum{}"),
+    ("|", r"\textbar{}"),
+    ("<", r"\textless{}"),
+    (">", r"\textgreater{}"),
+)
+
+
+def escape_latex(text) -> str:
+    """Escape LaTeX-special characters in a plain (non-verbatim) value."""
+    import pandas as pd
+
+    if pd.isna(text):
+        return ""
+    text = str(text)
+    for old, new in _ESCAPES:
+        text = text.replace(old, new)
+    return text
+
+
+def is_verbatim(value) -> bool:
+    r"""True if a header/cell already carries explicit LaTeX or math.
+
+    A value containing ``$`` (math) or ``\`` (a LaTeX command) is authored
+    intentionally -- pass it through verbatim (no escaping, number-formatting or
+    title-casing) so ``$R^2$``, ``$p<0.001$`` or ``\textit{r}`` render. Plain
+    values are still escaped (safe). A rare literal ``$`` in plain data must be
+    escaped by the author as ``\$``.
+    """
+    text = str(value)
+    return "$" in text or "\\" in text
+
+
+def format_number(val):
+    """Format a number for LaTeX: ints bare, tiny values scientific, else 3 dp."""
+    try:
+        num = float(val)
+    except (ValueError, TypeError):
+        return val
+    if num.is_integer():
+        return str(int(num))
+    if abs(num) < 0.01 and num != 0:
+        return f"{num:.2e}"
+    return f"{num:.3f}".rstrip("0").rstrip(".")
+
+
+def _value_decimals(val) -> Optional[int]:
+    """Decimals ``val`` shows under :func:`format_number`; None if not alignable.
+
+    Non-numbers, NaN and scientific-notation (very small) values return None --
+    they are left unaligned. Reusing format_number's own output keeps column
+    precision in lockstep with the per-cell display, so alignment only PADS
+    shorter values; it never uncaps precision.
+    """
+    try:
+        num = float(val)
+    except (ValueError, TypeError):
+        return None
+    if num != num:  # NaN
+        return None
+    shown = format_number(val)
+    if "e" in str(shown) or "E" in str(shown):
+        return None
+    shown = str(shown)
+    return len(shown.split(".")[1]) if "." in shown else 0
+
+
+def column_precision(values) -> Optional[int]:
+    """Decimal places a column pads to so its numbers align, or None.
+
+    None for an all-integer or non-numeric column: counts like ``288`` stay
+    ``288``, never ``288.000``.
+    """
+    decimals = [d for d in (_value_decimals(v) for v in values) if d is not None]
+    if not decimals:
+        return None
+    target = max(decimals)
+    return target if target > 0 else None
+
+
+def _format_aligned(val, precision: Optional[int]) -> str:
+    """Pad ``val`` to ``precision`` decimals so a column's numbers line up."""
+    if precision is None or _value_decimals(val) is None:
+        return str(format_number(val))
+    return f"{float(val):.{precision}f}"
+
+
+def _render_cell(val, precision: Optional[int]) -> str:
+    """One data cell: verbatim if authored LaTeX/math, else aligned + escaped."""
+    import pandas as pd
+
+    if not pd.notna(val):
+        return "--"
+    if is_verbatim(val):
+        return str(val)
+    return escape_latex(_format_aligned(val, precision))
+
+
+def _render_header(col) -> str:
+    r"""One header cell: verbatim if authored LaTeX/math, else escaped.
+
+    Underscores become spaces (``mean_iou`` -> ``mean iou``). NOT title-cased:
+    acronyms must survive as authored (``ROC-AUC`` stays ``ROC-AUC``).
+    """
+    header = str(col) if is_verbatim(col) else escape_latex(col).replace("\\_", " ")
+    return f"\\textbf{{{header}}}"
+
+
+def split_table_name(base_name: str):
+    """Split ``01_seizure_count`` into ``("1", "seizure count")``.
+
+    Falls back to ``(base_name, base_name)`` when the stem carries no leading
+    ``NN_`` number -- exactly the shell's behaviour.
+    """
+    match = re.match(r"^(\d+)_(.*)$", base_name)
+    if not match:
+        return base_name, base_name
+    number = match.group(1).lstrip("0") or "0"
+    return number, match.group(2).replace("_", " ")
+
+
+def caption_title(caption: Optional[str]) -> str:
+    r"""The table title carried by a caption, for the PDF bookmark.
+
+    Prefers the ``\textbf{...}`` title (the template's shape), else the caption
+    text up to its first period. Trailing periods are stripped. Empty when the
+    caption carries neither -- the caller then emits a bare ``Table N``
+    bookmark. Mirrors the sed pair in ``process_tables_modules/03_csv2tex.src``.
+    """
+    if not caption:
+        return ""
+    match = _TEXTBF_RE.search(caption)
+    if not match:
+        match = _CAPTION_HEAD_RE.search(caption)
+    if not match:
+        return ""
+    return match.group(1).strip().rstrip(".").strip()
+
+
+def _tabcolsep(num_columns: int) -> str:
+    """Column separation that keeps a wide table inside the text width."""
+    if num_columns > 8:
+        return "2pt"
+    if num_columns > 6:
+        return "3pt"
+    if num_columns > 4:
+        return "4pt"
+    return "6pt"
+
+
+def render_csv_table(
+    csv_path: Union[str, Path],
+    caption: Optional[str] = None,
+    label: Optional[str] = None,
+    max_rows: int = MAX_ROWS,
+) -> str:
+    r"""Render one CSV file as a complete LaTeX ``table`` float.
+
+    Parameters
+    ----------
+    csv_path : str or Path
+        The CSV to render. Its stem (``01_seizure_count``) supplies the table
+        number, the default caption text and the default label.
+    caption : str, optional
+        The author's caption BLOCK (a full ``\caption{...}``, typically the
+        sibling ``NN_name.tex``). When absent a default caption is generated.
+    label : str, optional
+        Overrides the default ``tab:<stem>`` label. A label is emitted ONLY when
+        the caption does not already carry a ``\label{tab:`` of its own -- so an
+        author-supplied label is never duplicated.
+    max_rows : int
+        Data rows shown before truncation (default 30). Truncated tables keep
+        the first ``max_rows - 2`` and the last 2 rows around an
+        "... N rows omitted ..." marker, and the note is appended to the caption.
+
+    Returns
+    -------
+    str
+        The LaTeX table float (no trailing newline).
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``csv_path`` does not exist (fail-loud: never a silent empty table).
+    """
+    import pandas as pd
+
+    csv_path = Path(csv_path)
+    if not csv_path.exists():
+        raise FileNotFoundError(f"CSV file not found: {csv_path}")
+
+    df = pd.read_csv(csv_path)
+    original_rows = len(df)
+    truncated = original_rows > max_rows
+    if truncated:
+        if max_rows > 5:
+            separator = pd.DataFrame([["..."] * len(df.columns)], columns=df.columns)
+            df = pd.concat(
+                [df.head(max_rows - 2), separator, df.tail(2)], ignore_index=True
+            )
+        else:
+            df = df.head(max_rows)
+
+    base_name = csv_path.stem
+    table_number, table_clean_name = split_table_name(base_name)
+
+    alignments = []
+    for col in df.columns:
+        try:
+            pd.to_numeric(df[col], errors="raise")
+            alignments.append("r")
+        except (ValueError, TypeError):
+            alignments.append("l")
+
+    title = caption_title(caption)
+    bookmark = f"Table {table_number}"
+    if title:
+        bookmark = f"Table {table_number} --- {title}"
+
+    lines = [
+        f"\\pdfbookmark[2]{{{bookmark}}}{{table_{base_name}}}",
+        "\\begin{table}[htbp]",
+        "\\centering",
+        "\\footnotesize",
+        f"\\setlength{{\\tabcolsep}}{{{_tabcolsep(len(df.columns))}}}",
+        # Shrink-to-fit ONLY: a too-wide table scales down to \linewidth; a
+        # narrow one keeps its natural width (never stretched).
+        "\\resizebox{\\ifdim\\width>\\linewidth\\linewidth\\else\\width\\fi}{!}{%",
+        f"\\begin{{tabular}}{{{''.join(alignments)}}}",
+        "\\toprule",
+        " & ".join(_render_header(col) for col in df.columns) + " \\\\",
+        "\\midrule",
+    ]
+
+    col_prec = {col: column_precision(df[col]) for col in df.columns}
+    for idx, row in df.iterrows():
+        if any(str(row[col]) == "..." for col in df.columns):
+            omitted = original_rows - max_rows + 1
+            lines.append("\\midrule")
+            lines.append(
+                f"\\multicolumn{{{len(df.columns)}}}{{c}}"
+                f"{{\\textit{{... {omitted} rows omitted ...}}}} \\\\"
+            )
+            lines.append("\\midrule")
+            continue
+        # Zebra striping via the theme color `lightgray` (redefined under
+        # dark_mode.tex), so the stripe stays legible in BOTH modes.
+        if idx % 2 == 1:
+            lines.append("\\rowcolor{lightgray}")
+        lines.append(
+            " & ".join(_render_cell(row[col], col_prec[col]) for col in df.columns)
+            + " \\\\"
+        )
+
+    lines += [
+        "\\bottomrule",
+        "\\end{tabular}",
+        "}",
+        "\\captionsetup{width=\\textwidth}",
+    ]
+
+    note = (
+        f"\\textit{{Note: Table truncated to {max_rows} rows from "
+        f"{original_rows} total rows for display purposes.}}"
+    )
+    if caption:
+        block = caption.rstrip()
+        if truncated:
+            block = block.rstrip("}") + f" {note}" + "}"
+        lines.append(block)
+    else:
+        lines.append(f"\\caption{{\\textbf{{Table {table_number}: {table_clean_name}}}")
+        lines.append("\\\\")
+        lines.append(note if truncated else "Data table generated from CSV file.")
+        lines.append("}")
+
+    # Label ONLY when the caption does not already carry one (no duplicates).
+    if not (caption and "\\label{tab:" in caption):
+        lines.append(f"\\label{{{label or 'tab:' + base_name}}}")
+
+    lines.append("\\end{table}")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "MAX_ROWS",
+    "caption_title",
+    "column_precision",
+    "escape_latex",
+    "format_number",
+    "is_verbatim",
+    "render_csv_table",
+    "split_table_name",
+]
+
+# EOF

--- a/src/scitex_writer/tables.py
+++ b/src/scitex_writer/tables.py
@@ -17,6 +17,9 @@ Usage::
 
     # Convert CSV to LaTeX
     result = sw.tables.csv_to_latex("data.csv", "table.tex")
+
+    # Run the whole engine pipeline (CSV/XLSX -> compiled LaTeX -> FINAL.tex)
+    result = sw.tables.render("./my-paper", doc_type="manuscript")
 """
 
 import shutil as _shutil
@@ -25,6 +28,7 @@ from typing import Optional as _Optional
 
 from ._mcp.handlers import csv_to_latex as _csv_to_latex
 from ._mcp.handlers import latex_to_csv as _latex_to_csv
+from ._mcp.handlers._tables_pipeline import process as _process
 from ._mcp.utils import resolve_project_path as _resolve_project_path
 
 try:
@@ -277,6 +281,36 @@ def latex_to_csv(
     return _latex_to_csv(latex_path, output_path, table_index)
 
 
-__all__ = ["list", "add", "remove", "archive", "csv_to_latex", "latex_to_csv"]
+@_supports_return_as
+def render(
+    project_dir: str,
+    doc_type: _Literal["manuscript", "supplementary", "revision"] = "manuscript",
+    no_tables: bool = False,
+) -> dict:
+    """Run the engine's table pipeline for ``doc_type``.
+
+    The pure-Python port of ``scripts/shell/modules/process_tables.sh``: refreshes
+    CSVs from newer Excel sources, writes a default caption for any table lacking
+    one, renders every ``NN_*.csv`` to LaTeX through the single pandas backend
+    (whole-cell verbatim passthrough for ``$``/``\\`` cells), and gathers the
+    results into the compiled ``FINAL.tex``. With no tables at all it emits a
+    comment-only fallback header -- never a placeholder float.
+
+    ``no_tables=True`` skips everything (the shell's ``--no_tables``). Returns
+    ``{success, tables_compiled, captions_created, xlsx_converted, tables,
+    compiled_file, fallback_header, skipped, error}``.
+    """
+    return _process(project_dir, doc_type, no_tables)
+
+
+__all__ = [
+    "list",
+    "add",
+    "remove",
+    "archive",
+    "csv_to_latex",
+    "latex_to_csv",
+    "render",
+]
 
 # EOF

--- a/tests/scitex_writer/_mcp/handlers/test__tables_pipeline.py
+++ b/tests/scitex_writer/_mcp/handlers/test__tables_pipeline.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_writer/_mcp/handlers/test__tables_pipeline.py
+
+r"""Tests for the pure-Python table pipeline (port of process_tables.sh).
+
+Real inputs throughout -- real CSV/XLSX files under ``tmp_path``, the real
+config the shell read, and (in the smoke test) a real ``pdflatex`` compile of the
+generated table. No mocks.
+
+The no-tables cases are the regression guard for card
+writer-stray-table-zero-artifact: the fallback header must emit NO table float.
+"""
+
+import shutil
+import subprocess
+
+import pytest
+
+from scitex_writer._mcp.handlers import _tables_pipeline
+
+_CONFIG = (
+    "tables:\n"
+    '  dir: "./01_manuscript/contents/tables"\n'
+    '  caption_media_dir: "./01_manuscript/contents/tables/caption_and_media"\n'
+    '  compiled_dir: "./01_manuscript/contents/tables/compiled"\n'
+    '  compiled_file: "./01_manuscript/contents/tables/compiled/FINAL.tex"\n'
+)
+
+_CSV = "patient,seizure_count,score\nP1,288,0.333\nP2,12,0.35\n"
+
+# A minimal preamble carrying every package/color the generated float uses.
+_PREAMBLE = (
+    "\\documentclass{article}\n"
+    "\\usepackage{graphicx}\n"
+    "\\usepackage{booktabs}\n"
+    "\\usepackage[table]{xcolor}\n"
+    "\\usepackage{caption}\n"
+    "\\usepackage{hyperref}\n"
+    "\\definecolor{lightgray}{gray}{0.95}\n"
+)
+
+
+def _seed_project(tmp_path, csv_text=_CSV, caption=None):
+    """Seed a project with one CSV table; return (project, caption_media_dir)."""
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    (cfg / "config_manuscript.yaml").write_text(_CONFIG, encoding="utf-8")
+    cam = tmp_path / "01_manuscript/contents/tables/caption_and_media"
+    cam.mkdir(parents=True)
+    if csv_text is not None:
+        (cam / "01_seizure_count.csv").write_text(csv_text, encoding="utf-8")
+    if caption is not None:
+        (cam / "01_seizure_count.tex").write_text(caption, encoding="utf-8")
+    return tmp_path, cam
+
+
+def _compiled_dir(project):
+    return project / "01_manuscript/contents/tables/compiled"
+
+
+class TestPipelineErrors:
+    def test_invalid_doc_type_returns_actionable_error(self):
+        # Arrange
+        bad_doc_type = "poster"
+        # Act
+        result = _tables_pipeline.process(".", bad_doc_type)
+        # Assert
+        assert result["success"] is False and "poster" in result["error"]
+
+    def test_missing_project_dir_returns_error_hint(self, tmp_path):
+        # Arrange
+        absent = tmp_path / "nope"
+        # Act
+        result = _tables_pipeline.process(str(absent), "manuscript")
+        # Assert
+        assert result["success"] is False and "not found" in result["error"]
+
+    def test_missing_config_returns_error_hint(self, tmp_path):
+        # Arrange
+        (tmp_path / "01_manuscript").mkdir()
+        # Act
+        result = _tables_pipeline.process(str(tmp_path), "manuscript")
+        # Assert
+        assert result["success"] is False and "Config not found" in result["error"]
+
+    def test_no_tables_flag_skips_processing(self, tmp_path):
+        # Arrange
+        project, _ = _seed_project(tmp_path)
+        # Act
+        result = _tables_pipeline.process(str(project), "manuscript", no_tables=True)
+        # Assert
+        assert result["skipped"] is True and result["tables_compiled"] == 0
+
+
+class TestCaptionStage:
+    def test_default_caption_created_for_uncaptioned_table(self, tmp_path):
+        # Arrange
+        project, cam = _seed_project(tmp_path)
+        # Act
+        result = _tables_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert (
+            result["captions_created"] == 1 and (cam / "01_seizure_count.tex").exists()
+        )
+
+    def test_default_caption_carries_edit_hint(self, tmp_path):
+        # Arrange
+        project, cam = _seed_project(tmp_path)
+        # Act
+        _tables_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert "TABLE TITLE HERE" in (cam / "01_seizure_count.tex").read_text()
+
+    def test_existing_caption_is_not_overwritten(self, tmp_path):
+        # Arrange
+        authored = "\\caption{\\textbf{Mine}\\\\ Authored.}\n"
+        project, cam = _seed_project(tmp_path, caption=authored)
+        # Act
+        result = _tables_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert (
+            result["captions_created"] == 0
+            and (cam / "01_seizure_count.tex").read_text() == authored
+        )
+
+
+class TestXlsxStage:
+    def test_excel_source_is_converted_to_csv(self, tmp_path):
+        # Arrange
+        import pandas as pd
+
+        project, cam = _seed_project(tmp_path, csv_text=None)
+        pd.DataFrame({"patient": ["P1"], "count": [3]}).to_excel(
+            cam / "02_from_excel.xlsx", index=False
+        )
+        # Act
+        result = _tables_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert result["xlsx_converted"] == 1 and (cam / "02_from_excel.csv").exists()
+
+    def test_excel_derived_table_is_compiled(self, tmp_path):
+        # Arrange
+        import pandas as pd
+
+        project, cam = _seed_project(tmp_path, csv_text=None)
+        pd.DataFrame({"patient": ["P1"], "count": [3]}).to_excel(
+            cam / "02_from_excel.xlsx", index=False
+        )
+        # Act
+        _tables_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert (_compiled_dir(project) / "02_from_excel.tex").exists()
+
+
+class TestRenderStage:
+    def test_csv_is_rendered_to_compiled_tex(self, tmp_path):
+        # Arrange
+        project, _ = _seed_project(tmp_path)
+        # Act
+        result = _tables_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert (
+            result["tables_compiled"] == 1
+            and (_compiled_dir(project) / "01_seizure_count.tex").exists()
+        )
+
+    def test_verbatim_math_cell_survives_pipeline(self, tmp_path):
+        # Arrange
+        project, _ = _seed_project(
+            tmp_path, csv_text="metric,value\nsignificance,$p<0.001$\n"
+        )
+        # Act
+        _tables_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert (
+            "$p<0.001$" in (_compiled_dir(project) / "01_seizure_count.tex").read_text()
+        )
+
+    def test_stale_compiled_tex_is_cleared(self, tmp_path):
+        # Arrange
+        project, _ = _seed_project(tmp_path)
+        compiled = _compiled_dir(project)
+        compiled.mkdir(parents=True)
+        stale = compiled / "99_stale.tex"
+        stale.write_text("stale", encoding="utf-8")
+        # Act
+        _tables_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert not stale.exists()
+
+    def test_per_table_outcome_reports_shape(self, tmp_path):
+        # Arrange
+        project, _ = _seed_project(tmp_path)
+        # Act
+        result = _tables_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert result["tables"][0]["rows"] == 2 and result["tables"][0]["columns"] == 3
+
+
+class TestGatherStage:
+    def test_final_tex_guards_inline_placed_table(self, tmp_path):
+        # Arrange
+        project, _ = _seed_project(tmp_path)
+        # Act
+        _tables_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert (
+            "\\ifcsname scitextabplaced@01\\endcsname"
+            in (_compiled_dir(project) / "FINAL.tex").read_text()
+        )
+
+    def test_placeable_copy_is_written_by_number(self, tmp_path):
+        # Arrange
+        project, _ = _seed_project(tmp_path)
+        # Act
+        _tables_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert (_compiled_dir(project) / "_placeable/01.tex").exists()
+
+    def test_no_tables_emits_fallback_header(self, tmp_path):
+        # Arrange
+        project, _ = _seed_project(tmp_path, csv_text=None)
+        # Act
+        result = _tables_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert result["fallback_header"] is True and result["tables_compiled"] == 0
+
+    def test_fallback_header_emits_no_table_float(self, tmp_path):
+        # Arrange
+        project, _ = _seed_project(tmp_path, csv_text=None)
+        # Act
+        _tables_pipeline.process(str(project), "manuscript")
+        header = (_compiled_dir(project) / "00_Tables_Header.tex").read_text()
+        active = "\n".join(
+            line for line in header.splitlines() if not line.lstrip().startswith("%")
+        )
+        # Assert
+        assert "\\begin{table}" not in active
+
+    def test_fallback_header_emits_no_zero_label(self, tmp_path):
+        # Arrange
+        project, _ = _seed_project(tmp_path, csv_text=None)
+        # Act
+        _tables_pipeline.process(str(project), "manuscript")
+        header = (_compiled_dir(project) / "00_Tables_Header.tex").read_text()
+        active = "\n".join(
+            line for line in header.splitlines() if not line.lstrip().startswith("%")
+        )
+        # Assert
+        assert "\\label{tab:" not in active
+
+    def test_real_table_replaces_fallback_header(self, tmp_path):
+        # Arrange
+        project, _ = _seed_project(tmp_path)
+        # Act
+        _tables_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert not (_compiled_dir(project) / "00_Tables_Header.tex").exists()
+
+
+@pytest.mark.skipif(
+    shutil.which("pdflatex") is None, reason="pdflatex not available in-container"
+)
+class TestPdflatexSmoke:
+    def test_generated_table_compiles_to_pdf(self, tmp_path):
+        # Arrange: real pipeline output, real pdflatex -- the port is only correct
+        # if what it writes actually typesets.
+        project, _ = _seed_project(
+            tmp_path,
+            csv_text="model,$R^2$,p\nlinear,0.333,$p<0.001$\nridge,0.35,$p=0.02$\n",
+        )
+        _tables_pipeline.process(str(project), "manuscript")
+        work = tmp_path / "build"
+        work.mkdir()
+        table = (_compiled_dir(project) / "01_seizure_count.tex").read_text()
+        (work / "doc.tex").write_text(
+            _PREAMBLE + "\\begin{document}\n" + table + "\n\\end{document}\n",
+            encoding="utf-8",
+        )
+        # Act
+        subprocess.run(
+            ["pdflatex", "-interaction=nonstopmode", "-halt-on-error", "doc.tex"],
+            cwd=str(work),
+            capture_output=True,
+            text=True,
+        )
+        # Assert
+        assert (work / "doc.pdf").is_file()
+
+    def test_gathered_final_tex_compiles_to_pdf(self, tmp_path):
+        # Arrange: compile the gathered FINAL.tex (the file the manuscript inputs),
+        # exercising the guarded \input + \pdfbookmark path end to end.
+        project, _ = _seed_project(tmp_path)
+        _tables_pipeline.process(str(project), "manuscript")
+        work = tmp_path / "build_final"
+        work.mkdir()
+        final = _compiled_dir(project) / "FINAL.tex"
+        (work / "doc.tex").write_text(
+            _PREAMBLE
+            + "\\begin{document}\n"
+            + f"\\input{{{final}}}\n"
+            + "\\end{document}\n",
+            encoding="utf-8",
+        )
+        # Act
+        subprocess.run(
+            ["pdflatex", "-interaction=nonstopmode", "-halt-on-error", "doc.tex"],
+            cwd=str(work),
+            capture_output=True,
+            text=True,
+        )
+        # Assert
+        assert (work / "doc.pdf").is_file()
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))
+
+# EOF

--- a/tests/scitex_writer/_utils/test__csv_table.py
+++ b/tests/scitex_writer/_utils/test__csv_table.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_writer/_utils/test__csv_table.py
+
+r"""Tests for the single pandas CSV -> LaTeX table backend.
+
+The verbatim-passthrough cases are the regression guard for card
+writer-csv-latex-verbatim-all-backends: with ONE backend there is no longer a
+path (csv2latex binary / AWK fallback) that can silently escape an authored
+``$p<0.001$`` or ``\textit{r}``.
+"""
+
+import pytest
+
+from scitex_writer._utils._csv_table import (
+    caption_title,
+    is_verbatim,
+    render_csv_table,
+    split_table_name,
+)
+
+_CAPTION_WITH_LABEL = (
+    "\\caption{\\textbf{Seizure counts}\\\\ Per-patient totals.}\n"
+    "\\label{tab:01_seizure_count}\n"
+)
+_CAPTION_NO_LABEL = "\\caption{\\textbf{Seizure counts}\\\\ Per-patient totals.}\n"
+
+
+def _write_csv(tmp_path, text, name="01_seizure_count.csv"):
+    csv_file = tmp_path / name
+    csv_file.write_text(text, encoding="utf-8")
+    return csv_file
+
+
+class TestVerbatimPassthrough:
+    def test_math_cell_passes_through_unescaped(self, tmp_path):
+        # Arrange
+        csv_file = _write_csv(tmp_path, "metric,value\nsignificance,$p<0.001$\n")
+        # Act
+        latex = render_csv_table(csv_file)
+        # Assert
+        assert "$p<0.001$" in latex
+
+    def test_latex_command_cell_passes_through(self, tmp_path):
+        # Arrange
+        csv_file = _write_csv(tmp_path, "metric,value\ncorrelation,\\textit{r}\n")
+        # Act
+        latex = render_csv_table(csv_file)
+        # Assert
+        assert "\\textit{r}" in latex
+
+    def test_math_header_passes_through_unescaped(self, tmp_path):
+        # Arrange
+        csv_file = _write_csv(tmp_path, "model,$R^2$\nlinear,0.9\n")
+        # Act
+        latex = render_csv_table(csv_file)
+        # Assert
+        assert "\\textbf{$R^2$}" in latex
+
+    def test_plain_underscore_cell_is_escaped(self, tmp_path):
+        # Arrange
+        csv_file = _write_csv(tmp_path, "metric,value\nname,mean_iou\n")
+        # Act
+        latex = render_csv_table(csv_file)
+        # Assert
+        assert "mean\\_iou" in latex
+
+    def test_plain_ampersand_cell_is_escaped(self, tmp_path):
+        # Arrange
+        csv_file = _write_csv(tmp_path, "metric,value\nname,A & B\n")
+        # Act
+        latex = render_csv_table(csv_file)
+        # Assert
+        assert "A \\& B" in latex
+
+    def test_is_verbatim_flags_dollar_value(self):
+        # Arrange
+        value = "$p<0.05$"
+        # Act
+        flagged = is_verbatim(value)
+        # Assert
+        assert flagged is True
+
+
+class TestNumberFormatting:
+    def test_integer_column_stays_bare(self, tmp_path):
+        # Arrange
+        csv_file = _write_csv(tmp_path, "patient,count\nP1,288\nP2,12\n")
+        # Act
+        latex = render_csv_table(csv_file)
+        # Assert
+        assert "288.000" not in latex
+
+    def test_decimal_column_pads_to_max_precision(self, tmp_path):
+        # Arrange
+        csv_file = _write_csv(tmp_path, "model,score\nA,0.333\nB,0.35\n")
+        # Act
+        latex = render_csv_table(csv_file)
+        # Assert
+        assert "0.350" in latex
+
+    def test_numeric_column_is_right_aligned(self, tmp_path):
+        # Arrange
+        csv_file = _write_csv(tmp_path, "model,score\nA,0.5\n")
+        # Act
+        latex = render_csv_table(csv_file)
+        # Assert
+        assert "\\begin{tabular}{lr}" in latex
+
+
+class TestBookmarkAndLabel:
+    def test_bookmark_carries_caption_title(self, tmp_path):
+        # Arrange
+        csv_file = _write_csv(tmp_path, "a,b\n1,2\n")
+        # Act
+        latex = render_csv_table(csv_file, caption=_CAPTION_NO_LABEL)
+        # Assert
+        assert "\\pdfbookmark[2]{Table 1 --- Seizure counts}" in latex
+
+    def test_bookmark_bare_number_without_caption(self, tmp_path):
+        # Arrange
+        csv_file = _write_csv(tmp_path, "a,b\n1,2\n")
+        # Act
+        latex = render_csv_table(csv_file)
+        # Assert
+        assert "\\pdfbookmark[2]{Table 1}{table_01_seizure_count}" in latex
+
+    def test_label_omitted_when_caption_has_label(self, tmp_path):
+        # Arrange
+        csv_file = _write_csv(tmp_path, "a,b\n1,2\n")
+        # Act
+        latex = render_csv_table(csv_file, caption=_CAPTION_WITH_LABEL)
+        # Assert
+        assert latex.count("\\label{tab:01_seizure_count}") == 1
+
+    def test_label_emitted_when_caption_lacks_label(self, tmp_path):
+        # Arrange
+        csv_file = _write_csv(tmp_path, "a,b\n1,2\n")
+        # Act
+        latex = render_csv_table(csv_file, caption=_CAPTION_NO_LABEL)
+        # Assert
+        assert "\\label{tab:01_seizure_count}" in latex
+
+    def test_default_caption_generated_without_caption(self, tmp_path):
+        # Arrange
+        csv_file = _write_csv(tmp_path, "a,b\n1,2\n")
+        # Act
+        latex = render_csv_table(csv_file)
+        # Assert
+        assert "\\caption{\\textbf{Table 1: seizure count}" in latex
+
+    def test_caption_title_reads_textbf_block(self):
+        # Arrange
+        caption = _CAPTION_NO_LABEL
+        # Act
+        title = caption_title(caption)
+        # Assert
+        assert title == "Seizure counts"
+
+    def test_split_table_name_strips_leading_zeros(self):
+        # Arrange
+        base_name = "01_seizure_count"
+        # Act
+        number, clean = split_table_name(base_name)
+        # Assert
+        assert (number, clean) == ("1", "seizure count")
+
+
+class TestTruncation:
+    def test_long_table_emits_omitted_rows_marker(self, tmp_path):
+        # Arrange
+        rows = "\n".join(f"P{i},{i}" for i in range(40))
+        csv_file = _write_csv(tmp_path, f"patient,count\n{rows}\n")
+        # Act
+        latex = render_csv_table(csv_file)
+        # Assert
+        assert "rows omitted" in latex
+
+    def test_long_table_notes_truncation_in_caption(self, tmp_path):
+        # Arrange
+        rows = "\n".join(f"P{i},{i}" for i in range(40))
+        csv_file = _write_csv(tmp_path, f"patient,count\n{rows}\n")
+        # Act
+        latex = render_csv_table(csv_file, caption=_CAPTION_NO_LABEL)
+        # Assert
+        assert "Note: Table truncated to 30 rows from 40 total rows" in latex
+
+
+class TestFailLoud:
+    def test_missing_csv_raises_file_not_found(self, tmp_path):
+        # Arrange
+        absent = tmp_path / "99_absent.csv"
+        # Act
+        render = lambda: render_csv_table(absent)  # noqa: E731
+        # Assert
+        with pytest.raises(FileNotFoundError, match="CSV file not found"):
+            render()
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))
+
+# EOF


### PR DESCRIPTION
Slice 4 of the shell → Python engine port (card `writer-engine-shell-to-python-wrap`). Ports `scripts/shell/modules/process_tables.sh` plus its sourced `process_tables_modules/03_csv2tex.src` and `04_gather.src` into pure Python inside the package, and RESOLVES the blocked card `writer-csv-latex-verbatim-all-backends`.

## The five ported stages

`scitex_writer._mcp.handlers._tables_pipeline` runs them in order, reading the SAME config keys the shell read via `yq` (`tables.dir`, `tables.caption_media_dir`, `tables.compiled_dir`, `tables.compiled_file` from `config/config_<doc_type>.yaml`):

1. **`init_tables`** — clear `compiled_dir/*.tex`, create the table dirs, truncate the gathered `FINAL.tex`.
2. **`xlsx2csv_convert`** — refresh `NN_*.csv` from a newer `NN_*.xlsx/.xls` (pandas first, `xlsx2csv` binary as the second route; loud on failure, never a silently missing table).
3. **`ensure_caption`** — write the default caption for any table lacking one (a symlinked caption counts as present, as in the shell's `-f || -L`).
4. **`csv2tex`** — render every `NN_*.csv` through the single pandas backend.
5. **`gather_table_tex_files`** — assemble `FINAL.tex` + the `_placeable/<number>.tex` copies, with the guarded `\ifcsname scitextabplaced@<n>` end-block `\input` so an inline-placed table is not duplicated.

## One backend — and why that IS the verbatim fix

The shell picked one of FOUR csv→LaTeX backends at runtime: the `csv2latex` binary (preferred when installed), python+pandas (`scripts/python/csv_to_latex.py`), "python basic", or an AWK fallback. The whole-cell **verbatim passthrough** (a header/cell containing `$` or `\` is authored LaTeX/math and must be emitted as-is, never escaped — added in #162) lived **only in the Python backend**. So on any machine with `csv2latex` installed, or with no pandas, an authored `$p<0.001$` / `$R^2$` / `\textit{r}` was silently escaped or mangled — that is card `writer-csv-latex-verbatim-all-backends`.

This PR collapses the four backends to **one pandas backend** (`src/scitex_writer/_utils/_csv_table.py`), absorbing `csv_to_latex.py`'s passthrough, number formatting, per-column decimal alignment and escaping. The passthrough is now universal **by construction**: there is no other code path left that could lose it.

## Parity cases carried over from the shell

- default-caption generation for tables with no `NN_*.tex` (same `%% Edit this file:` + `\url{...}` body);
- `\pdfbookmark[2]{Table N --- Title}{table_<base>}`, with the title lifted from the caption's `\textbf{...}` (else the caption text up to its first period) — a bare `Table N` when the caption carries neither;
- `\label{tab:<base>}` emitted **only** when the caption does not already contain a `\label{tab:` (no duplicate labels);
- column-count-dependent `\tabcolsep`, `\footnotesize`, shrink-to-fit `\resizebox` (never stretches a narrow table), booktabs rules, bold headers, `\rowcolor{lightgray}` zebra striping, 30-row truncation with the "... N rows omitted ..." marker and the caption note;
- **the no-tables fallback header emits NO table float** — only LaTeX comments (card `writer-stray-table-zero-artifact`: the old placeholder float rendered as a stray counter-numbered "Table 0" carrying `\label{tab:0_Tables_Header}`). Guarded by dedicated tests, same as the shell-side `test_table_no_stray_float.py`.

## Surfaces

- Python: `scitex_writer.tables.render(project_dir, doc_type, no_tables)` → `TablesResult` (`{success, tables_compiled, captions_created, xlsx_converted, tables[], compiled_file, fallback_header, skipped, error}`).
- CLI: `scitex-writer tables render [-t doc-type] [--no-tables] [--json]`.
- MCP: `writer_tables_render`.

Mirrors the slice-3 (cleanup, #271) structure exactly: handler + result dataclass + thin public module + CLI + MCP tool.

## Verification

- **Real pdflatex compile smoke** (no mocks — PA-306): the pipeline's own output is wrapped in a minimal document and compiled with the real `pdflatex`; both a single generated table (with verbatim `$R^2$` / `$p<0.001$` cells) and the gathered `FINAL.tex` (guarded `\input` + `\pdfbookmark` path) must produce a PDF.
- 40 new tests (19 backend + 21 pipeline), full package suite **642 passed**.
- `scitex-dev ecosystem audit-all scitex-writer` clean (exit 0, no violations).

## Deliberately NOT ported

- `\restoregeometry` (trailing line of `scripts/python/csv_to_latex.py`): the float never calls `\newgeometry`, so it was a no-op at best and a hard error in a document without `geometry`.
- `check_csv_for_special_chars` (the shell's grep-based warning): the single backend now escapes or passes through every cell deterministically, so the "these may need proper LaTeX escaping" warning has nothing left to warn about.
- The shell scripts themselves stay in place — this slice adds the Python path; removing the shell is a later slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
