### PR TITLE
fix(tables): escape % and & inside verbatim cells (silent row corruption)

### DIFF
--- a/src/scitex_writer/_utils/_csv_table.py
+++ b/src/scitex_writer/_utils/_csv_table.py
@@ -78,6 +78,25 @@ def is_verbatim(value) -> bool:
     return "$" in text or "\\" in text
 
 
+# In a verbatim cell these are NEVER valid unescaped, and each corrupts the
+# table SILENTLY rather than erroring: a bare `%` comments out the rest of the
+# row (including its `\\` terminator, so the next row is swallowed too), and a
+# bare `&` opens a phantom column. Escaping them is therefore always the
+# author's intent -- unlike `$`/`\`/`_`/`^`, which carry meaning in math and
+# must survive untouched.
+_VERBATIM_UNSAFE_RE = re.compile(r"(?<!\\)([%&])")
+
+
+def protect_verbatim(text: str) -> str:
+    r"""Escape the silently-corrupting chars inside an authored-LaTeX cell.
+
+    A MIXED cell -- prose next to math, e.g. ``5% ($p<0.05$)`` -- is verbatim
+    (it contains ``$``), so a naive passthrough left its ``%`` bare and LaTeX
+    ate the rest of the row. Already-escaped ``\%`` / ``\&`` are left alone.
+    """
+    return _VERBATIM_UNSAFE_RE.sub(r"\\\1", text)
+
+
 def format_number(val):
     """Format a number for LaTeX: ints bare, tiny values scientific, else 3 dp."""
     try:
@@ -139,7 +158,7 @@ def _render_cell(val, precision: Optional[int]) -> str:
     if not pd.notna(val):
         return "--"
     if is_verbatim(val):
-        return str(val)
+        return protect_verbatim(str(val))
     return escape_latex(_format_aligned(val, precision))
 
 
@@ -149,7 +168,10 @@ def _render_header(col) -> str:
     Underscores become spaces (``mean_iou`` -> ``mean iou``). NOT title-cased:
     acronyms must survive as authored (``ROC-AUC`` stays ``ROC-AUC``).
     """
-    header = str(col) if is_verbatim(col) else escape_latex(col).replace("\\_", " ")
+    if is_verbatim(col):
+        header = protect_verbatim(str(col))
+    else:
+        header = escape_latex(col).replace("\\_", " ")
     return f"\\textbf{{{header}}}"
 
 
@@ -336,6 +358,7 @@ __all__ = [
     "escape_latex",
     "format_number",
     "is_verbatim",
+    "protect_verbatim",
     "render_csv_table",
     "split_table_name",
 ]

--- a/tests/scitex_writer/_utils/test__csv_table.py
+++ b/tests/scitex_writer/_utils/test__csv_table.py
@@ -10,11 +10,15 @@ path (csv2latex binary / AWK fallback) that can silently escape an authored
 ``$p<0.001$`` or ``\textit{r}``.
 """
 
+import shutil
+import subprocess
+
 import pytest
 
 from scitex_writer._utils._csv_table import (
     caption_title,
     is_verbatim,
+    protect_verbatim,
     render_csv_table,
     split_table_name,
 )
@@ -184,6 +188,94 @@ class TestTruncation:
         latex = render_csv_table(csv_file, caption=_CAPTION_NO_LABEL)
         # Assert
         assert "Note: Table truncated to 30 rows from 40 total rows" in latex
+
+
+class TestMixedCellProtection:
+    r"""A cell mixing prose and math is verbatim, but its ``%`` / ``&`` must
+    still be escaped: a bare ``%`` comments out the rest of the LaTeX row
+    (swallowing its ``\\`` terminator and the next row with it), and a bare
+    ``&`` opens a phantom column. Both corrupt SILENTLY -- the table renders
+    wrong rather than failing.
+    """
+
+    def test_percent_beside_math_is_escaped(self, tmp_path):
+        # Arrange
+        csv_file = _write_csv(tmp_path, "metric,value\nrate,5% ($p<0.05$)\n")
+        # Act
+        latex = render_csv_table(csv_file)
+        # Assert
+        assert "5\\% ($p<0.05$)" in latex
+
+    def test_math_survives_beside_the_escaped_percent(self, tmp_path):
+        # Arrange
+        csv_file = _write_csv(tmp_path, "metric,value\nrate,5% ($p<0.05$)\n")
+        # Act
+        latex = render_csv_table(csv_file)
+        # Assert
+        assert "$p<0.05$" in latex
+
+    def test_ampersand_beside_math_is_escaped(self, tmp_path):
+        # Arrange
+        csv_file = _write_csv(tmp_path, "metric,value\ngroups,A & B ($n=3$)\n")
+        # Act
+        latex = render_csv_table(csv_file)
+        # Assert
+        assert "A \\& B ($n=3$)" in latex
+
+    def test_already_escaped_percent_is_not_double_escaped(self, tmp_path):
+        # Arrange
+        csv_file = _write_csv(tmp_path, "metric,value\nrate,5\\% ($p<0.05$)\n")
+        # Act
+        latex = render_csv_table(csv_file)
+        # Assert
+        assert "\\\\%" not in latex
+
+    def test_protect_verbatim_leaves_pure_math_untouched(self):
+        # Arrange
+        cell = "$p<0.001$"
+        # Act
+        protected = protect_verbatim(cell)
+        # Assert
+        assert protected == cell
+
+    def test_clew_macro_cell_survives_protection(self):
+        # Arrange
+        cell = "\\clewval{seizure_rate}"
+        # Act
+        protected = protect_verbatim(cell)
+        # Assert
+        assert protected == cell
+
+
+@pytest.mark.skipif(shutil.which("pdflatex") is None, reason="pdflatex not installed")
+class TestRealCompile:
+    def test_mixed_percent_math_table_compiles_to_pdf(self, tmp_path):
+        # Arrange
+        csv_file = _write_csv(tmp_path, "metric,value\nrate,5% ($p<0.05$)\n")
+        body = render_csv_table(csv_file, caption=_CAPTION_NO_LABEL)
+        doc = tmp_path / "doc.tex"
+        # The fragment uses \toprule (booktabs), \resizebox (graphicx),
+        # \captionsetup (caption) and \pdfbookmark (hyperref) — the real
+        # manuscript loads these via 00_shared/latex_styles/packages.tex.
+        doc.write_text(
+            "\\documentclass{article}\n"
+            "\\usepackage{booktabs}\n"
+            "\\usepackage{graphicx}\n"
+            "\\usepackage{caption}\n"
+            "\\usepackage{hyperref}\n"
+            "\\begin{document}\n"
+            f"{body}\n\\end{{document}}\n",
+            encoding="utf-8",
+        )
+        # Act
+        subprocess.run(
+            ["pdflatex", "-interaction=nonstopmode", "-halt-on-error", doc.name],
+            cwd=tmp_path,
+            capture_output=True,
+            check=True,
+        )
+        # Assert
+        assert (tmp_path / "doc.pdf").exists()
 
 
 class TestFailLoud:


### PR DESCRIPTION
## The bug
A cell mixing prose and math — `5% ($p<0.05$)` — is `is_verbatim()` (it contains `$`), so slice 4's passthrough emitted its `%` **bare**. LaTeX then comments out the rest of the row, swallowing the `\\` terminator and the following row with it. A bare `&` likewise opens a phantom column. Neither errors — the table just renders **wrong**.

Pure-math cells (`$p<0.001$`) were always fine; only mixed cells were exposed. I found this by probing the just-merged converter after the operator asked whether pandas made table output trustworthy.

## The fix
`protect_verbatim()` escapes an **unescaped** `%` or `&` inside a verbatim cell — neither is ever valid bare, in text or in math, so escaping is unambiguously the author's intent — while `$`, `\`, `_`, `^` pass through untouched because they carry meaning in math. `\%` is not double-escaped. Applied to headers and data cells.

Bonus, verified: a `\clewval{id}` cell survives protection intact, so per-value clew provenance works through the table pipeline.

## Test plan
- [x] 6 new unit tests (percent/ampersand beside math; math survives; no double-escape; pure math untouched; clew macro untouched)
- [x] REAL pdflatex compile of the offending mixed cell → PDF produced
- [x] Full suite: 1560 passed, 3 skipped
- [x] `scitex-dev ecosystem audit-all`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)