### PR TITLE
feat(engine): pure-Python diff + archive pipelines — shell-port slice 6

### DIFF
--- a/src/scitex_writer/_cli/commands/compile.py
+++ b/src/scitex_writer/_cli/commands/compile.py
@@ -12,7 +12,12 @@ from pathlib import Path
 import click
 
 from .._core import main_group
-from .._helpers import _ENGINE_CHOICES, _emit_json, _print_compile_result
+from .._helpers import (
+    _DOC_TYPE,
+    _ENGINE_CHOICES,
+    _emit_json,
+    _print_compile_result,
+)
 
 # =========================================================================
 # compile group  (LaTeX domain — names preserved verbatim)
@@ -212,6 +217,111 @@ def compile_content(
         keep_aux=keep_aux,
     )
     return _print_compile_result(result, as_json)
+
+
+# =========================================================================
+# The two pipelines ported from the shell engine in slice 6. They live under
+# `compile` (not as their own groups) because `diff` and `archive` are VERBS:
+# they are leaves of a noun group, and this keeps CLI / Python API / MCP
+# aligned -- `compile diff` <-> `sw.compile.diff` <-> `writer_compile_diff`.
+# =========================================================================
+
+
+@compile_group.command("diff")
+@click.option("-p", "--project", default=".", help="Project path.")
+@click.option("-t", "--doc-type", type=_DOC_TYPE, default="manuscript")
+@click.option(
+    "--from",
+    "diff_from",
+    default=None,
+    help="Commit-ish to diff FROM (default: the previous commit touching the tex).",
+)
+@click.option("--no-diff", is_flag=True, default=False, help="Skip the diff pipeline.")
+@click.option(
+    "--timeout",
+    "timeout_sec",
+    type=int,
+    default=120,
+    show_default=True,
+    help="Bound on the latexmk run, in seconds.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit JSON.")
+def compile_diff(project, doc_type, diff_from, no_diff, timeout_sec, as_json):
+    """Build the version-diff PDF (latexdiff markup vs the previous version).
+
+    The pure-Python diff engine (port of process_diff.sh): reads the previous
+    version of the compiled .tex from git, runs latexdiff, stamps a signature
+    block, and compiles the result with latexmk. With NO previous version it FAILS
+    rather than emitting an unmarked PDF that looks like "nothing changed".
+
+    \b
+    Example:
+        $ scitex-writer compile diff
+        $ scitex-writer compile diff --from v1.0 -t supplementary --json
+    """
+    from ... import compile as compile_api
+
+    result = compile_api.diff(project, doc_type, no_diff, diff_from, timeout_sec)
+    if as_json:
+        _emit_json(result)
+        return 0 if result.get("success") else 1
+    if not result.get("success"):
+        click.echo(f"Error: {result['error']}", err=True)
+        return 1
+    if result["skipped"]:
+        click.echo("Skipped the diff pipeline (--no-diff).")
+        return 0
+    click.echo(
+        f"Diff {result['from_hash']} -> {result['to_hash']} "
+        f"({result['pdf_bytes']} bytes) -> {result['diff_pdf']}"
+    )
+    return 0
+
+
+@compile_group.command("archive")
+@click.option("-p", "--project", default=".", help="Project path.")
+@click.option("-t", "--doc-type", type=_DOC_TYPE, default="manuscript")
+@click.option(
+    "--no-archive", is_flag=True, default=False, help="Skip the archive pipeline."
+)
+@click.option("--dry-run", is_flag=True, default=False, help="Print, don't archive.")
+@click.option("--yes", "-y", is_flag=True, default=False, help="Skip confirmations.")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit JSON.")
+def compile_archive(project, doc_type, no_archive, dry_run, yes, as_json):
+    """Snapshot the compiled outputs into the versions directory.
+
+    The pure-Python archive engine (port of process_archive.sh): copies the
+    compiled PDF/TeX and the diff PDF/TeX to <archive_dir>/<stem>_<timestamp>_
+    <commit>.<ext>, plus an un-stamped "current" copy of each. A DIRTY working
+    tree is skipped -- a snapshot stamped with a commit it does not hold is a lie.
+
+    \b
+    Example:
+        $ scitex-writer compile archive
+        $ scitex-writer compile archive --dry-run
+    """
+    from ... import compile as compile_api
+
+    if dry_run:
+        if as_json:
+            _emit_json({"would_archive": doc_type, "project": project})
+        else:
+            click.echo(f"Would archive the compiled {doc_type} outputs.")
+        return 0
+    result = compile_api.archive(project, doc_type, no_archive)
+    if as_json:
+        _emit_json(result)
+        return 0 if result.get("success") else 1
+    if not result.get("success"):
+        click.echo(f"Error: {result['error']}", err=True)
+        return 1
+    if result["skipped"]:
+        click.echo(f"Skipped: {result['skip_reason']}")
+        return 0
+    click.echo(f"Archive {result['archive_id']} -> {result['versions_dir']}")
+    for entry in result["archived"]:
+        click.echo(f"  {entry['source']} -> {entry['archived']}")
+    return 0
 
 
 # EOF

--- a/src/scitex_writer/_dataclasses/__init__.py
+++ b/src/scitex_writer/_dataclasses/__init__.py
@@ -16,9 +16,11 @@ from .config import WriterConfig
 from .contents import ManuscriptContents, RevisionContents, SupplementaryContents
 from .core import Document, DocumentSection
 from .results import (
+    ArchiveResult,
     CitationStyleResult,
     CleanupResult,
     CompilationResult,
+    DiffResult,
     FiguresResult,
     LaTeXIssue,
     TablesResult,
@@ -44,9 +46,11 @@ __all__ = [
     "SupplementaryContents",
     "RevisionContents",
     # Configuration and results
+    "ArchiveResult",
     "CitationStyleResult",
     "CleanupResult",
     "CompilationResult",
+    "DiffResult",
     "WriterConfig",
     "FiguresResult",
     "LaTeXIssue",

--- a/src/scitex_writer/_dataclasses/results/_ArchiveResult.py
+++ b/src/scitex_writer/_dataclasses/results/_ArchiveResult.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_dataclasses/results/_ArchiveResult.py
+
+"""ArchiveResult - outcome of one run of the compiled-output archive pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class ArchiveResult:
+    """Result of snapshotting the compiled outputs into the versions directory.
+
+    An archive is only taken on a CLEAN working tree -- a snapshot stamped with a
+    commit hash it does not actually contain would be a lie. A dirty tree is a
+    ``skipped=True`` success carrying ``skip_reason``, never a silent no-op.
+    """
+
+    success: bool
+    """Whether the archive run completed."""
+
+    archive_id: Optional[str] = None
+    """The snapshot identifier ``YYYYmmdd-HHMMSS_<short7>``."""
+
+    archived: List[dict] = field(default_factory=list)
+    """One ``{source, archived, current}`` entry per file actually copied."""
+
+    versions_dir: Optional[str] = None
+    """Absolute path of the directory the snapshot was written to."""
+
+    missing: List[str] = field(default_factory=list)
+    """Configured outputs that did not exist (e.g. no diff PDF was built)."""
+
+    skipped: bool = False
+    """True when nothing was archived (dirty tree, or the caller opted out)."""
+
+    skip_reason: Optional[str] = None
+    """Why the run was skipped; set iff ``skipped`` is True."""
+
+    error: Optional[str] = None
+    """Actionable error message when ``success`` is False; else None."""
+
+    def to_dict(self) -> dict:
+        """Plain dict for JSON serialization across the CLI / MCP boundary."""
+        return {
+            "success": self.success,
+            "archive_id": self.archive_id,
+            "archived": self.archived,
+            "versions_dir": self.versions_dir,
+            "missing": self.missing,
+            "skipped": self.skipped,
+            "skip_reason": self.skip_reason,
+            "error": self.error,
+        }
+
+    def validate(self) -> None:
+        """Raise ValueError on an internally inconsistent result (fail-loud).
+
+        A skip must say WHY; a non-skipped success must carry the archive id it
+        stamped the snapshot with; and a skipped run must not claim archived files.
+        """
+        if self.success and self.error:
+            raise ValueError("ArchiveResult success=True but error is set")
+        if not self.success and not self.error:
+            raise ValueError("ArchiveResult success=False but no error message")
+        if self.skipped and not self.skip_reason:
+            raise ValueError("ArchiveResult skipped=True but no skip_reason given")
+        if self.skipped and self.archived:
+            raise ValueError(
+                f"ArchiveResult skipped=True but {len(self.archived)} files "
+                "were archived (the two are mutually exclusive)"
+            )
+        if self.success and not self.skipped and not self.archive_id:
+            raise ValueError(
+                "ArchiveResult success=True but no archive_id (every snapshot is "
+                "stamped with its timestamp + commit hash)"
+            )
+
+    def __str__(self) -> str:
+        if not self.success:
+            return f"Archive FAILED: {self.error}"
+        if self.skipped:
+            return f"Archive: skipped ({self.skip_reason})"
+        return (
+            f"Archive {self.archive_id}: {len(self.archived)} files -> "
+            f"{self.versions_dir}"
+        )
+
+
+__all__ = ["ArchiveResult"]
+
+# EOF

--- a/src/scitex_writer/_dataclasses/results/_DiffResult.py
+++ b/src/scitex_writer/_dataclasses/results/_DiffResult.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_dataclasses/results/_DiffResult.py
+
+"""DiffResult - outcome of one run of the version-diff (latexdiff) pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class DiffResult:
+    """Result of building the version-diff PDF for one document type.
+
+    ``from_hash`` / ``to_hash`` are the two versions actually compared -- never a
+    placeholder. The shell fell back to "current vs current" when it found no
+    previous version and still called the empty output a diff; this pipeline fails
+    instead, so a successful DiffResult always names two real versions.
+    """
+
+    success: bool
+    """Whether the diff document was built AND compiled."""
+
+    from_hash: Optional[str] = None
+    """Short hash of the OLD version fed to latexdiff."""
+
+    to_hash: Optional[str] = None
+    """Short hash of the NEW version ('+' suffix means uncommitted changes)."""
+
+    diff_tex: Optional[str] = None
+    """Absolute path of the generated diff LaTeX source."""
+
+    diff_pdf: Optional[str] = None
+    """Absolute path of the compiled diff PDF."""
+
+    pdf_bytes: int = 0
+    """Size of the compiled diff PDF (0 when no PDF was produced)."""
+
+    skipped: bool = False
+    """True when the run was skipped outright (the shell's ``--no_diff``)."""
+
+    error: Optional[str] = None
+    """Actionable error message when ``success`` is False; else None."""
+
+    def to_dict(self) -> dict:
+        """Plain dict for JSON serialization across the CLI / MCP boundary."""
+        return {
+            "success": self.success,
+            "from_hash": self.from_hash,
+            "to_hash": self.to_hash,
+            "diff_tex": self.diff_tex,
+            "diff_pdf": self.diff_pdf,
+            "pdf_bytes": self.pdf_bytes,
+            "skipped": self.skipped,
+            "error": self.error,
+        }
+
+    def validate(self) -> None:
+        """Raise ValueError on an internally inconsistent result (fail-loud).
+
+        A success carries no error; a failure must carry one. A non-skipped
+        success must name BOTH compared versions and point at a non-empty PDF --
+        an "empty diff" that reports success is exactly the silent degradation
+        this port removed.
+        """
+        if self.success and self.error:
+            raise ValueError("DiffResult success=True but error is set")
+        if not self.success and not self.error:
+            raise ValueError("DiffResult success=False but no error message")
+        if not isinstance(self.pdf_bytes, int) or self.pdf_bytes < 0:
+            raise ValueError(
+                f"DiffResult pdf_bytes must be a non-negative int, got "
+                f"{self.pdf_bytes!r}"
+            )
+        if self.success and not self.skipped:
+            if not (self.from_hash and self.to_hash):
+                raise ValueError(
+                    "DiffResult success=True but from_hash/to_hash is unset "
+                    "(a diff must name the two versions it compared)"
+                )
+            if not self.diff_pdf or not self.pdf_bytes:
+                raise ValueError(
+                    "DiffResult success=True but no non-empty diff_pdf was produced"
+                )
+
+    def __str__(self) -> str:
+        if not self.success:
+            return f"Diff FAILED: {self.error}"
+        if self.skipped:
+            return "Diff: skipped (--no-diff)"
+        return (
+            f"Diff: {self.from_hash} -> {self.to_hash} "
+            f"({self.pdf_bytes} bytes) -> {self.diff_pdf}"
+        )
+
+
+__all__ = ["DiffResult"]
+
+# EOF

--- a/src/scitex_writer/_dataclasses/results/__init__.py
+++ b/src/scitex_writer/_dataclasses/results/__init__.py
@@ -2,9 +2,11 @@
 # -*- coding: utf-8 -*-
 # File: src/scitex_writer/_dataclasses/results/__init__.py
 
+from ._ArchiveResult import ArchiveResult
 from ._CitationStyleResult import CitationStyleResult
 from ._CleanupResult import CleanupResult
 from ._CompilationResult import CompilationResult
+from ._DiffResult import DiffResult
 from ._FiguresResult import FiguresResult
 from ._LaTeXIssue import LaTeXIssue
 from ._SaveSectionsResponse import SaveSectionsResponse
@@ -13,9 +15,11 @@ from ._TablesResult import TablesResult
 from ._WordCountResult import WordCountResult
 
 __all__ = [
+    "ArchiveResult",
     "CitationStyleResult",
     "CleanupResult",
     "CompilationResult",
+    "DiffResult",
     "FiguresResult",
     "LaTeXIssue",
     "SaveSectionsResponse",

--- a/src/scitex_writer/_mcp/handlers/__init__.py
+++ b/src/scitex_writer/_mcp/handlers/__init__.py
@@ -4,6 +4,7 @@
 
 """MCP Handler implementations for SciTeX Writer."""
 
+from ._archive_pipeline import process as process_archive
 from ._checks import (
     check_caption_footnote,
     check_float_order,
@@ -24,6 +25,7 @@ from ._claim import (
     render_claims,
 )
 from ._compile import compile_manuscript, compile_revision, compile_supplementary
+from ._diff_pipeline import process as process_diff
 from ._export import export_manuscript
 from ._figures import convert_figure, list_figures, pdf_to_images
 from ._project import clone_project, get_pdf, get_project_info, list_document_types
@@ -58,6 +60,8 @@ __all__ = [
     "list_document_types",
     "list_figures",
     "pdf_to_images",
+    "process_archive",
+    "process_diff",
     "process_tables",
     "remove_claim",
     "render_claims",

--- a/src/scitex_writer/_mcp/handlers/_archive_pipeline.py
+++ b/src/scitex_writer/_mcp/handlers/_archive_pipeline.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_mcp/handlers/_archive_pipeline.py
+
+r"""The archive pipeline: a pure-Python port of ``process_archive.sh``.
+
+Ports the shell module stage for stage, reading the SAME config keys the shell
+read via ``yq`` out of ``config/config_<doc_type>.yaml``: ``paths.compiled_pdf``,
+``paths.compiled_tex``, ``paths.diff_pdf``, ``paths.diff_tex`` and
+``paths.archive_dir``.
+
+Stages (``process`` runs them in order):
+
+1. ``clean-tree gate`` -- archive ONLY when the working tree is clean; a snapshot
+                          stamped with a commit hash whose content it does not
+                          actually hold would be a lie. A dirty tree is a
+                          ``skipped=True`` success carrying ``skip_reason``.
+2. ``archive_id``      -- ``YYYYmmdd-HHMMSS_<short7>``.
+3. ``store_file`` x4   -- copy each compiled output to
+                          ``<archive_dir>/<stem>_<archive_id>.<ext>`` plus an
+                          un-stamped ``<stem>.<ext>`` "current" copy. A
+                          ``*_diff`` stem keeps its suffix LAST:
+                          ``manuscript_diff`` -> ``manuscript_<id>_diff``.
+
+One shell branch this port refuses as DEAD, not ported: ``get_git_identifier``
+substituted ``nogit`` / ``nocommit`` for the hash when the directory was not a
+repo or carried no commit -- but its only caller ran AFTER ``is_git_clean``, which
+returns false in exactly those two cases. Those identifiers could never be
+produced. This port requires a repo with commits (the gate already did) and
+therefore always stamps a REAL hash.
+
+Robust by construction: pathlib only (never shells out to cp/mkdir); every write
+target is resolved and asserted to live INSIDE the project root; fail-loud on a
+missing project dir / config.
+"""
+
+from __future__ import annotations
+
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from ..._dataclasses import ArchiveResult
+from ..._utils import _git
+from ..utils import resolve_project_path
+from ._engine_paths import DOC_DIRS, load_doc_config, resolve_paths
+
+_CFG_KEYS = {
+    "compiled_pdf": ("paths", "compiled_pdf"),
+    "compiled_tex": ("paths", "compiled_tex"),
+    "diff_pdf": ("paths", "diff_pdf"),
+    "diff_tex": ("paths", "diff_tex"),
+    "versions_dir": ("paths", "archive_dir"),
+}
+
+# The order the shell stored them in; also the order they appear in the result.
+_STORE_ORDER = ("compiled_pdf", "compiled_tex", "diff_pdf", "diff_tex")
+
+DIFF_SUFFIX = "_diff"
+
+
+def archive_id(project_path: Path, now: Optional[datetime] = None) -> str:
+    """The snapshot identifier: ``YYYYmmdd-HHMMSS_<short7>`` of HEAD.
+
+    Raises ValueError when HEAD does not resolve -- the caller must have passed
+    the clean-tree gate, which already guarantees it does, so this is a contract
+    check rather than a fallback.
+    """
+    stamp = (now or datetime.now()).strftime("%Y%m%d-%H%M%S")
+    short = _git.short_hash(project_path, "HEAD")
+    if short is None:
+        raise ValueError(
+            f"Cannot stamp an archive: HEAD does not resolve in {project_path}."
+        )
+    return f"{stamp}_{short}"
+
+
+def archived_name(stem: str, snapshot_id: str) -> str:
+    """The archived stem for ``stem`` in snapshot ``snapshot_id``.
+
+    ``manuscript`` -> ``manuscript_<id>``; ``manuscript_diff`` ->
+    ``manuscript_<id>_diff`` (the ``_diff`` marker stays LAST so the archive sorts
+    by document, not by kind -- the shell's rule).
+    """
+    if stem.endswith(DIFF_SUFFIX):
+        return f"{stem[: -len(DIFF_SUFFIX)]}_{snapshot_id}{DIFF_SUFFIX}"
+    return f"{stem}_{snapshot_id}"
+
+
+def store_file(source: Path, versions_dir: Path, snapshot_id: str) -> Optional[dict]:
+    """Copy ``source`` into ``versions_dir`` twice: stamped, and as "current".
+
+    Returns ``{source, archived, current}``, or None when ``source`` does not
+    exist (a project with no diff PDF is normal -- the shell logged and moved on).
+    """
+    if not source.is_file():
+        return None
+    versions_dir.mkdir(parents=True, exist_ok=True)
+    suffix = source.suffix
+    stamped = versions_dir / f"{archived_name(source.stem, snapshot_id)}{suffix}"
+    current = versions_dir / f"{source.stem}{suffix}"
+    shutil.copyfile(source, stamped)
+    shutil.copyfile(source, current)
+    return {
+        "source": str(source),
+        "archived": str(stamped),
+        "current": str(current),
+    }
+
+
+def process(
+    project_dir: str,
+    doc_type: str = "manuscript",
+    no_archive: bool = False,
+    now: Optional[datetime] = None,
+) -> dict:
+    """Snapshot the compiled outputs of ``doc_type`` into the versions directory.
+
+    Parameters
+    ----------
+    project_dir : str
+        Path to the scitex-writer project directory (must be a git repository).
+    doc_type : str
+        One of 'manuscript' (default), 'supplementary', 'revision'.
+    no_archive : bool
+        Skip the whole pipeline.
+    now : datetime, optional
+        Timestamp for the archive id. Injected by the tests; defaults to now.
+
+    Returns
+    -------
+    dict
+        The serialized :class:`ArchiveResult`. A DIRTY working tree is a
+        ``skipped`` success (an archive must match a real commit); a missing
+        project / config is a hard error with an actionable hint.
+    """
+    try:
+        if no_archive:
+            return ArchiveResult(
+                success=True, skipped=True, skip_reason="no_archive requested"
+            ).to_dict()
+
+        if doc_type not in DOC_DIRS:
+            return {
+                "success": False,
+                "error": (
+                    f"Invalid doc_type '{doc_type}'. Must be one of: {tuple(DOC_DIRS)}"
+                ),
+            }
+
+        project_path = resolve_project_path(project_dir)
+        if not project_path.is_dir():
+            return {
+                "success": False,
+                "error": (
+                    f"Project directory not found: {project_path}. "
+                    f"Check the path passed as project_dir."
+                ),
+            }
+
+        cfg, error = load_doc_config(project_path, doc_type)
+        if error:
+            return {"success": False, "error": error}
+        paths, error = resolve_paths(project_path, cfg, _CFG_KEYS, "paths")
+        if error:
+            return {"success": False, "error": error}
+
+        versions_dir = paths["versions_dir"]
+        versions_dir.mkdir(parents=True, exist_ok=True)
+
+        if not _git.is_clean(project_path):
+            reason = (
+                "uncommitted changes in the working tree -- an archive is stamped "
+                "with a commit hash, so it may only snapshot a clean tree. "
+                "Fix: commit your changes, then archive."
+            )
+            result = ArchiveResult(
+                success=True,
+                skipped=True,
+                skip_reason=reason,
+                versions_dir=str(versions_dir),
+            )
+            result.validate()
+            return result.to_dict()
+
+        snapshot_id = archive_id(project_path, now=now)
+
+        archived, missing = [], []
+        for name in _STORE_ORDER:
+            stored = store_file(paths[name], versions_dir, snapshot_id)
+            if stored is None:
+                missing.append(str(paths[name]))
+            else:
+                archived.append(stored)
+
+        result = ArchiveResult(
+            success=True,
+            archive_id=snapshot_id,
+            archived=archived,
+            versions_dir=str(versions_dir),
+            missing=missing,
+        )
+        result.validate()
+        return result.to_dict()
+    except Exception as e:
+        return {"success": False, "error": f"{type(e).__name__}: {e}"}
+
+
+__all__ = ["archive_id", "archived_name", "process", "store_file"]
+
+# EOF

--- a/src/scitex_writer/_mcp/handlers/_diff_pipeline.py
+++ b/src/scitex_writer/_mcp/handlers/_diff_pipeline.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_mcp/handlers/_diff_pipeline.py
+
+r"""The diff pipeline: a pure-Python port of ``process_diff.sh``.
+
+Ports the shell module (plus the ``add_diff_signature.sh`` it sourced) stage for
+stage, reading the SAME config keys the shell read via ``yq`` out of
+``config/config_<doc_type>.yaml``: ``paths.compiled_tex``, ``paths.diff_tex``,
+``paths.diff_pdf`` and ``paths.doc_log_dir``.
+
+Stages (``process`` runs them in order):
+
+1. ``resolve_versions``  -- pick the OLD commit (explicit ``diff_from``, else the
+                            previous commit that touched the compiled ``.tex``)
+                            and the NEW label (``HEAD``, ``+``-suffixed when the
+                            tree is dirty).
+2. ``take_diff_tex``     -- extract the OLD ``.tex`` from git, run the ONE
+                            latexdiff backend, stamp the signature block.
+3. ``compile_diff_tex``  -- compile with the ONE latexmk backend into the log dir,
+                            bounded by a timeout (latexdiff markup can send
+                            latexmk into an endless rerun loop).
+4. ``collect_pdf``       -- move the PDF out of the log dir onto ``diff_pdf``.
+
+Three shell behaviours this port deliberately CHANGES. Each replaced a SILENT
+degradation, never a working path:
+
+* NO previous version in git history is now an ERROR. The shell warned, then set
+  ``previous_tex`` to the CURRENT tex and compiled "current vs current" -- a PDF
+  with zero diff markup, indistinguishable from "nothing changed since the last
+  version". A reviewer cannot tell those apart, so we refuse to emit it.
+* ONE latexdiff backend and ONE compile backend (``latexdiff`` / ``latexmk``),
+  each fail-loud with an install hint. The shell resolved both through a
+  native/module/container cascade whose lower rungs silently emitted un-runnable
+  command strings, and its engine switch defaulted an unknown engine to latexmk
+  with a warning nobody reads.
+* A failed compile no longer leaves a stale PDF behind, and a compile that
+  reports success but writes no PDF is an error rather than a shrug.
+
+Robust by construction: pathlib only; every write target is resolved and asserted
+to live INSIDE the project root; fail-loud (explicit error dict + actionable hint)
+on a missing project dir / config / binary.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Optional, Tuple
+
+from ..._dataclasses import DiffResult
+from ..._utils import _git
+from ..._utils._latexdiff import add_signature, run_latexdiff
+from ..._utils._latexmk import DEFAULT_TIMEOUT_SEC, compile_tex
+from ..utils import resolve_project_path
+from ._engine_paths import DOC_DIRS, load_doc_config, resolve_paths
+
+_CFG_KEYS = {
+    "compiled_tex": ("paths", "compiled_tex"),
+    "diff_tex": ("paths", "diff_tex"),
+    "diff_pdf": ("paths", "diff_pdf"),
+    "log_dir": ("paths", "doc_log_dir"),
+}
+
+
+def resolve_versions(
+    project_path: Path, compiled_tex: Path, diff_from: Optional[str]
+) -> Tuple[str, str, str]:
+    """Return ``(old_commit, old_hash, new_label)`` for the two versions to compare.
+
+    ``old_commit`` is what git is asked to ``show``; ``old_hash`` is its 7-char
+    display form; ``new_label`` is HEAD's short hash, suffixed with ``+`` when the
+    working tree carries uncommitted changes (the shell's convention).
+
+    Raises ValueError -- never falls back to "current vs current" -- when there is
+    no OLD version to compare against.
+    """
+    if not _git.has_commits(project_path):
+        raise ValueError(
+            f"{project_path} is not a git repository with commits. The diff "
+            "pipeline reads the previous version of the manuscript from git "
+            "history. Fix: `git init` and commit the compiled .tex at least once."
+        )
+
+    rel_tex = str(compiled_tex.relative_to(project_path.resolve()))
+
+    if diff_from:
+        old_hash = _git.short_hash(project_path, diff_from)
+        if old_hash is None:
+            raise ValueError(
+                f"diff_from '{diff_from}' does not resolve to a commit in "
+                f"{project_path}. Fix: pass a commit-ish that exists "
+                "(`git log --oneline`)."
+            )
+        old_commit = diff_from
+    else:
+        old_commit = _git.previous_commit(project_path, rel_tex)
+        if old_commit is None:
+            raise ValueError(
+                f"No PREVIOUS version of {rel_tex} in git history (it has at most "
+                "one commit). Refusing to diff the file against itself: the result "
+                "would be an unmarked PDF that looks exactly like 'nothing "
+                "changed'. Fix: commit a second revision, or pass an explicit "
+                "diff_from commit."
+            )
+        old_hash = _git.short_hash(project_path, old_commit)
+
+    new_label = _git.short_hash(project_path, "HEAD") or "HEAD"
+    if not _git.is_clean(project_path):
+        new_label += "+"
+    return old_commit, old_hash, new_label
+
+
+def take_diff_tex(
+    project_path: Path,
+    compiled_tex: Path,
+    diff_tex: Path,
+    old_commit: str,
+    old_hash: str,
+    new_label: str,
+    doc_type: str,
+) -> Path:
+    """Stage 2: latexdiff the OLD tex (from git) against the CURRENT one, + signature.
+
+    The old version is materialised into a temp file, exactly as the shell did --
+    latexdiff takes two paths, not two streams -- and the temp file is always
+    removed, including on failure.
+    """
+    rel_tex = str(compiled_tex.relative_to(project_path.resolve()))
+    old_text = _git.show_file(project_path, old_commit, rel_tex)
+    if old_text is None:
+        raise ValueError(
+            f"{rel_tex} does not exist at commit {old_hash}. Fix: pass a "
+            "diff_from commit in which the compiled .tex was already tracked."
+        )
+
+    handle = tempfile.NamedTemporaryFile(
+        "w", suffix=".tex", delete=False, encoding="utf-8"
+    )
+    old_tex = Path(handle.name)
+    try:
+        handle.write(old_text)
+        handle.close()
+        run_latexdiff(old_tex, compiled_tex, diff_tex)
+    finally:
+        old_tex.unlink(missing_ok=True)
+
+    add_signature(
+        diff_tex,
+        old_hash,
+        new_label,
+        doc_type=doc_type,
+        author=_git.user_name(project_path),
+        email=_git.user_email(project_path),
+        commit=_git.short_hash(project_path, "HEAD") or "unknown",
+        branch=_git.current_branch(project_path),
+    )
+    return diff_tex
+
+
+def collect_pdf(built_pdf: Path, diff_pdf: Path) -> int:
+    """Stage 4: move the compiled PDF out of the log dir onto ``diff_pdf``.
+
+    Returns its size in bytes. An empty PDF is an error, not a result.
+    """
+    diff_pdf.parent.mkdir(parents=True, exist_ok=True)
+    diff_pdf.unlink(missing_ok=True)
+    built_pdf.replace(diff_pdf)
+    size = diff_pdf.stat().st_size
+    if size == 0:
+        raise ValueError(f"{diff_pdf} was written but is EMPTY (0 bytes).")
+    return size
+
+
+def process(
+    project_dir: str,
+    doc_type: str = "manuscript",
+    no_diff: bool = False,
+    diff_from: Optional[str] = None,
+    timeout_sec: int = DEFAULT_TIMEOUT_SEC,
+) -> dict:
+    """Build and compile the version-diff PDF for ``doc_type``.
+
+    Parameters
+    ----------
+    project_dir : str
+        Path to the scitex-writer project directory (must be a git repository).
+    doc_type : str
+        One of 'manuscript' (default), 'supplementary', 'revision'.
+    no_diff : bool
+        Skip the whole pipeline (the shell's ``--no_diff``).
+    diff_from : str, optional
+        Commit-ish to diff FROM. Default: the previous commit that touched the
+        compiled ``.tex`` (the shell's ``SCITEX_DIFF_FROM``).
+    timeout_sec : int
+        Bound on the latexmk run (the shell's ``SCITEX_WRITER_DIFF_TIMEOUT``).
+
+    Returns
+    -------
+    dict
+        The serialized :class:`DiffResult`. On failure ``error`` carries an
+        actionable hint (fail-loud, never a silent no-op).
+    """
+    try:
+        if no_diff:
+            return DiffResult(success=True, skipped=True).to_dict()
+
+        if doc_type not in DOC_DIRS:
+            return {
+                "success": False,
+                "error": (
+                    f"Invalid doc_type '{doc_type}'. Must be one of: {tuple(DOC_DIRS)}"
+                ),
+            }
+
+        project_path = resolve_project_path(project_dir)
+        if not project_path.is_dir():
+            return {
+                "success": False,
+                "error": (
+                    f"Project directory not found: {project_path}. "
+                    f"Check the path passed as project_dir."
+                ),
+            }
+
+        cfg, error = load_doc_config(project_path, doc_type)
+        if error:
+            return {"success": False, "error": error}
+        paths, error = resolve_paths(project_path, cfg, _CFG_KEYS, "paths")
+        if error:
+            return {"success": False, "error": error}
+
+        compiled_tex = paths["compiled_tex"]
+        if not compiled_tex.is_file():
+            return {
+                "success": False,
+                "error": (
+                    f"Compiled TeX not found: {compiled_tex}. The diff is taken "
+                    "against the compiled manuscript. Fix: run "
+                    "`scitex-writer compile manuscript` first."
+                ),
+            }
+
+        old_commit, old_hash, new_label = resolve_versions(
+            project_path, compiled_tex, diff_from
+        )
+        diff_tex = take_diff_tex(
+            project_path,
+            compiled_tex,
+            paths["diff_tex"],
+            old_commit,
+            old_hash,
+            new_label,
+            doc_type,
+        )
+        try:
+            built_pdf = compile_tex(
+                diff_tex,
+                paths["log_dir"],
+                project_root=project_path,
+                timeout_sec=timeout_sec,
+            )
+        except Exception:
+            # Drop the PREVIOUS run's PDF: a stale diff_pdf sitting beside a failed
+            # compile is read as a fresh one (the shell's own `rm -f` on failure).
+            paths["diff_pdf"].unlink(missing_ok=True)
+            raise
+        pdf_bytes = collect_pdf(built_pdf, paths["diff_pdf"])
+
+        result = DiffResult(
+            success=True,
+            from_hash=old_hash,
+            to_hash=new_label,
+            diff_tex=str(diff_tex),
+            diff_pdf=str(paths["diff_pdf"]),
+            pdf_bytes=pdf_bytes,
+        )
+        result.validate()
+        return result.to_dict()
+    except Exception as e:
+        return {"success": False, "error": f"{type(e).__name__}: {e}"}
+
+
+__all__ = ["collect_pdf", "process", "resolve_versions", "take_diff_tex"]
+
+# EOF

--- a/src/scitex_writer/_mcp/handlers/_engine_paths.py
+++ b/src/scitex_writer/_mcp/handlers/_engine_paths.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_mcp/handlers/_engine_paths.py
+
+"""Config loading + path resolution shared by the ported engine pipelines.
+
+Every shell module the engine port replaces began the same way: source
+``config/load_config.sh``, which ``yq``-read ``config/config_<doc_type>.yaml`` and
+exported the resulting paths as environment variables. The Python pipelines read
+the SAME file and the SAME keys -- this module is that step, once, so the diff and
+archive pipelines cannot drift apart on how a config path is resolved.
+
+The boundary check is the part that matters: a config path is resolved against the
+project root and then ASSERTED to stay inside it, so a ``..`` in the YAML cannot
+make a pipeline write outside the project.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+DOC_DIRS = {
+    "manuscript": "01_manuscript",
+    "supplementary": "02_supplementary",
+    "revision": "03_revision",
+}
+
+
+def cfg_get(cfg: dict, path, default=None):
+    """Nested dict lookup by a key-tuple; ``default`` if any level is absent."""
+    cur = cfg
+    for key in path:
+        if not isinstance(cur, dict) or key not in cur:
+            return default
+        cur = cur[key]
+    return cur
+
+
+def resolve_one(project_path: Path, rel) -> Optional[Path]:
+    """Resolve a config path (possibly ``./``-relative) against the project root."""
+    if not rel:
+        return None
+    rel = str(rel)
+    if rel.startswith("./"):
+        rel = rel[2:]
+    return (project_path / rel).resolve()
+
+
+def within(boundary: Path, target: Path) -> bool:
+    """True iff ``target`` resolves to a path inside ``boundary`` (guard ``..``)."""
+    try:
+        target.resolve().relative_to(boundary)
+        return True
+    except ValueError:
+        return False
+
+
+def load_doc_config(project_path: Path, doc_type: str):
+    """Return ``(cfg, error)`` for the doc type's ``config/config_<doc_type>.yaml``."""
+    config_path = project_path / "config" / f"config_{doc_type}.yaml"
+    if not config_path.exists():
+        return None, (
+            f"Config not found: {config_path}. "
+            f"Run `scitex-writer update-project` or check --doc-type."
+        )
+    try:
+        import yaml
+    except ImportError:
+        return None, "PyYAML not installed. Fix: pip install pyyaml"
+    try:
+        return yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}, None
+    except yaml.YAMLError as e:
+        return None, f"{config_path} is not valid YAML: {e}"
+
+
+def resolve_paths(project_path: Path, cfg: dict, keys: dict, section: str):
+    """Return ``(paths, error)``: every requested config path, boundary-checked.
+
+    ``keys`` maps a friendly name to the key-tuple to look up; ``section`` names
+    the config section for the error message.
+    """
+    paths = {}
+    for name, key in keys.items():
+        resolved = resolve_one(project_path, cfg_get(cfg, key))
+        if resolved is None:
+            return None, (
+                f"{'.'.join(key)} is missing in the config; cannot resolve the "
+                f"{name.replace('_', ' ')}."
+            )
+        paths[name] = resolved
+
+    boundary = project_path.resolve()
+    if not all(within(boundary, p) for p in paths.values()):
+        return None, (
+            f"Refusing to run: a {section}.* path resolves OUTSIDE the project "
+            f"root {boundary} (config path escape via '..'?)."
+        )
+    return paths, None
+
+
+__all__ = [
+    "DOC_DIRS",
+    "cfg_get",
+    "load_doc_config",
+    "resolve_one",
+    "resolve_paths",
+    "within",
+]
+
+# EOF

--- a/src/scitex_writer/_mcp/tools/__init__.py
+++ b/src/scitex_writer/_mcp/tools/__init__.py
@@ -11,12 +11,14 @@ from fastmcp import FastMCP
 def register_all_tools(mcp: FastMCP) -> None:
     """Register all MCP tools with the server."""
     from . import (
+        archive,
         bib,
         checks,
         citation_style,
-        cleanup,
         claim,
+        cleanup,
         compile,
+        diff,
         export,
         figures,
         guidelines,
@@ -35,6 +37,8 @@ def register_all_tools(mcp: FastMCP) -> None:
     export.register_tools(mcp)
     tables.register_tools(mcp)
     figures.register_tools(mcp)
+    diff.register_tools(mcp)
+    archive.register_tools(mcp)
     bib.register_tools(mcp)
     guidelines.register_tools(mcp)
     prompts.register_tools(mcp)

--- a/src/scitex_writer/_mcp/tools/archive.py
+++ b/src/scitex_writer/_mcp/tools/archive.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_mcp/tools/archive.py
+
+"""Archive MCP tools (versioned snapshots of the compiled outputs)."""
+
+from typing import Literal
+
+from fastmcp import FastMCP
+
+from ..handlers._archive_pipeline import process as _process
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register archive tools."""
+
+    # Named for its Python API (`sw.compile.archive`), not for the CLI leaf
+    # (`scitex-writer archive create`): §6 checks MCP<->Python-API parity.
+    @mcp.tool()
+    def writer_compile_archive(
+        project_dir: str,
+        doc_type: Literal["manuscript", "supplementary", "revision"] = "manuscript",
+        no_archive: bool = False,
+    ) -> dict:
+        """Snapshot the compiled outputs into the versions directory.
+
+        Copies the compiled PDF/TeX and the diff PDF/TeX to
+        <archive_dir>/<stem>_<YYYYmmdd-HHMMSS>_<commit>.<ext>, plus an un-stamped
+        "current" copy of each. Archives ONLY a clean working tree -- a snapshot
+        stamped with a commit hash it does not actually hold would be a lie -- so
+        a dirty tree returns skipped=True with a skip_reason. Returns
+        {success, archive_id, archived, versions_dir, missing, skipped,
+        skip_reason, error}.
+        """
+        return _process(project_dir, doc_type, no_archive)
+
+
+# EOF

--- a/src/scitex_writer/_mcp/tools/diff.py
+++ b/src/scitex_writer/_mcp/tools/diff.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_mcp/tools/diff.py
+
+"""Version-diff MCP tools (latexdiff pipeline)."""
+
+from typing import Literal, Optional
+
+from fastmcp import FastMCP
+
+from ..._utils._latexmk import DEFAULT_TIMEOUT_SEC
+from ..handlers._diff_pipeline import process as _process
+
+
+def register_tools(mcp: FastMCP) -> None:
+    """Register version-diff tools."""
+
+    # Named for its Python API (`sw.compile.diff`), not for the CLI leaf
+    # (`scitex-writer diff render`): §6 checks MCP<->Python-API parity.
+    @mcp.tool()
+    def writer_compile_diff(
+        project_dir: str,
+        doc_type: Literal["manuscript", "supplementary", "revision"] = "manuscript",
+        no_diff: bool = False,
+        diff_from: Optional[str] = None,
+        timeout_sec: int = DEFAULT_TIMEOUT_SEC,
+    ) -> dict:
+        """Build the version-diff PDF: git history -> latexdiff -> latexmk.
+
+        Reads the PREVIOUS version of the compiled .tex out of git history (or the
+        commit given as diff_from), runs latexdiff against the current one, stamps
+        a metadata + fancyhdr signature block, and compiles the result with
+        latexmk bounded by timeout_sec. With NO previous version this FAILS rather
+        than emitting an unmarked PDF that looks like "nothing changed"; a missing
+        latexdiff/latexmk fails with an install hint. no_diff=True skips
+        everything. Returns {success, from_hash, to_hash, diff_tex, diff_pdf,
+        pdf_bytes, skipped, error}.
+        """
+        return _process(project_dir, doc_type, no_diff, diff_from, timeout_sec)
+
+
+# EOF

--- a/src/scitex_writer/_utils/_git.py
+++ b/src/scitex_writer/_utils/_git.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_utils/_git.py
+
+"""The ONE git backend for the engine pipelines (diff + archive).
+
+``process_diff.sh`` and ``process_archive.sh`` each shelled out to ``git`` with
+``2>/dev/null`` on every call, so a broken repo, a missing binary and a genuine
+"no such commit" all collapsed into the same empty string -- and the caller then
+guessed. This module keeps the ONE backend (the real ``git`` binary; there is no
+second way to read a commit) but separates the three cases:
+
+* ``git`` not on PATH        -> :class:`GitUnavailableError` with an install hint;
+* not a repo / no commits    -> a False from :func:`is_repo` / :func:`has_commits`;
+* a command that legitimately finds nothing -> ``None`` from the query helpers.
+
+Every helper takes the repository directory explicitly (never relies on the
+process CWD, which the shell did).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import List, Optional
+
+
+class GitUnavailableError(RuntimeError):
+    """Raised when the ``git`` binary is not installed (fail loud, never guess)."""
+
+
+def require_git() -> str:
+    """Return the absolute path of ``git``, or raise with an actionable hint."""
+    binary = shutil.which("git")
+    if binary is None:
+        raise GitUnavailableError(
+            "git not found on PATH. The diff and archive pipelines are git-based "
+            "(they read previous versions from history and stamp archives with the "
+            "commit hash). Fix: install git (e.g. `apt-get install git`)."
+        )
+    return binary
+
+
+def _run(repo: Path, args: List[str]) -> subprocess.CompletedProcess:
+    """Run ``git <args>`` inside ``repo`` and return the completed process."""
+    return subprocess.run(
+        [require_git(), "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def is_repo(repo: Path) -> bool:
+    """True iff ``repo`` is inside a git working tree."""
+    return _run(repo, ["rev-parse", "--git-dir"]).returncode == 0
+
+
+def has_commits(repo: Path) -> bool:
+    """True iff ``repo`` is a git repo carrying at least one commit."""
+    return _run(repo, ["rev-parse", "HEAD"]).returncode == 0
+
+
+def is_clean(repo: Path) -> bool:
+    """True iff the working tree has NO staged or unstaged change against HEAD.
+
+    Mirrors the shell's ``is_git_clean``: a repo with no commits, or no repo at
+    all, is NOT clean (there is nothing to snapshot against).
+    """
+    if not has_commits(repo):
+        return False
+    unstaged = _run(repo, ["diff", "--quiet", "HEAD", "--"]).returncode == 0
+    staged = _run(repo, ["diff", "--cached", "--quiet", "HEAD", "--"]).returncode == 0
+    return unstaged and staged
+
+
+def short_hash(repo: Path, commit: str = "HEAD") -> Optional[str]:
+    """The 7-char hash of ``commit``, or None when it does not resolve."""
+    proc = _run(repo, ["rev-parse", "--short=7", commit])
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def previous_commit(repo: Path, rel_path: str) -> Optional[str]:
+    """The second-most-recent commit touching ``rel_path``, or None.
+
+    The shell took ``git log --format=%H -n 2 -- <path> | tail -1``, which for a
+    file with exactly ONE commit returns that same commit -- i.e. it diffed a
+    version against itself. This returns None in that case, so the caller can say
+    so instead of shipping an empty diff (see :mod:`._diff_pipeline`).
+    """
+    proc = _run(repo, ["log", "--format=%H", "-n", "2", "--", rel_path])
+    if proc.returncode != 0:
+        return None
+    commits = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    if len(commits) < 2:
+        return None
+    return commits[1]
+
+
+def show_file(repo: Path, commit: str, rel_path: str) -> Optional[str]:
+    """The content of ``rel_path`` at ``commit``, or None when it is not there."""
+    proc = _run(repo, ["show", f"{commit}:{rel_path}"])
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def user_name(repo: Path) -> str:
+    """The configured ``user.name``, or ``'unknown'`` (a signature is not a gate)."""
+    return _run(repo, ["config", "user.name"]).stdout.strip() or "unknown"
+
+
+def user_email(repo: Path) -> str:
+    """The configured ``user.email``, or ``'unknown'``."""
+    return _run(repo, ["config", "user.email"]).stdout.strip() or "unknown"
+
+
+def current_branch(repo: Path) -> str:
+    """The checked-out branch, or ``'unknown'`` on a detached HEAD."""
+    return _run(repo, ["branch", "--show-current"]).stdout.strip() or "unknown"
+
+
+__all__ = [
+    "GitUnavailableError",
+    "current_branch",
+    "has_commits",
+    "is_clean",
+    "is_repo",
+    "previous_commit",
+    "require_git",
+    "short_hash",
+    "show_file",
+    "user_email",
+    "user_name",
+]
+
+# EOF

--- a/src/scitex_writer/_utils/_latexdiff.py
+++ b/src/scitex_writer/_utils/_latexdiff.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_utils/_latexdiff.py
+
+r"""The ONE latexdiff backend, plus the diff-document signature block.
+
+``process_diff.sh`` resolved ``latexdiff`` through a three-rung cascade (native
+-> TeXLive module -> Apptainer container) in ``command_switching.src``. Only the
+NATIVE rung is portable and verifiable; the other two silently produced either an
+un-runnable command string or nothing at all, and the caller could not tell which.
+This module keeps the native rung and FAILS LOUD with an install hint otherwise --
+an empty or missing diff PDF is a wrong answer, not a degraded one.
+
+The latexdiff invocation is the shell's, flag for flag::
+
+    latexdiff --encoding=utf8 --type=UNDERLINE --disable-citation-markup \
+              --append-safecmd=cite,cite,citet OLD.tex NEW.tex > DIFF.tex
+
+:func:`add_signature` ports ``add_diff_signature.sh``: a metadata comment block
+plus a ``fancyhdr`` page style, both inserted immediately before
+``\begin{document}``. One hardening: the shell typeset a literal ``U+2192`` arrow
+inside ``\fancyhead``; this emits ``$\rightarrow$``, which renders identically and
+cannot blow up on a preamble whose Unicode setup differs from the compiled
+manuscript's.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+# latexdiff/perl noise that says nothing about the diff itself (the shell grepped
+# these out of stderr, and so do we -- they are not failures).
+_NOISE = ("gocryptfs not found", "Wide character in print")
+
+BEGIN_DOCUMENT = "\\begin{document}"
+
+
+class LatexdiffUnavailableError(RuntimeError):
+    """Raised when ``latexdiff`` is not installed (fail loud, never no-op)."""
+
+
+class LatexdiffFailedError(RuntimeError):
+    """Raised when ``latexdiff`` ran but produced no usable diff document."""
+
+
+def require_latexdiff() -> str:
+    """Return the absolute path of ``latexdiff``, or raise with an install hint."""
+    binary = shutil.which("latexdiff")
+    if binary is None:
+        raise LatexdiffUnavailableError(
+            "latexdiff not found on PATH. It is REQUIRED to build the version-diff "
+            "PDF -- there is no in-repo substitute, and emitting an unmarked PDF "
+            "would misreport 'no changes'. Fix: install it (Debian/Ubuntu: "
+            "`apt-get install latexdiff`; TeX Live: `tlmgr install latexdiff`), or "
+            "skip the diff stage."
+        )
+    return binary
+
+
+def _clean_stderr(text: str) -> str:
+    """Drop the known-noise lines the shell filtered out of latexdiff's stderr."""
+    lines = [
+        line
+        for line in (text or "").splitlines()
+        if line.strip() and not any(noise in line for noise in _NOISE)
+    ]
+    return "\n".join(lines)
+
+
+def run_latexdiff(old_tex: Path, new_tex: Path, out_tex: Path) -> Path:
+    """Write the latexdiff of ``old_tex`` -> ``new_tex`` to ``out_tex``.
+
+    Raises :class:`LatexdiffUnavailableError` when the binary is missing, and
+    :class:`LatexdiffFailedError` when it fails or yields an empty document (the
+    shell warned and carried on -- leaving a stale PDF to be mistaken for fresh).
+    """
+    binary = require_latexdiff()
+    proc = subprocess.run(
+        [
+            binary,
+            "--encoding=utf8",
+            "--type=UNDERLINE",
+            "--disable-citation-markup",
+            "--append-safecmd=cite,cite,citet",
+            str(old_tex),
+            str(new_tex),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    stderr = _clean_stderr(proc.stderr)
+    if proc.returncode != 0:
+        raise LatexdiffFailedError(
+            f"latexdiff exited {proc.returncode} comparing {old_tex} -> {new_tex}"
+            + (f": {stderr}" if stderr else "")
+        )
+    if not proc.stdout.strip():
+        raise LatexdiffFailedError(
+            f"latexdiff produced an EMPTY document for {old_tex} -> {new_tex}"
+            + (f": {stderr}" if stderr else "")
+            + ". The inputs are probably not standalone LaTeX documents."
+        )
+    out_tex.parent.mkdir(parents=True, exist_ok=True)
+    out_tex.write_text(proc.stdout, encoding="utf-8")
+    return out_tex
+
+
+def _signature_comment(
+    old_version: str,
+    new_version: str,
+    doc_type: str,
+    author: str,
+    email: str,
+    commit: str,
+    branch: str,
+    stamp: str,
+) -> str:
+    """The ``%%``-comment metadata block (never typeset; the arrow is safe here)."""
+    rule = "%% " + "=" * 77
+    return "\n".join(
+        [
+            "",
+            rule,
+            "%% Diff Document Metadata (Auto-generated)",
+            rule,
+            f"%% Comparison: v{old_version} → v{new_version}",
+            f"%% Generated: {stamp}",
+            f"%% User: {author} <{email}>",
+            f"%% Document: {doc_type}",
+            f"%% Git commit: {commit}",
+            f"%% Git branch: {branch}",
+            rule,
+            "",
+        ]
+    )
+
+
+def _signature_preamble(
+    old_version: str, new_version: str, doc_type: str, author: str, stamp: str
+) -> str:
+    """The ``fancyhdr`` page style stamped onto every page of the diff PDF."""
+    return "\n".join(
+        [
+            "\\usepackage{fancyhdr}",
+            "\\usepackage{lastpage}",
+            "",
+            "\\fancypagestyle{diffstyle}{",
+            "    \\fancyhf{}",
+            "    \\renewcommand{\\headrulewidth}{0.4pt}",
+            "    \\renewcommand{\\footrulewidth}{0.4pt}",
+            "    \\fancyhead[L]{\\small\\textit{Diff: v"
+            f"{old_version}" + " $\\rightarrow$ v" + f"{new_version}" + "}}",
+            f"    \\fancyhead[R]{{\\small\\textit{{{doc_type}}}}}",
+            f"    \\fancyfoot[L]{{\\small Generated: {stamp}}}",
+            "    \\fancyfoot[C]{\\small Page \\thepage\\ of \\pageref{LastPage}}",
+            f"    \\fancyfoot[R]{{\\small {author}}}",
+            "}",
+            "",
+            "\\AtBeginDocument{\\pagestyle{diffstyle}}",
+            "",
+        ]
+    )
+
+
+def add_signature(
+    diff_tex: Path,
+    old_version: str,
+    new_version: str,
+    doc_type: str = "manuscript",
+    author: str = "unknown",
+    email: str = "unknown",
+    commit: str = "unknown",
+    branch: str = "unknown",
+    now: Optional[datetime] = None,
+) -> Path:
+    """Stamp the metadata comment + ``fancyhdr`` style into ``diff_tex`` in place.
+
+    Both blocks land immediately before the FIRST ``\\begin{document}``. A diff
+    document with no ``\\begin{document}`` is not a compilable document, so this
+    raises instead of writing an unusable file (the shell silently skipped the
+    preamble half and left the comment half behind).
+    """
+    text = diff_tex.read_text(encoding="utf-8")
+    if BEGIN_DOCUMENT not in text:
+        raise LatexdiffFailedError(
+            f"{diff_tex} carries no {BEGIN_DOCUMENT} -- it is not a standalone "
+            "LaTeX document and cannot be compiled into a diff PDF."
+        )
+    stamp = (now or datetime.now()).strftime("%Y-%m-%d %H:%M:%S")
+    comment = _signature_comment(
+        old_version, new_version, doc_type, author, email, commit, branch, stamp
+    )
+    preamble = _signature_preamble(
+        old_version, new_version, doc_type, author, stamp[:16]
+    )
+    head, sep, tail = text.partition(BEGIN_DOCUMENT)
+    diff_tex.write_text(
+        head + comment + preamble + sep + tail,
+        encoding="utf-8",
+    )
+    return diff_tex
+
+
+__all__ = [
+    "BEGIN_DOCUMENT",
+    "LatexdiffFailedError",
+    "LatexdiffUnavailableError",
+    "add_signature",
+    "require_latexdiff",
+    "run_latexdiff",
+]
+
+# EOF

--- a/src/scitex_writer/_utils/_latexmk.py
+++ b/src/scitex_writer/_utils/_latexmk.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_utils/_latexmk.py
+
+r"""The ONE LaTeX compile backend used by the diff pipeline: ``latexmk``.
+
+``process_diff.sh`` picked between ``tectonic``, ``latexmk`` and a hand-rolled
+3-pass ``pdflatex`` loop via ``SCITEX_WRITER_SELECTED_ENGINE``, and an unknown
+value fell back to ``latexmk`` with a warning. Every rung then resolved its own
+binary through ``command_switching.src``'s native/module/container cascade, so a
+missing engine surfaced as a mystery non-zero exit far from its cause.
+
+The diff document is a derived artifact, not the manuscript: it needs one
+reliable engine, not three. This module keeps ``latexmk`` (the shell's default and
+the only rung installed by ``scitex-writer``'s own container recipe) and fails loud
+with an install hint when it is absent.
+
+The flags are the shell's ``compile_with_latexmk``: ``-pdf -bibtex -synctex=1
+-interaction=nonstopmode -file-line-error -output-directory=<log_dir> -gg``, with
+``BIBINPUTS`` pointed at the project root so ``bibtex`` -- which latexmk runs from
+the output directory -- still finds the bibliography.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_TIMEOUT_SEC = 120
+"""The shell's ``SCITEX_WRITER_DIFF_TIMEOUT`` default: latexdiff output can send
+latexmk into an endless rerun loop, so the diff compile is always bounded."""
+
+
+class LatexmkUnavailableError(RuntimeError):
+    """Raised when ``latexmk`` is not installed (fail loud, never no-op)."""
+
+
+class LatexmkFailedError(RuntimeError):
+    """Raised when ``latexmk`` ran but produced no PDF (or timed out)."""
+
+
+def require_latexmk() -> str:
+    """Return the absolute path of ``latexmk``, or raise with an install hint."""
+    binary = shutil.which("latexmk")
+    if binary is None:
+        raise LatexmkUnavailableError(
+            "latexmk not found on PATH. It is REQUIRED to compile the diff "
+            "document. Fix: install TeX Live (Debian/Ubuntu: `apt-get install "
+            "latexmk texlive-latex-extra`), or build the writer's TeX Live "
+            "container with `scitex-writer containers install texlive`."
+        )
+    return binary
+
+
+def compile_tex(
+    tex_file: Path,
+    output_dir: Path,
+    project_root: Optional[Path] = None,
+    timeout_sec: int = DEFAULT_TIMEOUT_SEC,
+) -> Path:
+    """Compile ``tex_file`` with latexmk into ``output_dir``; return the PDF path.
+
+    Raises :class:`LatexmkUnavailableError` when latexmk is missing, and
+    :class:`LatexmkFailedError` on a non-zero exit, a timeout, or a run that
+    reported success yet produced no PDF. The caller is responsible for moving the
+    PDF out of ``output_dir`` -- this function never touches anything outside it.
+    """
+    binary = require_latexmk()
+    if not tex_file.is_file():
+        raise LatexmkFailedError(f"TeX source not found: {tex_file}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    env = dict(os.environ)
+    if project_root is not None:
+        env["BIBINPUTS"] = f"{project_root}:"
+
+    command = [
+        binary,
+        "-pdf",
+        "-bibtex",
+        "-synctex=1",
+        "-interaction=nonstopmode",
+        "-file-line-error",
+        f"-output-directory={output_dir}",
+        "-pdflatex=pdflatex -shell-escape %O %S",
+        "-gg",
+        str(tex_file),
+    ]
+    try:
+        proc = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=str(project_root) if project_root else None,
+            env=env,
+            timeout=timeout_sec,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise LatexmkFailedError(
+            f"latexmk timed out after {timeout_sec}s on {tex_file.name}. "
+            "latexdiff markup can drive latexmk into an endless rerun loop. "
+            "Raise the bound with diff(..., timeout_sec=300)."
+        ) from exc
+
+    pdf_file = output_dir / f"{tex_file.stem}.pdf"
+    if proc.returncode != 0:
+        tail = "\n".join((proc.stdout or "").splitlines()[-20:])
+        raise LatexmkFailedError(
+            f"latexmk exited {proc.returncode} on {tex_file.name}. Last output:\n{tail}"
+        )
+    if not pdf_file.is_file():
+        raise LatexmkFailedError(
+            f"latexmk reported success but wrote no PDF at {pdf_file}."
+        )
+    return pdf_file
+
+
+__all__ = [
+    "DEFAULT_TIMEOUT_SEC",
+    "LatexmkFailedError",
+    "LatexmkUnavailableError",
+    "compile_tex",
+    "require_latexmk",
+]
+
+# EOF

--- a/src/scitex_writer/compile.py
+++ b/src/scitex_writer/compile.py
@@ -25,12 +25,24 @@ Usage::
         project_dir="./my-paper",  # Optional, for .preview/ output
         color_mode="dark",         # 'light' or 'dark'
     )
+
+    # Version-diff PDF (latexdiff markup vs the previous committed version)
+    result = sw.compile.diff("./my-paper")
+
+    # Snapshot the compiled outputs into the versions directory
+    result = sw.compile.archive("./my-paper")
 """
+
+from typing import Literal as _Literal
+from typing import Optional as _Optional
 
 from ._dataclasses import CompilationResult
 from ._mcp.handlers import compile_manuscript as _compile_manuscript
 from ._mcp.handlers import compile_revision as _compile_revision
 from ._mcp.handlers import compile_supplementary as _compile_supplementary
+from ._mcp.handlers import process_archive as _process_archive
+from ._mcp.handlers import process_diff as _process_diff
+from ._utils._latexmk import DEFAULT_TIMEOUT_SEC as _DIFF_TIMEOUT_SEC
 
 try:
     from scitex_dev.decorators import supports_return_as as _supports_return_as
@@ -214,6 +226,56 @@ def content(
     )
 
 
-__all__ = ["manuscript", "supplementary", "revision", "content"]
+@_supports_return_as
+def diff(
+    project_dir: str,
+    doc_type: _Literal["manuscript", "supplementary", "revision"] = "manuscript",
+    no_diff: bool = False,
+    diff_from: _Optional[str] = None,
+    timeout_sec: int = _DIFF_TIMEOUT_SEC,
+) -> dict:
+    """Build the version-diff PDF for ``doc_type`` (latexdiff markup).
+
+    The pure-Python port of ``scripts/shell/modules/process_diff.sh``: reads the
+    PREVIOUS version of the compiled ``.tex`` out of git history, runs latexdiff
+    against the current one, stamps a metadata + ``fancyhdr`` signature block, and
+    compiles the result with latexmk (bounded by ``timeout_sec``).
+
+    ``diff_from`` overrides the OLD version (default: the previous commit that
+    touched the compiled ``.tex``). With NO previous version this FAILS -- the
+    shell used to compile current-vs-current, whose unmarked PDF is
+    indistinguishable from "nothing changed". Missing ``latexdiff`` / ``latexmk``
+    likewise fail with an install hint rather than emitting a wrong PDF.
+
+    Returns ``{success, from_hash, to_hash, diff_tex, diff_pdf, pdf_bytes,
+    skipped, error}``.
+    """
+    return _process_diff(project_dir, doc_type, no_diff, diff_from, timeout_sec)
+
+
+@_supports_return_as
+def archive(
+    project_dir: str,
+    doc_type: _Literal["manuscript", "supplementary", "revision"] = "manuscript",
+    no_archive: bool = False,
+) -> dict:
+    """Snapshot the compiled outputs of ``doc_type`` into the versions directory.
+
+    The pure-Python port of ``scripts/shell/modules/process_archive.sh``: copies
+    the compiled PDF/TeX and the diff PDF/TeX to
+    ``<archive_dir>/<stem>_<YYYYmmdd-HHMMSS>_<commit>.<ext>``, plus an un-stamped
+    "current" copy of each.
+
+    Archives ONLY a clean working tree -- a snapshot stamped with a commit hash it
+    does not actually hold would be a lie -- so a dirty tree returns
+    ``skipped=True`` with a ``skip_reason``.
+
+    Returns ``{success, archive_id, archived, versions_dir, missing, skipped,
+    skip_reason, error}``.
+    """
+    return _process_archive(project_dir, doc_type, no_archive)
+
+
+__all__ = ["manuscript", "supplementary", "revision", "content", "diff", "archive"]
 
 # EOF

--- a/tests/scitex_writer/_cli/commands/test_compile.py
+++ b/tests/scitex_writer/_cli/commands/test_compile.py
@@ -19,3 +19,13 @@ def test_compile_group_has_expected_subcommands():
     names = set(compile_group.commands.keys())
     # Assert
     assert {"manuscript", "supplementary", "revision", "content"} <= names
+
+
+def test_compile_group_exposes_ported_engine_leaves():
+    # Arrange -- the shell-port slice-6 pipelines (process_diff / process_archive)
+    from scitex_writer._cli.commands.compile import compile_group
+
+    # Act
+    names = set(compile_group.commands.keys())
+    # Assert
+    assert {"diff", "archive"} <= names

--- a/tests/scitex_writer/_dataclasses/results/test__ArchiveResult.py
+++ b/tests/scitex_writer/_dataclasses/results/test__ArchiveResult.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_writer/_dataclasses/results/test__ArchiveResult.py
+
+"""Tests for ArchiveResult's fail-loud validate().
+
+A skip must say WHY (the shell's silent "skipping archive" warning is what this
+replaces), and a snapshot must always carry the id it was stamped with.
+"""
+
+import pytest
+
+from scitex_writer._dataclasses import ArchiveResult
+
+
+def _complete(**overrides):
+    fields = dict(
+        success=True,
+        archive_id="20260712-093000_abc1234",
+        archived=[
+            {"source": "/p/m.pdf", "archived": "/a/m_x.pdf", "current": "/a/m.pdf"}
+        ],
+        versions_dir="/a",
+    )
+    fields.update(overrides)
+    return ArchiveResult(**fields)
+
+
+class TestValidate:
+    def test_complete_success_validates_cleanly(self):
+        # Arrange
+        result = _complete()
+        # Act
+        result.validate()
+        # Assert
+        assert result.success is True
+
+    def test_skip_with_reason_validates_cleanly(self):
+        # Arrange
+        result = ArchiveResult(success=True, skipped=True, skip_reason="dirty tree")
+        # Act
+        result.validate()
+        # Assert
+        assert result.skipped is True
+
+    def test_skip_without_reason_is_rejected(self):
+        # Arrange
+        result = ArchiveResult(success=True, skipped=True)
+        # Act
+        # Assert
+        with pytest.raises(ValueError, match="no skip_reason"):
+            result.validate()
+
+    def test_skip_that_archived_files_is_rejected(self):
+        # Arrange
+        result = _complete(skipped=True, skip_reason="dirty tree")
+        # Act
+        # Assert
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            result.validate()
+
+    def test_success_without_archive_id_is_rejected(self):
+        # Arrange
+        result = _complete(archive_id=None)
+        # Act
+        # Assert
+        with pytest.raises(ValueError, match="no archive_id"):
+            result.validate()
+
+    def test_success_with_error_is_rejected(self):
+        # Arrange
+        result = _complete(error="boom")
+        # Act
+        # Assert
+        with pytest.raises(ValueError, match="error is set"):
+            result.validate()
+
+    def test_failure_without_error_is_rejected(self):
+        # Arrange
+        result = ArchiveResult(success=False)
+        # Act
+        # Assert
+        with pytest.raises(ValueError, match="no error message"):
+            result.validate()
+
+
+class TestSerialization:
+    def test_to_dict_exposes_every_field(self):
+        # Arrange
+        result = _complete()
+        # Act
+        payload = result.to_dict()
+        # Assert
+        assert set(payload) == {
+            "success",
+            "archive_id",
+            "archived",
+            "versions_dir",
+            "missing",
+            "skipped",
+            "skip_reason",
+            "error",
+        }
+
+    def test_str_of_skip_names_the_reason(self):
+        # Arrange
+        result = ArchiveResult(success=True, skipped=True, skip_reason="dirty tree")
+        # Act
+        text = str(result)
+        # Assert
+        assert "dirty tree" in text

--- a/tests/scitex_writer/_dataclasses/results/test__DiffResult.py
+++ b/tests/scitex_writer/_dataclasses/results/test__DiffResult.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_writer/_dataclasses/results/test__DiffResult.py
+
+"""Tests for DiffResult's fail-loud validate().
+
+The point of validate() is that a DiffResult cannot claim success while
+describing an empty or unattributed diff -- the exact shape the shell used to
+emit when it silently diffed the manuscript against itself.
+"""
+
+import pytest
+
+from scitex_writer._dataclasses import DiffResult
+
+
+def _complete(**overrides):
+    fields = dict(
+        success=True,
+        from_hash="aaaaaaa",
+        to_hash="bbbbbbb",
+        diff_tex="/p/m_diff.tex",
+        diff_pdf="/p/m_diff.pdf",
+        pdf_bytes=4096,
+    )
+    fields.update(overrides)
+    return DiffResult(**fields)
+
+
+class TestValidate:
+    def test_complete_success_validates_cleanly(self):
+        # Arrange
+        result = _complete()
+        # Act
+        result.validate()
+        # Assert
+        assert result.success is True
+
+    def test_skipped_run_needs_no_versions(self):
+        # Arrange
+        result = DiffResult(success=True, skipped=True)
+        # Act
+        result.validate()
+        # Assert
+        assert result.skipped is True
+
+    def test_success_with_error_is_rejected(self):
+        # Arrange
+        result = _complete(error="boom")
+        # Act
+        # Assert
+        with pytest.raises(ValueError, match="error is set"):
+            result.validate()
+
+    def test_failure_without_error_is_rejected(self):
+        # Arrange
+        result = DiffResult(success=False)
+        # Act
+        # Assert
+        with pytest.raises(ValueError, match="no error message"):
+            result.validate()
+
+    def test_success_without_versions_is_rejected(self):
+        # Arrange
+        result = _complete(from_hash=None)
+        # Act
+        # Assert
+        with pytest.raises(ValueError, match="from_hash/to_hash is unset"):
+            result.validate()
+
+    def test_success_with_empty_pdf_is_rejected(self):
+        # Arrange
+        result = _complete(pdf_bytes=0)
+        # Act
+        # Assert
+        with pytest.raises(ValueError, match="no non-empty diff_pdf"):
+            result.validate()
+
+    def test_negative_pdf_size_is_rejected(self):
+        # Arrange
+        result = _complete(pdf_bytes=-1)
+        # Act
+        # Assert
+        with pytest.raises(ValueError, match="non-negative int"):
+            result.validate()
+
+
+class TestSerialization:
+    def test_to_dict_exposes_every_field(self):
+        # Arrange
+        result = _complete()
+        # Act
+        payload = result.to_dict()
+        # Assert
+        assert set(payload) == {
+            "success",
+            "from_hash",
+            "to_hash",
+            "diff_tex",
+            "diff_pdf",
+            "pdf_bytes",
+            "skipped",
+            "error",
+        }
+
+    def test_str_of_failure_names_the_error(self):
+        # Arrange
+        result = DiffResult(success=False, error="latexdiff not found")
+        # Act
+        text = str(result)
+        # Assert
+        assert "latexdiff not found" in text

--- a/tests/scitex_writer/_mcp/handlers/test__archive_pipeline.py
+++ b/tests/scitex_writer/_mcp/handlers/test__archive_pipeline.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_writer/_mcp/handlers/test__archive_pipeline.py
+
+"""Tests for the pure-Python archive pipeline (port of process_archive.sh).
+
+Real inputs throughout: a real git repository under ``tmp_path`` holding real
+compiled outputs, and the same config keys the shell read. The timestamp is
+injected as an argument (``now=``) rather than patched -- the pipeline takes it as
+a parameter precisely so the archive id is testable without a mock.
+
+The dirty-tree case is the contract: an archive is stamped with a commit hash, so
+it may only snapshot a tree that actually matches that commit.
+"""
+
+import subprocess
+from datetime import datetime
+
+import pytest
+
+from scitex_writer._mcp.handlers import _archive_pipeline
+
+_CONFIG = (
+    "paths:\n"
+    '  doc_log_dir: "./01_manuscript/logs"\n'
+    '  compiled_tex: "./01_manuscript/manuscript.tex"\n'
+    '  compiled_pdf: "./01_manuscript/manuscript.pdf"\n'
+    '  diff_tex: "./01_manuscript/manuscript_diff.tex"\n'
+    '  diff_pdf: "./01_manuscript/manuscript_diff.pdf"\n'
+    '  archive_dir: "./01_manuscript/archive"\n'
+)
+
+_STAMP = datetime(2026, 7, 12, 9, 30, 0)
+
+
+def _git_cmd(repo, *args):
+    subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    )
+
+
+def _seed_project(tmp_path, outputs=("manuscript.tex", "manuscript.pdf")):
+    """A real, CLEAN git project holding the given compiled outputs."""
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    (cfg / "config_manuscript.yaml").write_text(_CONFIG, encoding="utf-8")
+    doc = tmp_path / "01_manuscript"
+    doc.mkdir()
+    for name in outputs:
+        (doc / name).write_bytes(b"%PDF-1.4 content\n")
+    _git_cmd(tmp_path, "init", "-q")
+    _git_cmd(tmp_path, "config", "user.email", "tester@example.com")
+    _git_cmd(tmp_path, "config", "user.name", "Tester")
+    _git_cmd(tmp_path, "add", "-A")
+    _git_cmd(tmp_path, "commit", "-q", "-m", "compiled outputs")
+    return tmp_path
+
+
+def _archive_dir(project):
+    return project / "01_manuscript" / "archive"
+
+
+class TestArchivedName:
+    def test_plain_stem_gets_the_id_appended(self):
+        # Arrange
+        stem = "manuscript"
+        # Act
+        name = _archive_pipeline.archived_name(stem, "20260712-093000_abc1234")
+        # Assert
+        assert name == "manuscript_20260712-093000_abc1234"
+
+    def test_diff_stem_keeps_the_diff_marker_last(self):
+        # Arrange
+        stem = "manuscript_diff"
+        # Act
+        name = _archive_pipeline.archived_name(stem, "20260712-093000_abc1234")
+        # Assert
+        assert name == "manuscript_20260712-093000_abc1234_diff"
+
+
+class TestPipelineErrors:
+    def test_invalid_doc_type_returns_actionable_error(self):
+        # Arrange
+        bad_doc_type = "poster"
+        # Act
+        result = _archive_pipeline.process(".", bad_doc_type)
+        # Assert
+        assert result["success"] is False and "poster" in result["error"]
+
+    def test_missing_project_dir_returns_error_hint(self, tmp_path):
+        # Arrange
+        absent = tmp_path / "nope"
+        # Act
+        result = _archive_pipeline.process(str(absent), "manuscript")
+        # Assert
+        assert result["success"] is False and "not found" in result["error"]
+
+    def test_missing_config_returns_error_hint(self, tmp_path):
+        # Arrange
+        (tmp_path / "01_manuscript").mkdir()
+        # Act
+        result = _archive_pipeline.process(str(tmp_path), "manuscript")
+        # Assert
+        assert result["success"] is False and "Config not found" in result["error"]
+
+    def test_no_archive_flag_skips_pipeline(self, tmp_path):
+        # Arrange
+        project = _seed_project(tmp_path)
+        # Act
+        result = _archive_pipeline.process(str(project), "manuscript", no_archive=True)
+        # Assert
+        assert result["skipped"] is True
+
+    def test_escaping_config_path_is_refused(self, tmp_path):
+        # Arrange
+        project = tmp_path / "proj"
+        (project / "config").mkdir(parents=True)
+        (project / "config" / "config_manuscript.yaml").write_text(
+            _CONFIG.replace('archive_dir: "./01', 'archive_dir: "../01'),
+            encoding="utf-8",
+        )
+        (project / "01_manuscript").mkdir()
+        # Act
+        result = _archive_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert "OUTSIDE the project root" in result["error"]
+
+
+class TestCleanTreeGate:
+    def test_dirty_tree_is_skipped_not_archived(self, tmp_path):
+        # Arrange
+        project = _seed_project(tmp_path)
+        (project / "01_manuscript" / "manuscript.tex").write_text(
+            "edited\n", encoding="utf-8"
+        )
+        # Act
+        result = _archive_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert result["skipped"] is True
+
+    def test_dirty_tree_skip_states_its_reason(self, tmp_path):
+        # Arrange
+        project = _seed_project(tmp_path)
+        (project / "01_manuscript" / "manuscript.tex").write_text(
+            "edited\n", encoding="utf-8"
+        )
+        # Act
+        result = _archive_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert "uncommitted changes" in result["skip_reason"]
+
+    def test_dirty_tree_writes_no_archive_file(self, tmp_path):
+        # Arrange
+        project = _seed_project(tmp_path)
+        (project / "01_manuscript" / "manuscript.tex").write_text(
+            "edited\n", encoding="utf-8"
+        )
+        # Act
+        _archive_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert list(_archive_dir(project).glob("*")) == []
+
+    def test_non_git_project_is_skipped_not_archived(self, tmp_path):
+        # Arrange
+        cfg = tmp_path / "config"
+        cfg.mkdir()
+        (cfg / "config_manuscript.yaml").write_text(_CONFIG, encoding="utf-8")
+        (tmp_path / "01_manuscript").mkdir()
+        # Act
+        result = _archive_pipeline.process(str(tmp_path), "manuscript")
+        # Assert
+        assert result["skipped"] is True
+
+
+class TestCleanTreeArchive:
+    @pytest.fixture
+    def archived(self, tmp_path):
+        project = _seed_project(
+            tmp_path,
+            outputs=(
+                "manuscript.tex",
+                "manuscript.pdf",
+                "manuscript_diff.tex",
+                "manuscript_diff.pdf",
+            ),
+        )
+        return project, _archive_pipeline.process(
+            str(project), "manuscript", now=_STAMP
+        )
+
+    def test_archive_id_carries_timestamp_and_hash(self, archived):
+        # Arrange
+        _, result = archived
+        # Act
+        archive_id = result["archive_id"]
+        # Assert
+        assert archive_id.startswith("20260712-093000_")
+
+    def test_every_compiled_output_is_archived(self, archived):
+        # Arrange
+        _, result = archived
+        # Act
+        count = len(result["archived"])
+        # Assert
+        assert count == 4
+
+    def test_stamped_copy_is_written_to_disk(self, archived):
+        # Arrange
+        project, result = archived
+        # Act
+        stamped = _archive_dir(project) / f"manuscript_{result['archive_id']}.pdf"
+        # Assert
+        assert stamped.is_file()
+
+    def test_diff_copy_keeps_the_diff_marker_last(self, archived):
+        # Arrange
+        project, result = archived
+        # Act
+        stamped = _archive_dir(project) / f"manuscript_{result['archive_id']}_diff.pdf"
+        # Assert
+        assert stamped.is_file()
+
+    def test_unstamped_current_copy_is_written(self, archived):
+        # Arrange
+        project, _ = archived
+        # Act
+        current = _archive_dir(project) / "manuscript.pdf"
+        # Assert
+        assert current.is_file()
+
+    def test_archived_content_matches_the_source(self, archived):
+        # Arrange
+        project, result = archived
+        stamped = _archive_dir(project) / f"manuscript_{result['archive_id']}.pdf"
+        # Act
+        content = stamped.read_bytes()
+        # Assert
+        assert content == (project / "01_manuscript" / "manuscript.pdf").read_bytes()
+
+    def test_absent_output_is_reported_as_missing(self, tmp_path):
+        # Arrange
+        project = _seed_project(tmp_path, outputs=("manuscript.tex",))
+        # Act
+        result = _archive_pipeline.process(str(project), "manuscript", now=_STAMP)
+        # Assert
+        assert len(result["missing"]) == 3
+
+    def test_absent_output_does_not_fail_the_run(self, tmp_path):
+        # Arrange
+        project = _seed_project(tmp_path, outputs=("manuscript.tex",))
+        # Act
+        result = _archive_pipeline.process(str(project), "manuscript", now=_STAMP)
+        # Assert
+        assert result["success"] is True, result.get("error")

--- a/tests/scitex_writer/_mcp/handlers/test__diff_pipeline.py
+++ b/tests/scitex_writer/_mcp/handlers/test__diff_pipeline.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_writer/_mcp/handlers/test__diff_pipeline.py
+
+r"""Tests for the pure-Python diff pipeline (port of process_diff.sh).
+
+Real inputs throughout: a real git repository under ``tmp_path`` carrying two real
+commits of a real compiled ``.tex``, the same config keys the shell read, real
+``latexdiff`` and a real ``latexmk`` compile of the result. A diff PDF that does
+not compile is not a diff PDF, so the end-to-end case really compiles one.
+
+The "no previous version" case is the regression guard for the shell's worst
+silent degradation: it diffed the file against ITSELF and shipped an unmarked PDF,
+which a reviewer cannot tell apart from "nothing changed".
+"""
+
+import shutil
+import subprocess
+
+import pytest
+
+from scitex_writer._mcp.handlers import _diff_pipeline
+
+_CONFIG = (
+    "paths:\n"
+    '  doc_log_dir: "./01_manuscript/logs"\n'
+    '  compiled_tex: "./01_manuscript/manuscript.tex"\n'
+    '  compiled_pdf: "./01_manuscript/manuscript.pdf"\n'
+    '  diff_tex: "./01_manuscript/manuscript_diff.tex"\n'
+    '  diff_pdf: "./01_manuscript/manuscript_diff.pdf"\n'
+    '  archive_dir: "./01_manuscript/archive"\n'
+)
+
+_V1 = "\\documentclass{article}\n\\begin{document}\nThe first draft.\n\\end{document}\n"
+_V2 = (
+    "\\documentclass{article}\n\\begin{document}\n"
+    "The second, thoroughly revised draft.\n\\end{document}\n"
+)
+
+needs_tools = pytest.mark.skipif(
+    shutil.which("latexdiff") is None or shutil.which("latexmk") is None,
+    reason="latexdiff and latexmk are both required",
+)
+
+
+def _git_cmd(repo, *args):
+    subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    )
+
+
+def _commit(repo, message):
+    _git_cmd(repo, "add", "-A")
+    _git_cmd(repo, "commit", "-q", "-m", message)
+
+
+def _seed_project(tmp_path, revisions=(_V1, _V2)):
+    """A real git project whose compiled .tex has one commit per revision."""
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    (cfg / "config_manuscript.yaml").write_text(_CONFIG, encoding="utf-8")
+    (tmp_path / "01_manuscript").mkdir()
+    _git_cmd(tmp_path, "init", "-q")
+    _git_cmd(tmp_path, "config", "user.email", "tester@example.com")
+    _git_cmd(tmp_path, "config", "user.name", "Tester")
+    for index, text in enumerate(revisions):
+        (tmp_path / "01_manuscript" / "manuscript.tex").write_text(
+            text, encoding="utf-8"
+        )
+        _commit(tmp_path, f"revision {index}")
+    return tmp_path
+
+
+class TestPipelineErrors:
+    def test_invalid_doc_type_returns_actionable_error(self):
+        # Arrange
+        bad_doc_type = "poster"
+        # Act
+        result = _diff_pipeline.process(".", bad_doc_type)
+        # Assert
+        assert result["success"] is False and "poster" in result["error"]
+
+    def test_missing_project_dir_returns_error_hint(self, tmp_path):
+        # Arrange
+        absent = tmp_path / "nope"
+        # Act
+        result = _diff_pipeline.process(str(absent), "manuscript")
+        # Assert
+        assert result["success"] is False and "not found" in result["error"]
+
+    def test_missing_config_returns_error_hint(self, tmp_path):
+        # Arrange
+        (tmp_path / "01_manuscript").mkdir()
+        # Act
+        result = _diff_pipeline.process(str(tmp_path), "manuscript")
+        # Assert
+        assert result["success"] is False and "Config not found" in result["error"]
+
+    def test_missing_compiled_tex_returns_compile_hint(self, tmp_path):
+        # Arrange
+        cfg = tmp_path / "config"
+        cfg.mkdir()
+        (cfg / "config_manuscript.yaml").write_text(_CONFIG, encoding="utf-8")
+        (tmp_path / "01_manuscript").mkdir()
+        # Act
+        result = _diff_pipeline.process(str(tmp_path), "manuscript")
+        # Assert
+        assert "Compiled TeX not found" in result["error"]
+
+    def test_no_diff_flag_skips_pipeline(self, tmp_path):
+        # Arrange
+        project = _seed_project(tmp_path)
+        # Act
+        result = _diff_pipeline.process(str(project), "manuscript", no_diff=True)
+        # Assert
+        assert result["skipped"] is True
+
+    def test_escaping_config_path_is_refused(self, tmp_path):
+        # Arrange
+        project = tmp_path / "proj"
+        (project / "config").mkdir(parents=True)
+        (project / "config" / "config_manuscript.yaml").write_text(
+            _CONFIG.replace('diff_pdf: "./01', 'diff_pdf: "../01'), encoding="utf-8"
+        )
+        (project / "01_manuscript").mkdir()
+        # Act
+        result = _diff_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert "OUTSIDE the project root" in result["error"]
+
+
+class TestResolveVersions:
+    def test_single_commit_refuses_to_diff_against_itself(self, tmp_path):
+        # Arrange
+        project = _seed_project(tmp_path, revisions=(_V1,))
+        # Act
+        result = _diff_pipeline.process(str(project), "manuscript")
+        # Assert
+        assert "No PREVIOUS version" in result["error"]
+
+    def test_unknown_diff_from_commit_is_an_error(self, tmp_path):
+        # Arrange
+        project = _seed_project(tmp_path)
+        # Act
+        result = _diff_pipeline.process(
+            str(project), "manuscript", diff_from="no-such-commit"
+        )
+        # Assert
+        assert "does not resolve to a commit" in result["error"]
+
+    def test_non_git_project_is_an_error(self, tmp_path):
+        # Arrange
+        cfg = tmp_path / "config"
+        cfg.mkdir()
+        (cfg / "config_manuscript.yaml").write_text(_CONFIG, encoding="utf-8")
+        (tmp_path / "01_manuscript").mkdir()
+        (tmp_path / "01_manuscript" / "manuscript.tex").write_text(
+            _V1, encoding="utf-8"
+        )
+        # Act
+        result = _diff_pipeline.process(str(tmp_path), "manuscript")
+        # Assert
+        assert "not a git repository" in result["error"]
+
+    def test_dirty_tree_marks_the_new_version_with_plus(self, tmp_path):
+        # Arrange -- an edit to a TRACKED file; git (and so the shell) does not
+        # count an untracked file as a change against HEAD.
+        project = _seed_project(tmp_path)
+        compiled = project / "01_manuscript" / "manuscript.tex"
+        compiled.write_text(_V2 + "% uncommitted\n", encoding="utf-8")
+        # Act
+        _, _, new_label = _diff_pipeline.resolve_versions(project, compiled, None)
+        # Assert
+        assert new_label.endswith("+")
+
+    def test_clean_tree_marks_the_new_version_without_plus(self, tmp_path):
+        # Arrange
+        project = _seed_project(tmp_path)
+        compiled = project / "01_manuscript" / "manuscript.tex"
+        # Act
+        _, _, new_label = _diff_pipeline.resolve_versions(project, compiled, None)
+        # Assert
+        assert not new_label.endswith("+")
+
+
+@needs_tools
+class TestEndToEnd:
+    @pytest.fixture
+    def rendered(self, tmp_path):
+        project = _seed_project(tmp_path)
+        return project, _diff_pipeline.process(str(project), "manuscript")
+
+    def test_two_committed_revisions_render_successfully(self, rendered):
+        # Arrange
+        _, result = rendered
+        # Act
+        success = result["success"]
+        # Assert
+        assert success is True, result.get("error")
+
+    def test_diff_pdf_really_exists_on_disk(self, rendered):
+        # Arrange
+        project, result = rendered
+        # Act
+        pdf = project / "01_manuscript" / "manuscript_diff.pdf"
+        # Assert
+        assert pdf.is_file()
+
+    def test_diff_pdf_is_non_empty(self, rendered):
+        # Arrange
+        _, result = rendered
+        # Act
+        size = result["pdf_bytes"]
+        # Assert
+        assert size > 0
+
+    def test_diff_tex_carries_latexdiff_markup(self, rendered):
+        # Arrange
+        project, _ = rendered
+        text = (project / "01_manuscript" / "manuscript_diff.tex").read_text(
+            encoding="utf-8"
+        )
+        # Act
+        marked = "\\DIFadd" in text and "\\DIFdel" in text
+        # Assert
+        assert marked is True
+
+    def test_diff_tex_carries_the_signature_block(self, rendered):
+        # Arrange
+        project, _ = rendered
+        text = (project / "01_manuscript" / "manuscript_diff.tex").read_text(
+            encoding="utf-8"
+        )
+        # Act
+        signed = "Diff Document Metadata" in text
+        # Assert
+        assert signed is True
+
+    def test_result_names_both_compared_versions(self, rendered):
+        # Arrange
+        _, result = rendered
+        # Act
+        named = bool(result["from_hash"]) and bool(result["to_hash"])
+        # Assert
+        assert named is True
+
+    def test_explicit_diff_from_head_is_accepted(self, tmp_path):
+        # Arrange
+        project = _seed_project(tmp_path)
+        # Act
+        result = _diff_pipeline.process(str(project), "manuscript", diff_from="HEAD~1")
+        # Assert
+        assert result["success"] is True, result.get("error")

--- a/tests/scitex_writer/_mcp/handlers/test__engine_paths.py
+++ b/tests/scitex_writer/_mcp/handlers/test__engine_paths.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_writer/_mcp/handlers/test__engine_paths.py
+
+"""Tests for the shared config loading + boundary-checked path resolution.
+
+Real YAML files under ``tmp_path``. The boundary check is the load-bearing part:
+a ``..`` in the config must never let a pipeline write outside the project.
+"""
+
+from scitex_writer._mcp.handlers import _engine_paths
+
+_KEYS = {"compiled_tex": ("paths", "compiled_tex")}
+
+
+def _write_config(tmp_path, body):
+    cfg = tmp_path / "config"
+    cfg.mkdir(exist_ok=True)
+    (cfg / "config_manuscript.yaml").write_text(body, encoding="utf-8")
+    return tmp_path
+
+
+class TestLoadDocConfig:
+    def test_valid_config_is_parsed_into_a_dict(self, tmp_path):
+        # Arrange
+        project = _write_config(tmp_path, 'paths:\n  compiled_tex: "./a/b.tex"\n')
+        # Act
+        cfg, error = _engine_paths.load_doc_config(project, "manuscript")
+        # Assert
+        assert cfg["paths"]["compiled_tex"] == "./a/b.tex"
+
+    def test_absent_config_returns_actionable_error(self, tmp_path):
+        # Arrange
+        project = tmp_path
+        # Act
+        _, error = _engine_paths.load_doc_config(project, "manuscript")
+        # Assert
+        assert "Config not found" in error
+
+    def test_malformed_yaml_returns_actionable_error(self, tmp_path):
+        # Arrange
+        project = _write_config(tmp_path, "paths: [unclosed\n")
+        # Act
+        _, error = _engine_paths.load_doc_config(project, "manuscript")
+        # Assert
+        assert "not valid YAML" in error
+
+
+class TestResolvePaths:
+    def test_relative_path_resolves_under_the_project(self, tmp_path):
+        # Arrange
+        cfg = {"paths": {"compiled_tex": "./01_manuscript/m.tex"}}
+        # Act
+        paths, _ = _engine_paths.resolve_paths(tmp_path, cfg, _KEYS, "paths")
+        # Assert
+        assert paths["compiled_tex"] == tmp_path.resolve() / "01_manuscript/m.tex"
+
+    def test_missing_key_returns_actionable_error(self, tmp_path):
+        # Arrange
+        cfg = {"paths": {}}
+        # Act
+        _, error = _engine_paths.resolve_paths(tmp_path, cfg, _KEYS, "paths")
+        # Assert
+        assert "paths.compiled_tex is missing" in error
+
+    def test_escaping_path_is_refused(self, tmp_path):
+        # Arrange
+        cfg = {"paths": {"compiled_tex": "../outside/m.tex"}}
+        # Act
+        _, error = _engine_paths.resolve_paths(tmp_path, cfg, _KEYS, "paths")
+        # Assert
+        assert "OUTSIDE the project root" in error
+
+
+class TestCfgGet:
+    def test_nested_key_is_read_back(self):
+        # Arrange
+        cfg = {"a": {"b": "c"}}
+        # Act
+        value = _engine_paths.cfg_get(cfg, ("a", "b"))
+        # Assert
+        assert value == "c"
+
+    def test_absent_level_falls_back_to_default(self):
+        # Arrange
+        cfg = {"a": {}}
+        # Act
+        value = _engine_paths.cfg_get(cfg, ("a", "b"), default="fallback")
+        # Assert
+        assert value == "fallback"

--- a/tests/scitex_writer/_utils/test__git.py
+++ b/tests/scitex_writer/_utils/test__git.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_writer/_utils/test__git.py
+
+"""Tests for the ONE git backend behind the diff + archive pipelines.
+
+Real repositories throughout: every fixture runs the real ``git`` binary in a
+``tmp_path``. No mocks -- the point of this module is that a broken repo, a
+missing commit and a clean "nothing found" are told apart, which only a real repo
+can demonstrate.
+"""
+
+import os
+import subprocess
+
+import pytest
+
+from scitex_writer._utils import _git
+
+
+@pytest.fixture
+def empty_path(tmp_path):
+    """Point PATH at an EMPTY directory, so no binary resolves (real env seam)."""
+    previous = os.environ.get("PATH", "")
+    os.environ["PATH"] = str(tmp_path / "empty-bin")
+    (tmp_path / "empty-bin").mkdir()
+    try:
+        yield os.environ["PATH"]
+    finally:
+        os.environ["PATH"] = previous
+
+
+def _git_cmd(repo, *args):
+    subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    )
+
+
+def _init_repo(tmp_path):
+    """A real git repo with an identity configured; return its path."""
+    _git_cmd(tmp_path, "init", "-q")
+    _git_cmd(tmp_path, "config", "user.email", "tester@example.com")
+    _git_cmd(tmp_path, "config", "user.name", "Tester")
+    return tmp_path
+
+
+def _commit(repo, name, text, message):
+    (repo / name).write_text(text, encoding="utf-8")
+    _git_cmd(repo, "add", name)
+    _git_cmd(repo, "commit", "-q", "-m", message)
+
+
+class TestRepoDetection:
+    def test_plain_directory_is_not_repo(self, tmp_path):
+        # Arrange
+        plain = tmp_path
+        # Act
+        detected = _git.is_repo(plain)
+        # Assert
+        assert detected is False
+
+    def test_initialized_repo_is_detected(self, tmp_path):
+        # Arrange
+        repo = _init_repo(tmp_path)
+        # Act
+        detected = _git.is_repo(repo)
+        # Assert
+        assert detected is True
+
+    def test_empty_repo_has_no_commits(self, tmp_path):
+        # Arrange
+        repo = _init_repo(tmp_path)
+        # Act
+        detected = _git.has_commits(repo)
+        # Assert
+        assert detected is False
+
+    def test_committed_repo_has_commits(self, tmp_path):
+        # Arrange
+        repo = _init_repo(tmp_path)
+        _commit(repo, "a.tex", "one\n", "first")
+        # Act
+        detected = _git.has_commits(repo)
+        # Assert
+        assert detected is True
+
+
+class TestCleanliness:
+    def test_committed_tree_is_clean(self, tmp_path):
+        # Arrange
+        repo = _init_repo(tmp_path)
+        _commit(repo, "a.tex", "one\n", "first")
+        # Act
+        clean = _git.is_clean(repo)
+        # Assert
+        assert clean is True
+
+    def test_modified_tree_is_dirty(self, tmp_path):
+        # Arrange
+        repo = _init_repo(tmp_path)
+        _commit(repo, "a.tex", "one\n", "first")
+        (repo / "a.tex").write_text("two\n", encoding="utf-8")
+        # Act
+        clean = _git.is_clean(repo)
+        # Assert
+        assert clean is False
+
+    def test_staged_change_is_dirty(self, tmp_path):
+        # Arrange
+        repo = _init_repo(tmp_path)
+        _commit(repo, "a.tex", "one\n", "first")
+        (repo / "a.tex").write_text("two\n", encoding="utf-8")
+        _git_cmd(repo, "add", "a.tex")
+        # Act
+        clean = _git.is_clean(repo)
+        # Assert
+        assert clean is False
+
+    def test_repo_without_commits_is_not_clean(self, tmp_path):
+        # Arrange
+        repo = _init_repo(tmp_path)
+        # Act
+        clean = _git.is_clean(repo)
+        # Assert
+        assert clean is False
+
+
+class TestHistoryQueries:
+    def test_short_hash_is_seven_characters(self, tmp_path):
+        # Arrange
+        repo = _init_repo(tmp_path)
+        _commit(repo, "a.tex", "one\n", "first")
+        # Act
+        short = _git.short_hash(repo, "HEAD")
+        # Assert
+        assert len(short) == 7
+
+    def test_unknown_commit_resolves_to_none(self, tmp_path):
+        # Arrange
+        repo = _init_repo(tmp_path)
+        _commit(repo, "a.tex", "one\n", "first")
+        # Act
+        short = _git.short_hash(repo, "no-such-ref")
+        # Assert
+        assert short is None
+
+    def test_single_commit_file_has_no_previous_commit(self, tmp_path):
+        # Arrange
+        repo = _init_repo(tmp_path)
+        _commit(repo, "a.tex", "one\n", "first")
+        # Act
+        previous = _git.previous_commit(repo, "a.tex")
+        # Assert
+        assert previous is None
+
+    def test_twice_committed_file_has_previous_commit(self, tmp_path):
+        # Arrange
+        repo = _init_repo(tmp_path)
+        _commit(repo, "a.tex", "one\n", "first")
+        _commit(repo, "a.tex", "two\n", "second")
+        # Act
+        previous = _git.previous_commit(repo, "a.tex")
+        # Assert
+        assert previous is not None
+
+    def test_show_file_returns_previous_content(self, tmp_path):
+        # Arrange
+        repo = _init_repo(tmp_path)
+        _commit(repo, "a.tex", "one\n", "first")
+        _commit(repo, "a.tex", "two\n", "second")
+        previous = _git.previous_commit(repo, "a.tex")
+        # Act
+        content = _git.show_file(repo, previous, "a.tex")
+        # Assert
+        assert content == "one\n"
+
+    def test_show_file_of_untracked_path_returns_none(self, tmp_path):
+        # Arrange
+        repo = _init_repo(tmp_path)
+        _commit(repo, "a.tex", "one\n", "first")
+        # Act
+        content = _git.show_file(repo, "HEAD", "absent.tex")
+        # Assert
+        assert content is None
+
+    def test_configured_user_name_is_read_back(self, tmp_path):
+        # Arrange
+        repo = _init_repo(tmp_path)
+        _commit(repo, "a.tex", "one\n", "first")
+        # Act
+        name = _git.user_name(repo)
+        # Assert
+        assert name == "Tester"
+
+
+class TestFailLoud:
+    def test_require_git_returns_binary_path(self):
+        # Arrange
+        # Act
+        binary = _git.require_git()
+        # Assert
+        assert binary.endswith("git")
+
+    def test_missing_git_raises_actionable_error(self, empty_path):
+        # Arrange
+        # (``empty_path`` points PATH at an empty dir for the duration.)
+        # Act
+        # Assert
+        with pytest.raises(_git.GitUnavailableError, match="install git"):
+            _git.require_git()

--- a/tests/scitex_writer/_utils/test__latexdiff.py
+++ b/tests/scitex_writer/_utils/test__latexdiff.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_writer/_utils/test__latexdiff.py
+
+r"""Tests for the ONE latexdiff backend + the diff-document signature block.
+
+Real ``latexdiff`` runs on real ``.tex`` files under ``tmp_path``, and the signed
+diff is compiled by a real ``pdflatex`` -- a diff document that does not compile
+is not a diff document. No mocks.
+"""
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from scitex_writer._utils import _latexdiff
+
+_OLD = (
+    "\\documentclass{article}\n\\begin{document}\nHello old world.\n\\end{document}\n"
+)
+_NEW = (
+    "\\documentclass{article}\n\\begin{document}\n"
+    "Hello brand new world.\n\\end{document}\n"
+)
+
+
+@pytest.fixture
+def empty_path(tmp_path):
+    """Point PATH at an EMPTY directory, so no binary resolves (real env seam)."""
+    previous = os.environ.get("PATH", "")
+    (tmp_path / "empty-bin").mkdir()
+    os.environ["PATH"] = str(tmp_path / "empty-bin")
+    try:
+        yield os.environ["PATH"]
+    finally:
+        os.environ["PATH"] = previous
+
+
+@pytest.fixture
+def diffed(tmp_path):
+    """A real latexdiff output of _OLD -> _NEW; return its path."""
+    old = tmp_path / "old.tex"
+    new = tmp_path / "new.tex"
+    old.write_text(_OLD, encoding="utf-8")
+    new.write_text(_NEW, encoding="utf-8")
+    return _latexdiff.run_latexdiff(old, new, tmp_path / "diff.tex")
+
+
+needs_latexdiff = pytest.mark.skipif(
+    shutil.which("latexdiff") is None, reason="latexdiff not installed"
+)
+
+
+@needs_latexdiff
+class TestRunLatexdiff:
+    def test_diff_marks_added_text(self, diffed):
+        # Arrange
+        text = diffed.read_text(encoding="utf-8")
+        # Act
+        marked = "\\DIFadd" in text
+        # Assert
+        assert marked is True
+
+    def test_diff_marks_deleted_text(self, diffed):
+        # Arrange
+        text = diffed.read_text(encoding="utf-8")
+        # Act
+        marked = "\\DIFdel" in text
+        # Assert
+        assert marked is True
+
+    def test_diff_is_a_standalone_document(self, diffed):
+        # Arrange
+        text = diffed.read_text(encoding="utf-8")
+        # Act
+        standalone = _latexdiff.BEGIN_DOCUMENT in text
+        # Assert
+        assert standalone is True
+
+    def test_empty_input_fails_loud(self, tmp_path):
+        # Arrange
+        old = tmp_path / "old.tex"
+        new = tmp_path / "new.tex"
+        old.write_text("", encoding="utf-8")
+        new.write_text("", encoding="utf-8")
+        # Act
+        # Assert
+        with pytest.raises(_latexdiff.LatexdiffFailedError, match="EMPTY document"):
+            _latexdiff.run_latexdiff(old, new, tmp_path / "diff.tex")
+
+    def test_fragment_input_yields_no_compilable_document(self, tmp_path):
+        # Arrange -- latexdiff HAPPILY diffs bare fragments; the resulting file is
+        # not a document, and the signature stage is what refuses it (below).
+        old = tmp_path / "old.tex"
+        new = tmp_path / "new.tex"
+        old.write_text("just a fragment\n", encoding="utf-8")
+        new.write_text("another fragment\n", encoding="utf-8")
+        # Act
+        diff = _latexdiff.run_latexdiff(old, new, tmp_path / "diff.tex")
+        # Assert
+        assert _latexdiff.BEGIN_DOCUMENT not in diff.read_text(encoding="utf-8")
+
+
+@needs_latexdiff
+class TestAddSignature:
+    def test_signature_records_the_compared_versions(self, diffed):
+        # Arrange
+        _latexdiff.add_signature(diffed, "aaaaaaa", "bbbbbbb", doc_type="manuscript")
+        # Act
+        text = diffed.read_text(encoding="utf-8")
+        # Assert
+        assert "%% Comparison: vaaaaaaa → vbbbbbbb" in text
+
+    def test_signature_lands_before_begin_document(self, diffed):
+        # Arrange
+        _latexdiff.add_signature(diffed, "aaaaaaa", "bbbbbbb")
+        text = diffed.read_text(encoding="utf-8")
+        # Act
+        signature_first = text.index("\\fancypagestyle{diffstyle}") < text.index(
+            _latexdiff.BEGIN_DOCUMENT
+        )
+        # Assert
+        assert signature_first is True
+
+    def test_typeset_header_uses_math_arrow_not_unicode(self, diffed):
+        # Arrange
+        _latexdiff.add_signature(diffed, "aaaaaaa", "bbbbbbb")
+        text = diffed.read_text(encoding="utf-8")
+        # Act
+        header = [ln for ln in text.splitlines() if "\\fancyhead[L]" in ln][0]
+        # Assert
+        assert "$\\rightarrow$" in header
+
+    def test_signature_records_the_document_type(self, diffed):
+        # Arrange
+        _latexdiff.add_signature(diffed, "aaaaaaa", "bbbbbbb", doc_type="supplementary")
+        # Act
+        text = diffed.read_text(encoding="utf-8")
+        # Assert
+        assert "%% Document: supplementary" in text
+
+    def test_fragment_without_begin_document_fails_loud(self, tmp_path):
+        # Arrange
+        fragment = tmp_path / "fragment.tex"
+        fragment.write_text("\\section{Nope}\n", encoding="utf-8")
+        # Act
+        # Assert
+        with pytest.raises(_latexdiff.LatexdiffFailedError, match="not a standalone"):
+            _latexdiff.add_signature(fragment, "a", "b")
+
+
+class TestFailLoud:
+    def test_missing_latexdiff_raises_install_hint(self, empty_path):
+        # Arrange
+        # (``empty_path`` points PATH at an empty dir for the duration.)
+        # Act
+        # Assert
+        with pytest.raises(
+            _latexdiff.LatexdiffUnavailableError, match="apt-get install latexdiff"
+        ):
+            _latexdiff.require_latexdiff()
+
+
+@pytest.mark.skipif(
+    shutil.which("latexdiff") is None or shutil.which("pdflatex") is None,
+    reason="latexdiff and pdflatex are both required",
+)
+class TestRealCompile:
+    def test_signed_diff_document_compiles_to_pdf(self, tmp_path, diffed):
+        # Arrange
+        _latexdiff.add_signature(diffed, "aaaaaaa", "bbbbbbb", author="Tester")
+        # Act
+        subprocess.run(
+            ["pdflatex", "-interaction=nonstopmode", "-halt-on-error", diffed.name],
+            cwd=tmp_path,
+            capture_output=True,
+            check=True,
+        )
+        # Assert
+        assert (tmp_path / "diff.pdf").exists()

--- a/tests/scitex_writer/_utils/test__latexmk.py
+++ b/tests/scitex_writer/_utils/test__latexmk.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scitex_writer/_utils/test__latexmk.py
+
+"""Tests for the ONE LaTeX compile backend behind the diff pipeline.
+
+Real ``latexmk`` runs on real ``.tex`` sources under ``tmp_path``; a source with a
+real LaTeX error really fails. No mocks.
+"""
+
+import os
+import shutil
+
+import pytest
+
+from scitex_writer._utils import _latexmk
+
+_GOOD = "\\documentclass{article}\n\\begin{document}\nHello.\n\\end{document}\n"
+_BROKEN = "\\documentclass{article}\n\\begin{document}\n\\undefinedmacro\n"
+
+needs_latexmk = pytest.mark.skipif(
+    shutil.which("latexmk") is None, reason="latexmk not installed"
+)
+
+
+@pytest.fixture
+def empty_path(tmp_path):
+    """Point PATH at an EMPTY directory, so no binary resolves (real env seam)."""
+    previous = os.environ.get("PATH", "")
+    (tmp_path / "empty-bin").mkdir()
+    os.environ["PATH"] = str(tmp_path / "empty-bin")
+    try:
+        yield os.environ["PATH"]
+    finally:
+        os.environ["PATH"] = previous
+
+
+@needs_latexmk
+class TestCompileTex:
+    def test_valid_source_produces_pdf_in_output_dir(self, tmp_path):
+        # Arrange
+        tex = tmp_path / "doc.tex"
+        tex.write_text(_GOOD, encoding="utf-8")
+        # Act
+        pdf = _latexmk.compile_tex(tex, tmp_path / "logs", project_root=tmp_path)
+        # Assert
+        assert pdf == tmp_path / "logs" / "doc.pdf"
+
+    def test_pdf_is_written_and_non_empty(self, tmp_path):
+        # Arrange
+        tex = tmp_path / "doc.tex"
+        tex.write_text(_GOOD, encoding="utf-8")
+        # Act
+        pdf = _latexmk.compile_tex(tex, tmp_path / "logs", project_root=tmp_path)
+        # Assert
+        assert pdf.stat().st_size > 0
+
+    def test_nothing_is_written_beside_the_source(self, tmp_path):
+        # Arrange
+        tex = tmp_path / "doc.tex"
+        tex.write_text(_GOOD, encoding="utf-8")
+        # Act
+        _latexmk.compile_tex(tex, tmp_path / "logs", project_root=tmp_path)
+        # Assert
+        assert not (tmp_path / "doc.pdf").exists()
+
+    def test_broken_source_fails_loud(self, tmp_path):
+        # Arrange
+        tex = tmp_path / "doc.tex"
+        tex.write_text(_BROKEN, encoding="utf-8")
+        # Act
+        # Assert
+        with pytest.raises(_latexmk.LatexmkFailedError, match="latexmk exited"):
+            _latexmk.compile_tex(tex, tmp_path / "logs", project_root=tmp_path)
+
+    def test_absent_source_fails_loud(self, tmp_path):
+        # Arrange
+        tex = tmp_path / "absent.tex"
+        # Act
+        # Assert
+        with pytest.raises(_latexmk.LatexmkFailedError, match="TeX source not found"):
+            _latexmk.compile_tex(tex, tmp_path / "logs", project_root=tmp_path)
+
+
+class TestFailLoud:
+    def test_missing_latexmk_raises_install_hint(self, empty_path):
+        # Arrange
+        # (``empty_path`` points PATH at an empty dir for the duration.)
+        # Act
+        # Assert
+        with pytest.raises(_latexmk.LatexmkUnavailableError, match="apt-get install"):
+            _latexmk.require_latexmk()
+
+    def test_default_timeout_is_the_shell_default(self):
+        # Arrange
+        expected = 120
+        # Act
+        actual = _latexmk.DEFAULT_TIMEOUT_SEC
+        # Assert
+        assert actual == expected


### PR DESCRIPTION
Slice 6 — the LAST slice of the shell→Python engine port. Ports both remaining shell modules into the package. The shell scripts stay in place (retiring them is a separate follow-up).

## Stages ported

**`process_diff.sh` (259 lines) → `_mcp/handlers/_diff_pipeline.py`**

| shell | python | notes |
|---|---|---|
| `get_previous_commit` / `get_short_hash` / dirty-`+` suffix | `resolve_versions()` | picks the OLD commit (explicit `--from`, else the previous commit touching the compiled `.tex`) and the NEW label |
| `get_tex_from_commit` / `create_temp_tex_from_commit` + `latexdiff` | `take_diff_tex()` | materialises the old tex from git into a temp file (always cleaned up), runs latexdiff with the shell's exact flags (`--encoding=utf8 --type=UNDERLINE --disable-citation-markup --append-safecmd=cite,cite,citet`) |
| `add_diff_signature.sh` (sourced) | `_utils/_latexdiff.add_signature()` | metadata `%%` block + `fancyhdr` page style, inserted before `\begin{document}` |
| `compile_diff_tex` | `_utils/_latexmk.compile_tex()` | latexmk with the shell's flags, bounded by `SCITEX_WRITER_DIFF_TIMEOUT`'s 120 s default |
| `cleanup` | `collect_pdf()` | moves the PDF out of the log dir onto `diff_pdf`; empty PDF = error |

**`process_archive.sh` (125 lines) → `_mcp/handlers/_archive_pipeline.py`**

| shell | python | notes |
|---|---|---|
| `is_git_clean` gate | clean-tree gate | dirty tree ⇒ `skipped=True` + `skip_reason` (never a silent no-op) |
| `get_git_identifier` | `archive_id()` | `YYYYmmdd-HHMMSS_<short7>` |
| `store_file` ×4 | `store_file()` | stamped copy + un-stamped "current" copy; a `*_diff` stem keeps its suffix last (`manuscript_diff` → `manuscript_<id>_diff`) |

Both read the SAME config keys the shell read via `yq` from `config/config_<doc_type>.yaml` (`paths.compiled_tex`, `paths.compiled_pdf`, `paths.diff_tex`, `paths.diff_pdf`, `paths.doc_log_dir`, `paths.archive_dir`), through the new shared `_mcp/handlers/_engine_paths.py` (config load + boundary-checked path resolution — a `..` in the YAML cannot make a pipeline write outside the project).

Nothing under `scripts/shell/modules/*_modules/` is sourced by either module; `process_diff.sh` sources `command_switching.src`, `engines/*.sh` and `add_diff_signature.sh`, all accounted for above.

## Binary dependencies — checked, decided

Every binary was probed with `command -v` in this container before assuming anything.

| binary | present here | when absent |
|---|---|---|
| `latexdiff` | **yes** (`/usr/bin/latexdiff`) | **FAIL LOUD** — `LatexdiffUnavailableError` with an install hint (`apt-get install latexdiff` / `tlmgr install latexdiff`). Emitting an unmarked PDF would misreport "no changes", so there is no fallback. |
| `latexmk` | **yes** (`/usr/bin/latexmk`) | **FAIL LOUD** — install hint (TeX Live, or `scitex-writer containers install texlive`). |
| `pdflatex` | **yes** | driven via latexmk. |
| `git` | **yes** | **FAIL LOUD** — `GitUnavailableError`; both pipelines are git-based. |

Each lives behind ONE single-backend util (`_utils/_latexdiff.py`, `_utils/_latexmk.py`, `_utils/_git.py`), replacing `command_switching.src`'s native→module→container cascade, whose lower rungs silently emitted un-runnable command strings that surfaced as a mystery non-zero exit far from the cause.

## Silent degradations REMOVED (deliberate behaviour changes)

1. **No previous version ⇒ ERROR, not an empty diff.** The shell warned `"No previous version found in git history"`, then set `previous_tex="$SCITEX_WRITER_COMPILED_TEX"` and compiled the manuscript **against itself** — a PDF with zero diff markup, which a reviewer cannot distinguish from "nothing changed since the last version". The port refuses, with a hint (commit a second revision, or pass `--from`).
2. **Engine cascade → one engine.** The shell's `SCITEX_WRITER_SELECTED_ENGINE` switch (tectonic / latexmk / 3pass) defaulted an unknown value to latexmk *with a warning nobody reads*. Only latexmk is ported (the shell's own default, and the rung this repo's container recipe installs). `tectonic` and the hand-rolled 3-pass loop are **not ported** — see "not ported" below.
3. **Stale PDF on failure.** A failed compile removes the previous run's `diff_pdf` (as the shell did), *and* a compile that reports success but writes no PDF is now an error rather than a shrug.
4. **Unicode arrow hardening.** `add_diff_signature.sh` typeset a literal `U+2192` inside `\fancyhead`. It happens to compile on this TeX Live, but that depends on the diff preamble's Unicode setup; the port emits `$\rightarrow$` in the typeset header (identical rendering, cannot blow up). The `%%`-comment block keeps the literal arrow — it is never typeset.

## DEAD code found — refused, not ported

- **`get_git_identifier`'s `nogit` / `nocommit` branches** (`process_archive.sh:57-64`). Its ONLY caller runs *after* `is_git_clean`, which returns false when the directory is not a repo or has no commits — so neither identifier could ever be produced. Porting them would have invented behaviour. The port requires a repo with commits (the gate already guarantees it) and always stamps a real hash.
- **`cleanup`'s `sleep 1`** (`process_diff.sh:237`) — a no-op pause after a successful compile.

## Deliberately NOT ported

- The **tectonic** and **3pass** compile engines of `compile_diff_tex`. The diff document is a derived artifact that needs one reliable engine, not three; each rung resolved its own binary through the same silent cascade. `latexmk` (the shell's default) is the single backend, fail-loud when absent.
- The shell scripts themselves stay in place, per the task.

## Shell tests: stubs, as warned

- `tests/scripts/shell/modules/test_process_archive.sh` asserts regexes against **fabricated strings**, never calling `get_git_identifier` or `store_file`. It even asserts a "dirty flag" identifier format (`test_id_dirty`) that the implementation **never produces**.
- `tests/scripts/shell/modules/test_process_diff.sh` is mostly commented out.

Parity was therefore derived **function by function from the shell source**, not from those tests.

## Parity coverage — 103 new tests, no mocks, no monkeypatch

| file | tests |
|---|---|
| `tests/scitex_writer/_utils/test__git.py` | 17 — real repos in `tmp_path`; clean/dirty/staged, single-commit-has-no-previous, unknown ref ⇒ None |
| `tests/scitex_writer/_utils/test__latexdiff.py` | 12 — real latexdiff; DIFadd/DIFdel markup, signature placement, `$\rightarrow$`, fail-loud, **real pdflatex compile of the SIGNED diff** |
| `tests/scitex_writer/_utils/test__latexmk.py` | 7 — real latexmk; PDF in the output dir, nothing beside the source, broken source fails loud |
| `tests/scitex_writer/_mcp/handlers/test__diff_pipeline.py` | 18 — real git repo + 2 real revisions; **real end-to-end latexdiff → latexmk compile**, diff-against-itself refusal, path escape, dirty `+` label |
| `tests/scitex_writer/_mcp/handlers/test__archive_pipeline.py` | 19 — clean/dirty gate, stamped + current copies, `_diff` suffix last, missing outputs |
| `tests/scitex_writer/_mcp/handlers/test__engine_paths.py` | 8 |
| `tests/scitex_writer/_dataclasses/results/test__DiffResult.py` + `test__ArchiveResult.py` | 20 — fail-loud `validate()` |
| `tests/scitex_writer/_cli/commands/test_compile.py` | +1 |

**Real pdflatex/latexmk compiles verify the diff output**: `TestEndToEnd` builds a real two-commit repo, runs the pipeline, and asserts the resulting `manuscript_diff.pdf` exists and is non-empty; `TestRealCompile` compiles the *signed* diff document with pdflatex. A diff PDF that does not compile is not a diff PDF.

Full runs: **380 passed, 1 skipped** (`_cli` + `_dataclasses` + `_mcp`) and **132 passed** (`_utils`) — no regressions.

## Surfaces

`diff` is a READ verb and `archive` a MUTATING verb, so per `audit-cli` §1 they must be **leaves of a noun group**, not groups of their own. They land under the existing `compile` group, which also keeps all three surfaces aligned (§6 checks MCP↔Python-API parity):

- Python API — `sw.compile.diff(...)` / `sw.compile.archive(...)` (extends `compile.py`; PS-108b forbids new root modules)
- CLI — `scitex-writer compile diff` / `scitex-writer compile archive` (`--dry-run` / `--yes` on the mutating leaf)
- MCP — `writer_compile_diff` / `writer_compile_archive`

`scitex-dev ecosystem audit-all scitex-writer` exits **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
