### PR TITLE
fix(engine): compile path now uses the Python pipelines (the 2.28.0 fixes never reached users)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to SciTeX Writer will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **The 2.28.0 engine fixes never reached a real compile.** `compile-manuscript` runs the vendored `scripts/shell/compile_manuscript.sh`, which still invoked `modules/process_{figures,tables,diff,archive}.sh` — so the pure-Python pipelines were reachable only through `tables render` / `figures render` / `compile diff` / `compile archive`, which nothing on the compile path calls. Every 2.28.0 user still got backend-dependent math escaping, multi-panel figures shipped as panel-a, no-op cropping, and diff-against-self. All three compile scripts (manuscript / supplementary / revision) now delegate those four stages to the installed Python engine through the new `modules/run_python_pipeline.sh` launcher, which FAILS LOUD (with a `pip install -U scitex-writer` hint) rather than falling back to the shell. Consumer projects pick this up with `scitex-writer update-project`.
+
+### Changed
+- A failing diff stage no longer aborts the compile: the Python diff engine refuses to diff a version against itself, so on a project with no previous version the stage now reports the refusal loudly and the manuscript PDF still ships.
+- `modules/process_{figures,tables,diff,archive}.sh` are now DEAD (nothing invokes them) but are kept in the tree for one release cycle; they are marked SUPERSEDED in their headers.
+
 ## [2.28.0] - 2026-07-12
 
 The compile engine is now **pure Python**. All five shell modules were ported, each verified by *real* `pdflatex`/`latexmk` compiles rather than by inspection. The port surfaced four bugs that had been failing **silently** — every one of them survived because the shell's own tests asserted nothing (one test file printed `TODO` and passed).

--- a/scripts/shell/compile_manuscript.sh
+++ b/scripts/shell/compile_manuscript.sh
@@ -328,15 +328,17 @@ main() {
     local tbl_log="$temp_dir/tables.log"
     local wrd_log="$temp_dir/words.log"
 
-    # Run all three in parallel
+    # Figures/tables delegate to the INSTALLED scitex-writer Python engine
+    # (run_python_pipeline.sh); the shell modules they replace shipped silent
+    # bugs (math escaping, multi-panel figures emitted as panel-a, no-op crop).
     (
-        "$PROJECT_ROOT/scripts/shell/modules/process_figures.sh" "$no_figs" "$do_p2t" "$do_verbose" "$do_crop_tif" >"$fig_log" 2>&1
+        "$PROJECT_ROOT/scripts/shell/modules/run_python_pipeline.sh" figures "$no_figs" "$do_p2t" "$do_verbose" "$do_crop_tif" >"$fig_log" 2>&1
         echo $? >"$temp_dir/fig_exit"
     ) &
     local fig_pid=$!
 
     (
-        "$PROJECT_ROOT/scripts/shell/modules/process_tables.sh" "$no_tables" >"$tbl_log" 2>&1
+        "$PROJECT_ROOT/scripts/shell/modules/run_python_pipeline.sh" tables "$no_tables" >"$tbl_log" 2>&1
         echo $? >"$temp_dir/tbl_exit"
     ) &
     local tbl_pid=$!
@@ -371,7 +373,8 @@ main() {
     # Extract summary lines for normal mode
     if [ "${SCITEX_LOG_LEVEL:-1}" -lt 2 ]; then
         # Show only key results (remove file paths from grep output)
-        grep -hE "(figures compiled|tables compiled|Word counts updated)" "$fig_log" "$tbl_log" "$wrd_log" 2>/dev/null | sed 's/^/  /' || true
+        # "Compiled N figures/tables" is the Python engine's summary wording.
+        grep -hE "(figures compiled|tables compiled|Compiled [0-9]+ (figures|tables)|Word counts updated)" "$fig_log" "$tbl_log" "$wrd_log" 2>/dev/null | sed 's/^/  /' || true
     fi
 
     rm -rf "$temp_dir"
@@ -462,18 +465,21 @@ main() {
         || echo_warning "Manuscript hints feed skipped (non-fatal)"
     log_stage_end "Manuscript Hints"
 
-    # Diff (skip if --no_diff specified)
+    # Diff (skip if --no_diff). The Python diff engine REFUSES to diff a version
+    # against itself; a failing diff is loud but never aborts the compile.
     if [ "$no_diff" = false ]; then
         log_stage_start "Diff Generation"
-        "$PROJECT_ROOT/scripts/shell/modules/process_diff.sh"
+        if ! "$PROJECT_ROOT/scripts/shell/modules/run_python_pipeline.sh" diff; then
+            log_warning "Diff generation failed (above); PDF unaffected. Use --no_diff to skip."
+        fi
         log_stage_end "Diff Generation"
     else
         echo_info "Skipping diff generation (--no_diff specified)"
     fi
 
-    # Versioning
+    # Versioning (Python archive engine; a dirty tree is skipped, not archived)
     log_stage_start "Archive/Versioning"
-    "$PROJECT_ROOT/scripts/shell/modules/process_archive.sh"
+    "$PROJECT_ROOT/scripts/shell/modules/run_python_pipeline.sh" archive
     log_stage_end "Archive/Versioning"
 
     # Cleanup

--- a/scripts/shell/compile_revision.sh
+++ b/scripts/shell/compile_revision.sh
@@ -339,15 +339,15 @@ parse_arguments() {
     fig_log="$temp_dir/figures.log"
     tbl_log="$temp_dir/tables.log"
 
-    # Run both in parallel
+    # Figures/tables delegate to the INSTALLED scitex-writer Python engine.
     (
-        ./scripts/shell/modules/process_figures.sh "$no_figs" false false false >"$fig_log" 2>&1
+        ./scripts/shell/modules/run_python_pipeline.sh figures "$no_figs" false false false >"$fig_log" 2>&1
         echo $? >"$temp_dir/fig_exit"
     ) &
     fig_pid=$!
 
     (
-        ./scripts/shell/modules/process_tables.sh "$no_tables" >"$tbl_log" 2>&1
+        ./scripts/shell/modules/run_python_pipeline.sh tables "$no_tables" >"$tbl_log" 2>&1
         echo $? >"$temp_dir/tbl_exit"
     ) &
     tbl_pid=$!
@@ -414,9 +414,9 @@ parse_arguments() {
     # Skip diff generation for revision (revision document already shows changes inline)
     echo_info "Skipping diff generation (revision document shows changes inline)"
 
-    # Archive
+    # Archive (Python archive engine; a dirty tree is skipped, not archived)
     log_stage_start "Archive/Versioning"
-    ./scripts/shell/modules/process_archive.sh
+    ./scripts/shell/modules/run_python_pipeline.sh archive
     log_stage_end "Archive/Versioning"
 
     # Cleanup

--- a/scripts/shell/compile_supplementary.sh
+++ b/scripts/shell/compile_supplementary.sh
@@ -286,15 +286,15 @@ main() {
     local tbl_log="$temp_dir/tables.log"
     local wrd_log="$temp_dir/words.log"
 
-    # Run all three in parallel
+    # Figures/tables delegate to the INSTALLED scitex-writer Python engine.
     (
-        ./scripts/shell/modules/process_figures.sh "$no_figs" "$do_p2t" "$do_verbose" "$do_crop_tif" >"$fig_log" 2>&1
+        ./scripts/shell/modules/run_python_pipeline.sh figures "$no_figs" "$do_p2t" "$do_verbose" "$do_crop_tif" >"$fig_log" 2>&1
         echo $? >"$temp_dir/fig_exit"
     ) &
     local fig_pid=$!
 
     (
-        ./scripts/shell/modules/process_tables.sh "$no_tables" >"$tbl_log" 2>&1
+        ./scripts/shell/modules/run_python_pipeline.sh tables "$no_tables" >"$tbl_log" 2>&1
         echo $? >"$temp_dir/tbl_exit"
     ) &
     local tbl_pid=$!
@@ -368,18 +368,21 @@ main() {
     fi
     log_stage_end "Overflow Check"
 
-    # Diff (skip if --no_diff specified)
+    # Diff (skip if --no_diff). The Python diff engine REFUSES to diff a version
+    # against itself; a failing diff is loud but never aborts the compile.
     if [ "$no_diff" = false ]; then
         log_stage_start "Diff Generation"
-        ./scripts/shell/modules/process_diff.sh
+        if ! ./scripts/shell/modules/run_python_pipeline.sh diff; then
+            echo_warning "Diff generation failed (above); PDF unaffected. Use --no_diff to skip."
+        fi
         log_stage_end "Diff Generation"
     else
         echo_info "Skipping diff generation (--no_diff specified)"
     fi
 
-    # Versioning
+    # Versioning (Python archive engine; a dirty tree is skipped, not archived)
     log_stage_start "Archive/Versioning"
-    ./scripts/shell/modules/process_archive.sh
+    ./scripts/shell/modules/run_python_pipeline.sh archive
     log_stage_end "Archive/Versioning"
 
     # Cleanup

--- a/scripts/shell/modules/process_archive.sh
+++ b/scripts/shell/modules/process_archive.sh
@@ -7,6 +7,11 @@
 # Timestamp: "2026-01-19 (ywatanabe)"
 # File: ./scripts/shell/modules/process_archive.sh
 # Description: Archive compiled documents with git-based naming (timestamp + commit hash)
+#
+# SUPERSEDED (2.29.0) — NOTHING ON THE COMPILE PATH CALLS THIS ANY MORE.
+# The compile scripts now delegate the archive stage to the installed Python
+# engine via `modules/run_python_pipeline.sh archive` (-> `scitex-writer compile
+# archive`). Kept for one release cycle only.
 
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LOG_PATH="$THIS_DIR/.$(basename "$0").log"

--- a/scripts/shell/modules/process_diff.sh
+++ b/scripts/shell/modules/process_diff.sh
@@ -7,6 +7,12 @@
 # Timestamp: "2026-01-19 (ywatanabe)"
 # File: ./scripts/shell/modules/process_diff.sh
 # Description: Generate diff between current and previous git commit (or arbitrary commits)
+#
+# SUPERSEDED (2.29.0) — NOTHING ON THE COMPILE PATH CALLS THIS ANY MORE.
+# The compile scripts now delegate the diff stage to the installed Python engine
+# via `modules/run_python_pipeline.sh diff` (-> `scitex-writer compile diff`),
+# which refuses to diff a version against itself instead of silently emitting an
+# unmarked "nothing changed" PDF. Kept for one release cycle only.
 
 ORIG_DIR="$(pwd)"
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/shell/modules/process_figures.sh
+++ b/scripts/shell/modules/process_figures.sh
@@ -6,7 +6,13 @@
 # may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "$(date +"%Y-%m-%d %H:%M:%S") ($(whoami))"
 # File: process_figures.sh
-# Refactored modular version of process_figures.sh
+#
+# SUPERSEDED (2.29.0) — NOTHING ON THE COMPILE PATH CALLS THIS ANY MORE.
+# The compile scripts now delegate the figure stage to the installed Python
+# engine via `modules/run_python_pipeline.sh figures` (-> `scitex-writer figures
+# render`), which fixes bugs this module still has: multi-panel figures shipped
+# as panel-a while logging success, and a no-op crop when magick/mogrify is
+# absent. Kept for one release cycle only; do not wire it back in.
 
 # shellcheck disable=SC1091  # Don't follow sourced files
 

--- a/scripts/shell/modules/process_tables.sh
+++ b/scripts/shell/modules/process_tables.sh
@@ -6,6 +6,12 @@
 # may set it read-only in the consumer workspace after vendoring).
 # Timestamp: "2026-01-19 02:59:33 (ywatanabe)"
 # File: ./scripts/shell/modules/process_tables.sh
+#
+# SUPERSEDED (2.29.0) — NOTHING ON THE COMPILE PATH CALLS THIS ANY MORE.
+# The compile scripts now delegate the table stage to the installed Python
+# engine via `modules/run_python_pipeline.sh tables` (-> `scitex-writer tables
+# render`), which fixes this module's backend-dependent math escaping (a cell
+# like `5% ($p<0.05$)` came out mangled). Kept for one release cycle only.
 
 # Literal LaTeX backslashes are written via "\\…" in echo throughout this
 # module; SC2028's "echo may not expand escape sequences" is a false positive

--- a/scripts/shell/modules/run_python_pipeline.sh
+++ b/scripts/shell/modules/run_python_pipeline.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
+# File: ./scripts/shell/modules/run_python_pipeline.sh
+# Description: Delegate a heavy compile stage to the INSTALLED scitex-writer
+#              Python package.
+#
+# The four heavy stages (figures / tables / diff / archive) were ported to
+# Python (scitex-writer 2.28.0). The shell stays the ORCHESTRATOR; this module
+# is the single launcher every compile_*.sh uses to reach the Python engine, so
+# the ported bug fixes (backend-independent math escaping, really-tiled
+# multi-panel figures, real cropping, no diff-against-self) actually run on the
+# real compile path.
+#
+# Contract (positional, mirrors the shell modules this replaces):
+#     run_python_pipeline.sh figures  <no_figs> <p2t> <verbose> <crop>
+#     run_python_pipeline.sh tables   <no_tables>
+#     run_python_pipeline.sh diff
+#     run_python_pipeline.sh archive
+#
+# Document type comes from $SCITEX_WRITER_DOC_TYPE (exported by every
+# compile_*.sh); the project root from $PROJECT_ROOT or the script location.
+#
+# FAILS LOUD when the Python package is not importable. There is deliberately
+# NO fallback to the old shell modules: falling back would silently reintroduce
+# the four bugs the Python port fixed.
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$THIS_DIR/../../.." && pwd)}"
+
+GRAY='\033[0;90m'
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+echo_info() { echo -e "${GRAY}INFO: $1${NC}"; }
+echo_success() { echo -e "${GREEN}SUCC: $1${NC}"; }
+echo_error() { echo -e "${RED}ERRO: $1${NC}"; }
+
+usage() {
+    echo "Usage: $(basename "${BASH_SOURCE[0]}") <figures|tables|diff|archive> [args...]"
+}
+
+SCITEX_WRITER_PYTHON="${SCITEX_WRITER_PYTHON:-python3}"
+
+ensure_python_engine() {
+    if ! command -v "$SCITEX_WRITER_PYTHON" >/dev/null 2>&1; then
+        echo_error "Python interpreter not found: $SCITEX_WRITER_PYTHON"
+        echo_error "  The compile engine's figure/table/diff/archive stages run in Python."
+        echo_error "  Install Python 3, or point SCITEX_WRITER_PYTHON at your interpreter."
+        return 1
+    fi
+    if ! "$SCITEX_WRITER_PYTHON" -c "import scitex_writer" >/dev/null 2>&1; then
+        echo_error "The scitex-writer Python package is not importable by $SCITEX_WRITER_PYTHON"
+        echo_error "  The compile engine's figure/table/diff/archive stages live in that package."
+        echo_error "  Fix: pip install -U scitex-writer"
+        echo_error "  (or: export SCITEX_WRITER_PYTHON=/path/to/venv/bin/python)"
+        return 1
+    fi
+    return 0
+}
+
+run_stage() {
+    local stage="$1"
+    shift
+
+    local doc_type="${SCITEX_WRITER_DOC_TYPE:-manuscript}"
+    local -a cmd=("$SCITEX_WRITER_PYTHON" -m scitex_writer)
+
+    case "$stage" in
+    figures)
+        local no_figs="${1:-false}"
+        local p2t="${2:-false}"
+        # ${3} is the shell module's `verbose` flag — the Python engine always
+        # reports its per-stage counts, so it has no separate verbose switch.
+        local crop="${4:-false}"
+        cmd+=(figures render -p "$PROJECT_ROOT" -t "$doc_type")
+        [ "$no_figs" = true ] && cmd+=(--no-figs)
+        [ "$p2t" = true ] && cmd+=(--pptx)
+        [ "$crop" = true ] && cmd+=(--crop)
+        ;;
+    tables)
+        local no_tables="${1:-false}"
+        cmd+=(tables render -p "$PROJECT_ROOT" -t "$doc_type")
+        [ "$no_tables" = true ] && cmd+=(--no-tables)
+        ;;
+    diff)
+        cmd+=(compile diff -p "$PROJECT_ROOT" -t "$doc_type")
+        [ -n "${SCITEX_DIFF_FROM:-}" ] && cmd+=(--from "$SCITEX_DIFF_FROM")
+        [ -n "${SCITEX_WRITER_DIFF_TIMEOUT:-}" ] && cmd+=(--timeout "$SCITEX_WRITER_DIFF_TIMEOUT")
+        ;;
+    archive)
+        cmd+=(compile archive -p "$PROJECT_ROOT" -t "$doc_type" --yes)
+        ;;
+    *)
+        echo_error "Unknown pipeline stage: $stage"
+        usage
+        return 2
+        ;;
+    esac
+
+    echo_info "Python engine: ${cmd[*]}"
+    "${cmd[@]}"
+    local status=$?
+    if [ $status -eq 0 ]; then
+        echo_success "Python $stage pipeline finished"
+    else
+        echo_error "Python $stage pipeline failed (exit $status)"
+    fi
+    return $status
+}
+
+main() {
+    if [ $# -lt 1 ]; then
+        usage
+        exit 2
+    fi
+    ensure_python_engine || exit 1
+    run_stage "$@"
+}
+
+if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
+    main "$@"
+fi
+
+# EOF

--- a/tests/scitex_writer/_compile/test__runner.py
+++ b/tests/scitex_writer/_compile/test__runner.py
@@ -393,6 +393,83 @@ class TestLatexdiffType:
         assert "--type=CULINECHBAR" not in process_diff_content
 
 
+class TestCompilePathUsesPythonPipelines:
+    """The compile path must reach the PYTHON engine, not the old shell modules.
+
+    `run_compile` shells out to `scripts/shell/compile_<doc_type>.sh`, so the
+    heavy stages those scripts invoke ARE the compile path. Until 2.29.0 they
+    invoked `modules/process_{figures,tables,diff,archive}.sh` — meaning the
+    Python ports (and the four bugs they fixed) were unreachable from a real
+    compile. These tests pin the delegation so it cannot silently regress.
+    """
+
+    SHELL_MODULES = [
+        "process_figures.sh",
+        "process_tables.sh",
+        "process_diff.sh",
+        "process_archive.sh",
+    ]
+
+    def _script_text(self, doc_type: str) -> str:
+        project_root = Path(__file__).resolve().parents[3]
+        return _get_compile_script(project_root, doc_type).read_text()
+
+    def _delegates(self, doc_type: str, stage: str) -> bool:
+        """True iff the compile script launches `stage` via the Python launcher.
+
+        The path may or may not be quoted (`"$PROJECT_ROOT/.../x.sh" figures`
+        vs `./scripts/.../x.sh figures`), so match the launcher + stage pair.
+        """
+        pattern = rf'modules/run_python_pipeline\.sh"?\s+{stage}\b'
+        return re.search(pattern, self._script_text(doc_type)) is not None
+
+    @pytest.mark.parametrize("doc_type", ["manuscript", "supplementary", "revision"])
+    @pytest.mark.parametrize("shell_module", SHELL_MODULES)
+    def test_compile_script_never_invokes_shell_module(self, doc_type, shell_module):
+        # Arrange
+        text = self._script_text(doc_type)
+        # Act
+        invocations = re.findall(rf"modules/{re.escape(shell_module)}", text)
+        # Assert
+        assert invocations == []
+
+    @pytest.mark.parametrize("doc_type", ["manuscript", "supplementary", "revision"])
+    def test_compile_script_delegates_figures_to_python(self, doc_type):
+        # Arrange
+        stage = "figures"
+        # Act
+        delegated = self._delegates(doc_type, stage)
+        # Assert
+        assert delegated
+
+    @pytest.mark.parametrize("doc_type", ["manuscript", "supplementary", "revision"])
+    def test_compile_script_delegates_tables_to_python(self, doc_type):
+        # Arrange
+        stage = "tables"
+        # Act
+        delegated = self._delegates(doc_type, stage)
+        # Assert
+        assert delegated
+
+    @pytest.mark.parametrize("doc_type", ["manuscript", "supplementary"])
+    def test_compile_script_delegates_diff_to_python(self, doc_type):
+        # Arrange
+        stage = "diff"
+        # Act
+        delegated = self._delegates(doc_type, stage)
+        # Assert
+        assert delegated
+
+    @pytest.mark.parametrize("doc_type", ["manuscript", "supplementary", "revision"])
+    def test_compile_script_delegates_archive_to_python(self, doc_type):
+        # Arrange
+        stage = "archive"
+        # Act
+        delegated = self._delegates(doc_type, stage)
+        # Assert
+        assert delegated
+
+
 if __name__ == "__main__":
     import os
 

--- a/tests/scripts/shell/modules/test_run_python_pipeline.py
+++ b/tests/scripts/shell/modules/test_run_python_pipeline.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: tests/scripts/shell/modules/test_run_python_pipeline.py
+
+"""Tests for scripts/shell/modules/run_python_pipeline.sh.
+
+The launcher every compile_*.sh uses to reach the INSTALLED scitex-writer
+Python engine for the four heavy stages (figures / tables / diff / archive).
+
+Real subprocesses against a real fixture project on disk -- the point of the
+module is precisely that a REAL shell invocation reaches the REAL Python
+pipeline, which a stubbed call could never prove.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+LAUNCHER = REPO_ROOT / "scripts" / "shell" / "modules" / "run_python_pipeline.sh"
+
+# A cell the old shell table module mangled: a percent sign plus inline math.
+MATH_CELL = "5% ($p<0.05$)"
+
+
+def _make_project(root: Path) -> Path:
+    """Build the minimum project the table pipeline needs: config + one CSV."""
+    project = root / "paper"
+    tables = project / "01_manuscript" / "contents" / "tables" / "caption_and_media"
+    tables.mkdir(parents=True)
+    (tables / "01_demo.csv").write_text(
+        f"Group,Change\nTreated,{MATH_CELL}\n", encoding="utf-8"
+    )
+    (project / "config").mkdir()
+    (project / "config" / "config_manuscript.yaml").write_text(
+        "tables:\n"
+        "  dir: ./01_manuscript/contents/tables\n"
+        "  caption_media_dir: ./01_manuscript/contents/tables/caption_and_media\n"
+        "  compiled_dir: ./01_manuscript/contents/tables/compiled\n"
+        "  compiled_file: ./01_manuscript/contents/tables/compiled/FINAL.tex\n",
+        encoding="utf-8",
+    )
+    return project
+
+
+def _run(project: Path, *args: str, python: str = "") -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["PROJECT_ROOT"] = str(project)
+    env["SCITEX_WRITER_DOC_TYPE"] = "manuscript"
+    if python:
+        env["SCITEX_WRITER_PYTHON"] = python
+    return subprocess.run(
+        ["bash", str(LAUNCHER), *args],
+        cwd=str(project),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+
+class TestTableStageReachesPythonEngine:
+    """`run_python_pipeline.sh tables` really runs the Python table pipeline."""
+
+    @pytest.fixture
+    def rendered(self, tmp_path):
+        project = _make_project(tmp_path)
+        result = _run(project, "tables")
+        # FINAL.tex only \input's the per-table files; the rendered rows live
+        # in compiled/<name>.tex.
+        compiled = (
+            project
+            / "01_manuscript"
+            / "contents"
+            / "tables"
+            / "compiled"
+            / "01_demo.tex"
+        )
+        return result, compiled
+
+    def test_table_stage_exits_zero(self, rendered):
+        # Arrange
+        result, _ = rendered
+        # Act
+        code = result.returncode
+        # Assert
+        assert code == 0, result.stdout + result.stderr
+
+    def test_table_stage_invokes_the_python_module(self, rendered):
+        # Arrange
+        result, _ = rendered
+        # Act
+        printed = result.stdout
+        # Assert
+        assert "-m scitex_writer tables render" in printed
+
+    def test_table_stage_preserves_the_inline_math_cell(self, rendered):
+        # Arrange
+        _, compiled = rendered
+        # Act
+        text = compiled.read_text(encoding="utf-8")
+        # Assert
+        assert r"5\% ($p<0.05$)" in text
+
+    def test_table_stage_skips_when_no_tables_requested(self, tmp_path):
+        # Arrange
+        project = _make_project(tmp_path)
+        # Act
+        result = _run(project, "tables", "true")
+        # Assert
+        assert "--no-tables" in result.stdout
+
+
+class TestMissingPythonEngineFailsLoud:
+    """A missing scitex-writer package must ABORT, never fall back to the shell."""
+
+    @pytest.fixture
+    def fake_python(self, tmp_path):
+        """A real interpreter-shaped executable that cannot import the package."""
+        fake = tmp_path / "python-without-scitex-writer"
+        fake.write_text(
+            '#!/bin/bash\nif [ "$1" = "-c" ]; then exit 1; fi\nexit 1\n',
+            encoding="utf-8",
+        )
+        fake.chmod(0o755)
+        return fake
+
+    def test_missing_package_exits_nonzero(self, tmp_path, fake_python):
+        # Arrange
+        project = _make_project(tmp_path)
+        # Act
+        result = _run(project, "tables", python=str(fake_python))
+        # Assert
+        assert result.returncode == 1
+
+    def test_missing_package_prints_install_hint(self, tmp_path, fake_python):
+        # Arrange
+        project = _make_project(tmp_path)
+        # Act
+        result = _run(project, "tables", python=str(fake_python))
+        # Assert
+        assert "pip install -U scitex-writer" in result.stdout
+
+    def test_missing_package_does_not_render_tables(self, tmp_path, fake_python):
+        # Arrange
+        project = _make_project(tmp_path)
+        # Act
+        _run(project, "tables", python=str(fake_python))
+        # Assert
+        assert not (
+            project / "01_manuscript" / "contents" / "tables" / "compiled"
+        ).exists()
+
+
+class TestUnknownStageIsRejected:
+    """An unknown stage name is a usage error, not a silent no-op."""
+
+    def test_unknown_stage_exits_with_usage_code(self, tmp_path):
+        # Arrange
+        project = _make_project(tmp_path)
+        # Act
+        result = _run(project, "nonsense")
+        # Assert
+        assert result.returncode == 2
+
+
+if __name__ == "__main__":
+    pytest.main([os.path.abspath(__file__)])
+
+# EOF


### PR DESCRIPTION
## The gap

2.28.0 ported the compile engine to Python (#296 / #298 / #299) and fixed four silent bugs along the way. **None of those fixes reached a single user.**

The real compile path is:

```
scitex-writer compile-manuscript
  -> _compile/_runner.py::_get_compile_script -> subprocess
    -> scripts/shell/compile_manuscript.sh
      -> modules/process_figures.sh    <- OLD SHELL
      -> modules/process_tables.sh     <- OLD SHELL
      -> modules/process_diff.sh       <- OLD SHELL
      -> modules/process_archive.sh    <- OLD SHELL
```

The Python pipelines were reachable only through `tables render` / `figures render` / `compile diff` / `compile archive` — commands nothing on the compile path calls. So a user on 2.28.0 still got: backend-dependent math escaping, multi-panel figures shipped as panel-a (while logging success), no-op cropping, and diff-against-self.

`compile_supplementary.sh` and `compile_revision.sh` had the same wiring.

## What changed

- **New `scripts/shell/modules/run_python_pipeline.sh`** — one launcher, used by all three compile scripts, that dispatches a stage to the installed package (`python3 -m scitex_writer figures render` / `tables render` / `compile diff` / `compile archive`). It maps the shell modules' positional args verbatim (`no_figs` / `p2t` / `crop` / `no_tables`) and honours `SCITEX_WRITER_DOC_TYPE`, `SCITEX_WRITER_PYTHON`, `SCITEX_DIFF_FROM`, `SCITEX_WRITER_DIFF_TIMEOUT`.
- **Fails loud, never falls back.** If `scitex_writer` is not importable the stage aborts with `pip install -U scitex-writer` (a silent fallback to the .sh would reintroduce the four bugs invisibly).
- **All 8 call sites rewired** across `compile_manuscript.sh`, `compile_supplementary.sh`, `compile_revision.sh`. `--no_figs` / `--no_tables` still skip; the per-stage log files (`$fig_log` / `$tbl_log`) and the parallel figure/table fan-out are unchanged, so the compile log stays coherent (the summary grep now also matches the Python engine's "Compiled N figures/tables" wording).
- **Diff is loud but non-fatal.** The Python diff engine *refuses* to diff a version against itself. The old shell module always exited 0, so under `set -e` a hard failure here would newly abort compiles on projects with no previous version. The stage now reports the refusal loudly and the manuscript PDF still ships.
- **The four `process_*.sh` modules are left in the tree but are now DEAD** — nothing invokes them; each carries a `SUPERSEDED` header. (Their `.src` submodules still back existing shell tests, so deleting them is a follow-up, not this PR.)

## How a consumer picks it up

`scripts/**` is engine-vendored: `SYNC_DIRS = ["scripts"]` in the update handler copies the whole tree, so `scitex-writer update-project` pulls in the rewired compile scripts **and** the new launcher (as an added file). The Python package itself is pip-installed, so the engine and the launcher land together.

## End-to-end evidence (a REAL compile, not a pipeline unit test)

Built a real fixture project (repo skeleton + git init), added a two-panel figure (`01a_panel.png` red 400x300, `01b_panel.png` blue 400x300) and a table cell `5% ($p<0.05$)`, then ran the actual entry point `sw.compile.manuscript(project)`:

- `manuscript.pdf` produced — **124,561 bytes**, exit 0.
- The composite figure the compile emitted is **820x300, red on the left, blue on the right** — genuinely TILED. The old shell shipped panel-a (400x300, all red). *This is the Python figure pipeline running inside a real compile.*
- `compiled/01_example_table.tex` holds `Treated & 5\% ($p<0.05$) & yes \\` — the math+percent cell survives. *This is the Python table pipeline running inside a real compile.*
- The diff stage printed its refusal (fresh repo, no previous version of the .tex) and the compile continued to a good PDF — the new loud-but-non-fatal behaviour.
- The archive stage ran through `python -m scitex_writer compile archive`.

## Tests

- `tests/scitex_writer/_compile/test__runner.py::TestCompilePathUsesPythonPipelines` — the regression pin that would have caught this gap: for every doc type, the compile script the runner launches must NOT invoke any `modules/process_*.sh`, and MUST delegate figures/tables/diff/archive to `run_python_pipeline.sh`.
- `tests/scripts/shell/modules/test_run_python_pipeline.py` — real bash subprocess against a real fixture: the table stage reaches the Python module and the `5\% ($p<0.05$)` cell survives; a missing package exits 1 with the install hint and renders nothing; an unknown stage exits 2.

118 passed (`tests/scitex_writer/_compile/` + the new launcher tests). `scitex-dev ecosystem audit-all scitex-writer` clean (skills / python-apis / project-structure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
