### PR TITLE
feat(checks): citation-trustworthiness check via scitex-scholar

### DIFF
--- a/scripts/python/_citation_trust_cache.py
+++ b/scripts/python/_citation_trust_cache.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
+# File: scripts/python/_citation_trust_cache.py
+# Purpose: Verdict cache for check_citation_trust.py.
+#
+#          CACHING IS MANDATORY here: scitex-scholar has NO persistent cache in
+#          the verify_cites path (it builds fresh resolver engines per call), and
+#          a manuscript carries 100+ cites recompiled many times a day -- so
+#          every compile would otherwise re-hit CrossRef/OpenAlex/arXiv.
+#
+#          Verdicts live in the project runtime dir
+#          (.scitex/writer/runtime/citation_trust.json -- the same
+#          `.scitex/writer/runtime/` convention as the annotations DB and the GUI
+#          runtime state), keyed by cite key + a CONTENT fingerprint of the bib
+#          entry, so editing any field of an entry re-verifies it.
+#
+#          Invariants (fail-loud):
+#            * a cache MISS is never reported as verified -- it forces a real
+#              verification run;
+#            * only KNOWN statuses are stored, so an unrecognised status can
+#              never be resurrected from the cache;
+#            * entries older than CACHE_TTL_DAYS are re-verified;
+#            * a corrupt/foreign cache file reads as empty (= all misses).
+#          The caller additionally never stores OFFLINE verdicts (an offline
+#          "unverified" must not poison a later online run).
+#
+# Self-contained: stdlib only.
+
+import hashlib
+import json
+import time
+from pathlib import Path
+
+# Runtime dir convention: <project>/.scitex/writer/runtime/<file>.
+CACHE_REL = ".scitex/writer/runtime/citation_trust.json"
+CACHE_SCHEMA = "scitex-writer/citation_trust/v1"
+CACHE_TTL_DAYS = 30
+
+
+def cache_path(project_dir):
+    """Path of the verdict cache inside the project runtime dir."""
+    return Path(project_dir) / CACHE_REL
+
+
+def entry_fingerprint(fields):
+    """Content fingerprint of one bib entry (sha256 over its normalized fields)."""
+    payload = "\n".join(f"{name}={fields[name]}" for name in sorted(fields))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def load_cache(path):
+    """Load the verdict cache, or ``{}`` on any problem (a bad cache = all misses)."""
+    try:
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(data, dict) or data.get("schema") != CACHE_SCHEMA:
+        return {}
+    verdicts = data.get("verdicts")
+    return verdicts if isinstance(verdicts, dict) else {}
+
+
+def save_cache(path, verdicts):
+    """Write the verdict cache. Best-effort: a read-only tree must not crash."""
+    path = Path(path)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {"schema": CACHE_SCHEMA, "verdicts": verdicts},
+                indent=2,
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+    except OSError:
+        return False
+    return True
+
+
+def cache_lookup(cached, key, fingerprint, known_statuses, now=None):
+    """Return the cached verdict dict for ``key``, or None on a MISS.
+
+    A miss (unknown key, changed entry content, unknown status, expired verdict,
+    malformed record) yields None -- and a miss is NEVER a pass; the caller
+    re-verifies.
+    """
+    record = cached.get(key)
+    if not isinstance(record, dict):
+        return None
+    if fingerprint is None or record.get("fingerprint") != fingerprint:
+        return None
+    status = record.get("status")
+    if status not in known_statuses:
+        return None
+    stamp = record.get("verified_at")
+    if not isinstance(stamp, (int, float)):
+        return None
+    now = time.time() if now is None else now
+    if now - stamp > CACHE_TTL_DAYS * 86400:
+        return None
+    return {
+        "key": key,
+        "status": status,
+        "detail": record.get("detail", ""),
+        "confidence": record.get("confidence"),
+        "cached": True,
+    }
+
+
+def cache_store(cached, verdicts, fingerprints, known_statuses, now=None):
+    """Merge fresh verdicts into ``cached`` (returns it). Unknown status = skipped."""
+    now = time.time() if now is None else now
+    for verdict in verdicts:
+        key = verdict.get("key")
+        status = verdict.get("status")
+        fingerprint = fingerprints.get(key)
+        if not key or status not in known_statuses or fingerprint is None:
+            continue
+        cached[key] = {
+            "fingerprint": fingerprint,
+            "status": status,
+            "detail": verdict.get("detail", ""),
+            "confidence": verdict.get("confidence"),
+            "verified_at": now,
+        }
+    return cached
+
+
+__all__ = [
+    "CACHE_REL",
+    "CACHE_SCHEMA",
+    "CACHE_TTL_DAYS",
+    "cache_lookup",
+    "cache_path",
+    "cache_store",
+    "entry_fingerprint",
+    "load_cache",
+    "save_cache",
+]
+
+# EOF

--- a/scripts/python/check_citation_trust.py
+++ b/scripts/python/check_citation_trust.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
+# File: scripts/python/check_citation_trust.py
+# Purpose: CITATION-TRUSTWORTHINESS check -- beyond "does the \cite key exist in
+#          the .bib" (check_ref_integrity) and beyond "is the entry a scholar
+#          stub" (check_citations): actually RESOLVE every cited entry against
+#          the real bibliographic record (CrossRef / OpenAlex / arXiv / Semantic
+#          Scholar) and flag the ones that cannot be shown to be a real,
+#          trustworthy source.
+#
+#          Verification is DELEGATED to scitex-scholar (>= 1.2.1, the `scholar`
+#          extra): `from scitex_scholar.verify_cites import verify_cites`.
+#          "Trustworthy" in scholar's terms = the entry resolves to a real
+#          source AND its claimed title fuzzy-matches what that source says
+#          (>= min_confidence).
+#          KNOWN GAP (not covered): scholar does NOT check retraction status or
+#          predatory venues -- a resolvable, title-matching citation to a
+#          RETRACTED paper still classifies as `verified` here.
+#
+#          Status -> severity mapping (agreed on card
+#          writer-dynamic-paper-findings-feed):
+#            verified                     -> info (suppressed; counted as pass)
+#            unverified / stub / unlinked -> warning
+#            hallucinated                 -> error
+#          A finding's severity is then CLAMPED by the resolved level: at
+#          level=warn an error-mapped finding is still reported LOUDLY but does
+#          not block (exit 0); at level=error it blocks (exit 1).
+#
+#          FAIL-LOUD, NEVER SILENTLY PASS. When verification is UN-RUNNABLE
+#          (scitex-scholar not installed, bib unresolvable, network down,
+#          resolver crash), the check reports the un-runnable condition at the
+#          resolved level -- WARN by default, FAIL at level=error -- and emits
+#          NO pass. No code path reports a citation as trustworthy without an
+#          actual verdict for it.
+#
+#          CACHING is mandatory (scholar has none in this path); see
+#          _citation_trust_cache.py. Verdicts are keyed by cite key + bib-entry
+#          content hash in .scitex/writer/runtime/citation_trust.json; a cache
+#          miss forces real verification; OFFLINE verdicts are never cached.
+#
+#          DEFAULT = warn: a network-dependent check must never block a compile
+#          by default. Set citation_trust.level: error to gate.
+#
+#          Severity precedence: --level > env SCITEX_WRITER_CITATION_TRUST >
+#          project ./config.yaml citation_trust.level > user
+#          ~/.scitex/writer/config.yaml citation_trust.level > warn.
+#
+# Usage:
+#   python check_citation_trust.py [project_dir] [--level off|warn|error]
+#                                  [--bib PATH] [--offline]
+#                                  [--min-confidence 0.8] [--no-cache]
+#
+# Self-contained: stdlib + optional PyYAML (config) + optional scitex-scholar
+# (the verifier itself; its absence is reported LOUDLY, never as a pass).
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _citation_trust_cache import (  # noqa: E402
+    cache_lookup,
+    cache_path,
+    cache_store,
+    entry_fingerprint,
+    load_cache,
+    save_cache,
+)
+from _severity import env_truthy, resolve_level  # noqa: E402
+from check_citations import (  # noqa: E402
+    _load_text,
+    _resolve_tex_paths,
+    extract_cited_keys,
+    iter_bib_entries,
+    resolve_bib_paths,
+)
+
+GREEN = "\033[0;32m"
+YELLOW = "\033[1;33m"
+RED = "\033[0;31m"
+DIM = "\033[0;90m"
+BOLD = "\033[1m"
+NC = "\033[0m"
+
+_LEVELS = ("off", "warn", "error")
+
+# scitex-scholar verify_cites statuses (scitex_scholar.verify_cites._model).
+VERIFIED = "verified"
+UNVERIFIED = "unverified"
+STUB = "stub"
+HALLUCINATED = "hallucinated"
+UNLINKED = "unlinked"
+
+# The agreed status -> canonical severity mapping. An UNKNOWN status is treated
+# as an error, never as a pass -- fail-loud on anything unrecognised.
+STATUS_SEVERITY = {
+    VERIFIED: "info",
+    UNVERIFIED: "warning",
+    STUB: "warning",
+    UNLINKED: "warning",
+    HALLUCINATED: "error",
+}
+
+_STATUS_EXPLAIN = {
+    UNVERIFIED: "has an identifier but did NOT resolve (or its title matched "
+    "below the confidence threshold)",
+    STUB: "is an auto-generated placeholder -- no real metadata to verify",
+    UNLINKED: "is cited but has no entry in the compiled bibliography",
+    HALLUCINATED: "was not found in ANY source index -- it looks fabricated",
+}
+
+# Force offline verification (no network) without touching the CLI.
+OFFLINE_ENV = "SCITEX_WRITER_CITATION_TRUST_OFFLINE"
+
+
+class VerificationUnavailable(RuntimeError):
+    """Verification could not be RUN (missing scholar, bad bib, network, crash).
+
+    Distinct from "verification ran and found problems". This is the fail-loud
+    signal: the check reports it at the resolved level and never emits a PASS.
+    """
+
+
+class Reporter:
+    """PASS/WARN/FAIL reporter with per-run counters (no module globals).
+
+    ``exit_code()`` is 1 iff a real FAIL was reported, so an in-process caller
+    (and a test) gets an exit code that depends only on THIS run.
+    """
+
+    def __init__(self):
+        self.passed = 0
+        self.warnings = 0
+        self.errors = 0
+
+    def log_pass(self, msg):
+        print(f"  {GREEN}[PASS]{NC} {msg}")
+        self.passed += 1
+
+    def log_warn(self, msg):
+        print(f"  {YELLOW}[WARN]{NC} {msg}")
+        self.warnings += 1
+
+    def log_fail(self, msg):
+        print(f"  {RED}[FAIL]{NC} {msg}")
+        self.errors += 1
+
+    def log_detail(self, msg):
+        print(f"    {DIM}{msg}{NC}")
+
+    def at(self, severity):
+        """The logger for ``severity`` ("error" -> FAIL, else WARN)."""
+        return self.log_fail if severity == "error" else self.log_warn
+
+    def summary(self):
+        print()
+        print(
+            f"{BOLD}Summary:{NC} {GREEN}{self.passed} passed{NC}, "
+            f"{YELLOW}{self.warnings} warnings{NC}, {RED}{self.errors} errors{NC}"
+        )
+
+    def exit_code(self):
+        return 1 if self.errors > 0 else 0
+
+
+def default_verifier(project_dir, bib=None, offline=False, min_confidence=0.8):
+    """Verify every cited key via scitex-scholar; return a list of verdict dicts.
+
+    Each verdict is ``{"key", "status", "detail", "confidence"}``. Raises
+    :class:`VerificationUnavailable` when verification cannot be run at all
+    (scitex-scholar absent, bib unresolvable, resolver/network failure) -- the
+    caller turns that into a loud warning/error, never a pass.
+
+    This is the DEFAULT injection seam: callers (and tests) pass a callable with
+    the same signature to exercise the check without a network.
+    """
+    try:
+        from scitex_scholar.verify_cites import verify_cites
+    except Exception as exc:  # not installed, too old, or a broken install
+        raise VerificationUnavailable(
+            "scitex_scholar.verify_cites is unavailable "
+            f"({type(exc).__name__}: {exc}), so citations could NOT be verified "
+            "-- install the extra: pip install 'scitex-writer[scholar]'"
+        ) from exc
+    try:
+        report = verify_cites(
+            str(project_dir),
+            bib=Path(bib) if bib else None,
+            min_confidence=min_confidence,
+            offline=offline,
+            write=False,
+        )
+    except Exception as exc:  # resolver / network / bib failure -- never swallow
+        raise VerificationUnavailable(
+            f"scitex-scholar verify_cites() failed: {type(exc).__name__}: {exc}"
+        ) from exc
+    return [
+        {
+            "key": status.key,
+            "status": (status.status or "").strip().lower(),
+            "detail": getattr(status, "provenance", "") or "",
+            "confidence": getattr(status, "match_confidence", None),
+        }
+        for status in report.statuses
+    ]
+
+
+def effective_severity(status, level):
+    """Clamp a finding's mapped severity by the check's resolved ``level``.
+
+    ``error`` findings only FAIL at level=error; at level=warn they are still
+    reported loudly, but never block the compile.
+    """
+    mapped = STATUS_SEVERITY.get(status, "error")
+    if mapped == "error" and level != "error":
+        return "warning"
+    return mapped
+
+
+def _report_findings(reporter, verdicts, level):
+    """Print one line per verdict group at its effective severity."""
+    buckets = {}
+    for verdict in verdicts:
+        buckets.setdefault(verdict["status"], []).append(verdict)
+
+    verified = buckets.pop(VERIFIED, [])
+    if verified:
+        reporter.log_pass(
+            f"{len(verified)} citation(s) resolve to a real source with a "
+            f"matching title (trustworthy)"
+        )
+
+    for status in (HALLUCINATED, UNVERIFIED, STUB, UNLINKED):
+        found = buckets.pop(status, [])
+        if not found:
+            continue
+        reporter.at(effective_severity(status, level))(
+            f"{len(found)} citation(s) classified {status.upper()} -- "
+            f"{_STATUS_EXPLAIN[status]}:"
+        )
+        for verdict in found:
+            suffix = " (cached)" if verdict.get("cached") else ""
+            detail = verdict.get("detail") or ""
+            reporter.log_detail(f"\\cite{{{verdict['key']}}}{suffix} {detail}".rstrip())
+
+    # Anything scholar reports that we do not recognise is an ERROR, not a pass.
+    for status, found in sorted(buckets.items()):
+        reporter.at("error" if level == "error" else "warning")(
+            f"{len(found)} citation(s) have an UNRECOGNISED status {status!r} -- "
+            f"treating as untrusted (writer/scholar version skew?):"
+        )
+        for verdict in found:
+            reporter.log_detail(f"\\cite{{{verdict['key']}}}")
+
+
+def _read_entries(reporter, bib_paths):
+    """Merge bib entries across the resolved bibs (first occurrence wins)."""
+    entries = {}
+    for bib_path in bib_paths:
+        reporter.log_detail(f"reading bib: {bib_path}")
+        for key, fields in iter_bib_entries(
+            bib_path.read_text(encoding="utf-8", errors="replace")
+        ):
+            entries.setdefault(key, fields)
+    return entries
+
+
+def run_check(
+    project_dir,
+    level=None,
+    bib=None,
+    offline=False,
+    min_confidence=0.8,
+    use_cache=True,
+    tex=None,
+    verifier=default_verifier,
+):
+    """Run the citation-trustworthiness check; return a process exit code.
+
+    ``verifier`` is the injection seam (default :func:`default_verifier`, which
+    calls scitex-scholar). Returns 1 iff a real FAIL was reported.
+    """
+    project_dir = Path(project_dir).resolve()
+    reporter = Reporter()
+    level = resolve_level(
+        "citation_trust",
+        level,
+        project_dir,
+        default="warn",
+        env_var="SCITEX_WRITER_CITATION_TRUST",
+    )
+    offline = bool(offline) or env_truthy(OFFLINE_ENV)
+    mode = "offline" if offline else "online"
+    print(f"\n{BOLD}=== Citation Trustworthiness (level={level}, {mode}) ==={NC}\n")
+
+    if level == "off":
+        print(
+            f"  {DIM}[INFO]{NC} citation-trust check is disabled (level=off). "
+            f"Set citation_trust.level or --level to enable."
+        )
+        reporter.summary()
+        return 0
+
+    # A check that cannot RUN is reported AT the resolved level -- never a pass.
+    unrunnable = reporter.at("error" if level == "error" else "warning")
+
+    tex_paths = _resolve_tex_paths(project_dir, tex)
+    cited_keys = extract_cited_keys(_load_text(tex_paths))
+    if not cited_keys:
+        reporter.log_warn(
+            "no \\cite keys found in the scanned tex -- nothing to verify."
+        )
+        reporter.log_detail(f"scanned: {len(tex_paths)} tex file(s)")
+        reporter.summary()
+        return reporter.exit_code()
+
+    bib_paths = resolve_bib_paths(project_dir, tex_paths, bib)
+    if not bib_paths:
+        unrunnable(
+            "no bibliography resolved -- citations could NOT be verified for this "
+            "build (they are NOT known to be trustworthy)."
+        )
+        reporter.log_detail(
+            "fix: pass --bib, or add a \\bibliography{}/\\addbibresource{}."
+        )
+        reporter.summary()
+        return reporter.exit_code()
+
+    entries = _read_entries(reporter, bib_paths)
+    fingerprints = {
+        key: entry_fingerprint(entries[key]) for key in cited_keys if key in entries
+    }
+
+    cached = load_cache(cache_path(project_dir)) if use_cache else {}
+    hits = {}
+    if use_cache:
+        for key in sorted(cited_keys):
+            hit = cache_lookup(cached, key, fingerprints.get(key), STATUS_SEVERITY)
+            if hit is not None:
+                hits[key] = hit
+
+    misses = sorted(set(cited_keys) - set(hits))
+    if not misses:
+        reporter.log_detail(
+            f"all {len(hits)} cited key(s) served from the verdict cache "
+            f"({cache_path(project_dir)})"
+        )
+        _report_findings(reporter, [hits[key] for key in sorted(hits)], level)
+        reporter.summary()
+        return reporter.exit_code()
+
+    reporter.log_detail(
+        f"verifying via scitex-scholar: {len(misses)} uncached cite key(s), "
+        f"{len(hits)} cache hit(s)"
+    )
+    try:
+        fresh = verifier(
+            project_dir,
+            bib=bib_paths[0],
+            offline=offline,
+            min_confidence=min_confidence,
+        )
+    except VerificationUnavailable as exc:
+        unrunnable(f"citations could NOT be verified for this build: {exc}")
+        reporter.log_detail(
+            f"{len(cited_keys)} cited reference(s) are therefore UNVERIFIED (NOT "
+            f"proven trustworthy) -- this is NOT a pass."
+        )
+        reporter.log_detail(
+            "fix: install the scholar extra / restore network access, or set "
+            "citation_trust.level: off to silence this check deliberately."
+        )
+        reporter.summary()
+        return reporter.exit_code()
+
+    fresh = [v for v in fresh if v.get("key") in cited_keys]
+    fresh_keys = {v["key"] for v in fresh}
+    verdicts = list(fresh)
+    # Keep cache hits for any key the verifier returned no verdict for.
+    verdicts += [hits[key] for key in sorted(hits) if key not in fresh_keys]
+
+    missing = sorted(set(cited_keys) - {v["key"] for v in verdicts})
+    if missing:
+        unrunnable(
+            f"{len(missing)} cited key(s) got NO verdict from scitex-scholar -- "
+            f"they are NOT verified:"
+        )
+        for key in missing:
+            reporter.log_detail(f"\\cite{{{key}}}")
+
+    # OFFLINE verdicts are never cached: an offline "unverified" must not poison
+    # a later online run.
+    if use_cache and not offline and fresh:
+        save_cache(
+            cache_path(project_dir),
+            cache_store(cached, fresh, fingerprints, STATUS_SEVERITY),
+        )
+
+    _report_findings(reporter, verdicts, level)
+    reporter.summary()
+    return reporter.exit_code()
+
+
+def main(argv=None, verifier=default_verifier):
+    parser = argparse.ArgumentParser(
+        description="Citation-trustworthiness check: resolve every cited entry "
+        "against the real bibliographic record (via scitex-scholar) and flag the "
+        "ones that cannot be shown to be real, trustworthy sources. Defaults to "
+        "warn (a network-dependent check never blocks a compile by default) and "
+        "fails LOUDLY -- never silently passes -- when it cannot run."
+    )
+    parser.add_argument("project_dir", nargs="?", default=".")
+    parser.add_argument(
+        "--level",
+        choices=list(_LEVELS),
+        default=None,
+        help="Severity: off, warn (default), or error. Overrides env and config.",
+    )
+    parser.add_argument(
+        "--tex",
+        action="append",
+        default=None,
+        help="Tex file(s)/glob(s) to scan for \\cite keys (repeatable).",
+    )
+    parser.add_argument(
+        "--bib",
+        default=None,
+        help="Bibliography .bib to verify against (default: the \\bibliography{} "
+        "target resolved from the tex).",
+    )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Never touch the network (deterministic; unresolvable entries are "
+        "reported UNVERIFIED / HALLUCINATED, never as trustworthy).",
+    )
+    parser.add_argument(
+        "--min-confidence",
+        type=float,
+        default=0.8,
+        help="Minimum title-match confidence for a VERIFIED verdict (default 0.8).",
+    )
+    parser.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Ignore (and do not write) the verdict cache; re-verify everything.",
+    )
+    args = parser.parse_args(argv)
+
+    return run_check(
+        args.project_dir,
+        level=args.level,
+        bib=args.bib,
+        offline=args.offline,
+        min_confidence=args.min_confidence,
+        use_cache=not args.no_cache,
+        tex=args.tex,
+        verifier=verifier,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+# EOF

--- a/scripts/shell/modules/run_provenance_checks.sh
+++ b/scripts/shell/modules/run_provenance_checks.sh
@@ -47,6 +47,17 @@
 # converted. Reading the compiled output means it never re-flags what the auto-pad
 # already normalized; it fires exactly on the un-normalized paths. Defaults to
 # warn (a safety net; the auto-pad is the systemic prevention).
+# citation_trust is the CITATION-TRUSTWORTHINESS check: it resolves every cited
+# entry against the real bibliographic record via scitex-scholar
+# (verify_cites -> CrossRef/OpenAlex/arXiv/SemanticScholar) and flags citations
+# that are not provably real (hallucinated -> error, unverified/stub/unlinked ->
+# warning). Defaults to WARN -- a network-dependent check must never block a
+# compile by default -- and FAILS LOUDLY (never silently passes) when it cannot
+# run: no scitex-scholar extra, no network, or an unresolvable bib is reported as
+# "citations could NOT be verified", never as a pass. Verdicts are cached in
+# .scitex/writer/runtime/citation_trust.json (scholar has no cache of its own),
+# keyed by cite key + bib-entry content hash, so repeated compiles are network-free
+# until an entry actually changes.
 #
 # Returns the worst exit code across the checks (0 unless a check errored).
 
@@ -57,7 +68,7 @@ PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$THIS_DIR/../../.." && pwd)}"
 PY="${SCITEX_WRITER_PYTHON:-python3}"
 
 rc=0
-for chk in check_paper_symlink check_media_provenance check_figure_media check_ref_integrity check_caption_footnote check_table_decimals check_clew_verify check_citations check_version_freshness; do
+for chk in check_paper_symlink check_media_provenance check_figure_media check_ref_integrity check_caption_footnote check_table_decimals check_clew_verify check_citations check_citation_trust check_version_freshness; do
     script="$THIS_DIR/../../python/${chk}.py"
     [ -f "$script" ] || continue
     "$PY" "$script" "$PROJECT_ROOT" || rc=$?

--- a/src/scitex_writer/_cli/commands/checks.py
+++ b/src/scitex_writer/_cli/commands/checks.py
@@ -191,4 +191,70 @@ def check_references_cmd(project, doc_type, parse_log, as_json):
     return result.get("exit_code", 0)
 
 
+@main_group.command("check-citation-trust")
+@click.option("-p", "--project", default=".", help="Project path.")
+@click.option(
+    "--level",
+    type=click.Choice(["off", "warn", "error"]),
+    default=None,
+    help="Severity: off, warn (default), or error. Overrides env/config.",
+)
+@click.option(
+    "--offline",
+    is_flag=True,
+    default=False,
+    help="Never touch the network (deterministic; unresolved != trustworthy).",
+)
+@click.option(
+    "--min-confidence",
+    type=float,
+    default=None,
+    help="Minimum title-match confidence for a VERIFIED verdict (default 0.8).",
+)
+@click.option(
+    "--no-cache",
+    is_flag=True,
+    default=False,
+    help="Ignore (and do not write) the cached verdicts; re-verify everything.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit JSON.")
+def check_citation_trust_cmd(
+    project, level, offline, min_confidence, no_cache, as_json
+):
+    """Verify every \\cite resolves to a REAL, trustworthy source (scitex-scholar).
+
+    Beyond "the key exists in the .bib": each cited entry is resolved against
+    CrossRef/OpenAlex/arXiv/SemanticScholar via scitex-scholar and classified.
+    verified -> pass; unverified/stub/unlinked -> warning; hallucinated -> error.
+    FAILS LOUDLY (never silently passes) when it cannot run -- scholar missing,
+    no network, bib unresolvable. Verdicts are cached under
+    .scitex/writer/runtime/. Note: retracted/predatory venues are NOT checked.
+
+    \b
+    Example:
+        $ scitex-writer check-citation-trust
+        $ scitex-writer check-citation-trust --offline
+        $ scitex-writer check-citation-trust --level error --no-cache
+    """
+    from ... import checks
+
+    result = checks.citation_trust(
+        project,
+        level=level,
+        offline=offline,
+        min_confidence=min_confidence,
+        no_cache=no_cache,
+    )
+    if as_json:
+        _emit_json(result)
+        return 0 if result.get("success") else 1
+    out = (result.get("stdout") or "").rstrip()
+    if out:
+        click.echo(out)
+    err = (result.get("stderr") or "").rstrip()
+    if err:
+        click.echo(err, err=True)
+    return result.get("exit_code", 0)
+
+
 # EOF

--- a/src/scitex_writer/_mcp/handlers/__init__.py
+++ b/src/scitex_writer/_mcp/handlers/__init__.py
@@ -7,6 +7,7 @@
 from ._archive_pipeline import process as process_archive
 from ._checks import (
     check_caption_footnote,
+    check_citation_trust,
     check_float_order,
     check_limits,
     check_media_provenance,
@@ -36,6 +37,7 @@ from ._update import update_project  # noqa: F401 -- now a package
 __all__ = [
     "add_claim",
     "check_caption_footnote",
+    "check_citation_trust",
     "check_float_order",
     "check_limits",
     "check_media_provenance",

--- a/src/scitex_writer/_mcp/handlers/_checks.py
+++ b/src/scitex_writer/_mcp/handlers/_checks.py
@@ -392,6 +392,63 @@ def check_table_decimals(
     return _run_script(script, project_path, args, timeout)
 
 
+def check_citation_trust(
+    project_dir: str,
+    level: str | None = None,
+    offline: bool = False,
+    min_confidence: float | None = None,
+    no_cache: bool = False,
+    timeout: int = 300,
+) -> dict:
+    """Citation-TRUSTWORTHINESS check: does each \\cite resolve to a real source?
+
+    Beyond "the key exists in the .bib" (``check_ref_integrity``) and "the entry
+    is not a scholar stub" (``check_citations``): this RESOLVES every cited entry
+    against the real bibliographic record via scitex-scholar
+    (``scitex_scholar.verify_cites``, the ``scholar`` extra) -- CrossRef /
+    OpenAlex / arXiv / Semantic Scholar -- and flags every citation that cannot
+    be shown to be a real, trustworthy source. Status -> severity: ``verified``
+    -> info (pass), ``unverified``/``stub``/``unlinked`` -> warning,
+    ``hallucinated`` -> error.
+
+    FAIL-LOUD: when verification cannot RUN (scitex-scholar not installed, bib
+    unresolvable, network down, resolver crash) the check reports that condition
+    at the resolved level -- WARN by default, FAIL at ``error`` -- and NEVER
+    reports the citations as trustworthy. Verdicts are cached (scholar has no
+    cache) in ``.scitex/writer/runtime/citation_trust.json``, keyed by cite key +
+    bib-entry content hash.
+
+    KNOWN GAP: scholar does not check retraction status or predatory venues.
+
+    Severity precedence (highest -> lowest): ``level`` arg, env
+    ``SCITEX_WRITER_CITATION_TRUST``, project ``./config.yaml``
+    (``citation_trust.level``), user ``~/.scitex/writer/config.yaml``, default
+    ``warn`` (a network-dependent check must not block a compile by default).
+
+    Args:
+        project_dir: Project root.
+        level: One of ``off``, ``warn``, ``error``. When ``None``, env/config
+            precedence resolves the level.
+        offline: Never touch the network (deterministic; unresolvable entries
+            are reported UNVERIFIED/HALLUCINATED, never as trustworthy).
+        min_confidence: Minimum title-match confidence for a VERIFIED verdict.
+        no_cache: Ignore (and do not write) the verdict cache.
+        timeout: Subprocess timeout in seconds (network resolution is slow).
+    """
+    project_path = resolve_project_path(project_dir)
+    script = _script_path(project_path, "check_citation_trust.py")
+    args: list[str] = []
+    if level is not None:
+        args += ["--level", level]
+    if offline:
+        args.append("--offline")
+    if min_confidence is not None:
+        args += ["--min-confidence", str(min_confidence)]
+    if no_cache:
+        args.append("--no-cache")
+    return _run_script(script, project_path, args, timeout)
+
+
 __all__ = [
     "check_references",
     "check_float_order",
@@ -402,6 +459,7 @@ __all__ = [
     "check_caption_footnote",
     "check_ref_integrity",
     "check_table_decimals",
+    "check_citation_trust",
 ]
 
 # EOF

--- a/src/scitex_writer/checks.py
+++ b/src/scitex_writer/checks.py
@@ -30,6 +30,7 @@ from typing import Literal as _Literal
 from typing import Optional as _Optional
 
 from ._mcp.handlers import check_caption_footnote as _check_caption_footnote
+from ._mcp.handlers import check_citation_trust as _check_citation_trust
 from ._mcp.handlers import check_float_order as _check_float_order
 from ._mcp.handlers import check_limits as _check_limits
 from ._mcp.handlers import check_media_provenance as _check_media_provenance
@@ -372,6 +373,68 @@ def table_decimals(
     return handler(project_dir, doc_type, level)
 
 
+def citation_trust(
+    project_dir: str,
+    level: _Optional[_Literal["off", "warn", "error"]] = None,
+    offline: bool = False,
+    min_confidence: _Optional[float] = None,
+    no_cache: bool = False,
+    handler: _Optional[_Callable[..., dict]] = None,
+) -> dict:
+    """Verify every ``\\cite`` resolves to a REAL, trustworthy source.
+
+    Goes beyond :func:`ref_integrity` ("the key exists in the .bib") and the
+    citation gate ("the entry is not a scholar stub"): each cited entry is
+    RESOLVED against the real bibliographic record via **scitex-scholar**
+    (``scitex_scholar.verify_cites``, the ``scholar`` extra) — CrossRef /
+    OpenAlex / arXiv / Semantic Scholar — and every citation that cannot be
+    shown to be a real source with a matching title is flagged.
+
+    Status → severity (as agreed for the findings feed):
+
+    * ``verified`` → info (suppressed; counted as a pass),
+    * ``unverified`` / ``stub`` / ``unlinked`` → warning,
+    * ``hallucinated`` → error.
+
+    **Fail-loud, never a silent pass.** When verification cannot RUN —
+    scitex-scholar is not installed, the bibliography cannot be resolved, the
+    network is unavailable, or the resolver raises — the check reports *that*
+    condition at the resolved level (a warning by default, an error with
+    ``exit_code`` 1 at ``level="error"``) and never reports the citations as
+    trustworthy.
+
+    Verdicts are **cached** in ``.scitex/writer/runtime/citation_trust.json``
+    (scholar has no persistent cache in this path), keyed by cite key + a
+    content hash of the bib entry, so an edited entry re-verifies. A cache miss
+    forces real verification; offline verdicts are never cached.
+
+    **Known gap:** scholar does not check retraction status or predatory
+    venues — a resolvable, title-matching citation to a retracted paper still
+    classifies as ``verified``.
+
+    Severity:
+
+    * ``warn`` — report, exit 0. **The default** (a network-dependent check must
+      never block a compile by default).
+    * ``error`` — hallucinated citations (and an un-runnable check) exit 1.
+    * ``off`` — check disabled.
+
+    Severity precedence (highest → lowest): the ``level`` argument, env
+    ``SCITEX_WRITER_CITATION_TRUST``, project ``./config.yaml``
+    (``citation_trust.level``), user ``~/.scitex/writer/config.yaml``, then the
+    ``warn`` default.
+
+    Returns a dict with ``success``, ``exit_code``, ``stdout``, ``stderr``,
+    and ``summary={passed, warnings, errors}``.
+
+    ``handler`` is the underlying check implementation; it defaults to
+    :func:`scitex_writer._mcp.handlers.check_citation_trust`. Exposed so callers
+    can supply an alternate implementation without patching internals.
+    """
+    handler = handler or _check_citation_trust
+    return handler(project_dir, level, offline, min_confidence, no_cache)
+
+
 __all__ = [
     "references",
     "float_order",
@@ -382,6 +445,7 @@ __all__ = [
     "caption_footnote",
     "ref_integrity",
     "table_decimals",
+    "citation_trust",
 ]
 
 # EOF

--- a/tests/scitex_writer/_cli/commands/test_checks.py
+++ b/tests/scitex_writer/_cli/commands/test_checks.py
@@ -19,6 +19,7 @@ def test_module_exposes_all_check_commands():
         "check_overflow_cmd",
         "check_paper_symlink_cmd",
         "check_references_cmd",
+        "check_citation_trust_cmd",
     }
     # Act
     present = {name for name in expected if hasattr(module, name)}

--- a/tests/scitex_writer/test_checks.py
+++ b/tests/scitex_writer/test_checks.py
@@ -38,7 +38,33 @@ def test_module_exports_references_float_order_limits_and_overflow():
         "caption_footnote",
         "ref_integrity",
         "table_decimals",
+        "citation_trust",
     ]
+
+
+def test_citation_trust_forwards_all_arguments_to_handler():
+    # Arrange
+    handler = _RecordingHandler({"success": True})
+    # Act
+    checks.citation_trust(
+        "/path",
+        level="error",
+        offline=True,
+        min_confidence=0.9,
+        no_cache=True,
+        handler=handler,
+    )
+    # Assert
+    assert handler.calls == [("/path", "error", True, 0.9, True)]
+
+
+def test_citation_trust_defaults_are_none_level_online_cached():
+    # Arrange
+    handler = _RecordingHandler({"success": True})
+    # Act
+    checks.citation_trust("/path", handler=handler)
+    # Assert
+    assert handler.calls == [("/path", None, False, None, False)]
 
 
 def test_ref_integrity_forwards_all_arguments_to_handler():

--- a/tests/scripts/python/test__citation_trust_cache.py
+++ b/tests/scripts/python/test__citation_trust_cache.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: scripts/python/_citation_trust_cache.py
+#
+# The verdict cache for the citation-trustworthiness check. Real files under
+# tmp_path only -- no mocks, no monkeypatch.
+
+import json
+import sys
+import time
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from _citation_trust_cache import (  # noqa: E402
+    CACHE_SCHEMA,
+    CACHE_TTL_DAYS,
+    cache_lookup,
+    cache_path,
+    cache_store,
+    entry_fingerprint,
+    load_cache,
+    save_cache,
+)
+
+KNOWN = {"verified", "unverified", "stub", "unlinked", "hallucinated"}
+
+
+def _verdict(key="Smith2020", status="verified"):
+    return {"key": key, "status": status, "detail": "crossref", "confidence": 0.99}
+
+
+def test_cache_path_lives_under_project_runtime_dir():
+    # Arrange
+    project = Path("/tmp/proj")
+    # Act
+    path = cache_path(project)
+    # Assert
+    assert path == project / ".scitex/writer/runtime/citation_trust.json"
+
+
+def test_entry_fingerprint_changes_when_a_field_is_edited():
+    # Arrange
+    before = entry_fingerprint({"title": "A study", "doi": "10.1/x"})
+    # Act
+    after = entry_fingerprint({"title": "A different study", "doi": "10.1/x"})
+    # Assert
+    assert before != after
+
+
+def test_entry_fingerprint_is_stable_across_field_order():
+    # Arrange
+    first = entry_fingerprint({"title": "A study", "doi": "10.1/x"})
+    # Act
+    second = entry_fingerprint({"doi": "10.1/x", "title": "A study"})
+    # Assert
+    assert first == second
+
+
+def test_saved_verdict_is_returned_on_cache_hit(tmp_path):
+    # Arrange
+    path = cache_path(tmp_path)
+    save_cache(path, cache_store({}, [_verdict()], {"Smith2020": "fp"}, KNOWN))
+    # Act
+    hit = cache_lookup(load_cache(path), "Smith2020", "fp", KNOWN)
+    # Assert
+    assert hit["status"] == "verified"
+
+
+def test_cache_hit_is_flagged_as_cached(tmp_path):
+    # Arrange
+    cached = cache_store({}, [_verdict()], {"Smith2020": "fp"}, KNOWN)
+    # Act
+    hit = cache_lookup(cached, "Smith2020", "fp", KNOWN)
+    # Assert
+    assert hit["cached"] is True
+
+
+def test_changed_fingerprint_is_a_cache_miss():
+    # Arrange
+    cached = cache_store({}, [_verdict()], {"Smith2020": "old-fp"}, KNOWN)
+    # Act
+    hit = cache_lookup(cached, "Smith2020", "new-fp", KNOWN)
+    # Assert
+    assert hit is None
+
+
+def test_unknown_cite_key_is_a_cache_miss():
+    # Arrange
+    cached = cache_store({}, [_verdict()], {"Smith2020": "fp"}, KNOWN)
+    # Act
+    hit = cache_lookup(cached, "NeverSeen2021", "fp", KNOWN)
+    # Assert
+    assert hit is None
+
+
+def test_expired_verdict_is_a_cache_miss():
+    # Arrange
+    stale = time.time() - (CACHE_TTL_DAYS + 1) * 86400
+    cached = cache_store({}, [_verdict()], {"Smith2020": "fp"}, KNOWN, now=stale)
+    # Act
+    hit = cache_lookup(cached, "Smith2020", "fp", KNOWN)
+    # Assert
+    assert hit is None
+
+
+def test_unknown_status_is_never_stored_in_cache():
+    # Arrange
+    verdicts = [_verdict(status="totally-new-status")]
+    # Act
+    cached = cache_store({}, verdicts, {"Smith2020": "fp"}, KNOWN)
+    # Assert
+    assert cached == {}
+
+
+def test_unknown_status_in_cache_file_is_a_miss():
+    # Arrange
+    cached = {
+        "Smith2020": {
+            "fingerprint": "fp",
+            "status": "totally-new-status",
+            "verified_at": time.time(),
+        }
+    }
+    # Act
+    hit = cache_lookup(cached, "Smith2020", "fp", KNOWN)
+    # Assert
+    assert hit is None
+
+
+def test_corrupt_cache_file_reads_as_empty(tmp_path):
+    # Arrange
+    path = tmp_path / "citation_trust.json"
+    path.write_text("{not json", encoding="utf-8")
+    # Act
+    cached = load_cache(path)
+    # Assert
+    assert cached == {}
+
+
+def test_foreign_schema_cache_file_reads_as_empty(tmp_path):
+    # Arrange
+    path = tmp_path / "citation_trust.json"
+    path.write_text(json.dumps({"schema": "other/v9", "verdicts": {"a": {}}}), "utf-8")
+    # Act
+    cached = load_cache(path)
+    # Assert
+    assert cached == {}
+
+
+def test_missing_cache_file_reads_as_empty(tmp_path):
+    # Arrange
+    path = cache_path(tmp_path)
+    # Act
+    cached = load_cache(path)
+    # Assert
+    assert cached == {}
+
+
+def test_saved_cache_file_carries_the_schema_marker(tmp_path):
+    # Arrange
+    path = cache_path(tmp_path)
+    # Act
+    save_cache(path, cache_store({}, [_verdict()], {"Smith2020": "fp"}, KNOWN))
+    # Assert
+    assert json.loads(path.read_text(encoding="utf-8"))["schema"] == CACHE_SCHEMA
+
+
+# EOF

--- a/tests/scripts/python/test_check_citation_trust.py
+++ b/tests/scripts/python/test_check_citation_trust.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: scripts/python/check_citation_trust.py
+#
+# NO mocks / NO monkeypatch (PA-306). The check exposes a real dependency-
+# injection seam -- ``run_check(..., verifier=...)`` -- whose default is
+# ``default_verifier`` (scitex-scholar). Tests pass real callables through that
+# seam plus real tmp_path projects with real .tex/.bib files, so every path
+# (verified / hallucinated / scholar-absent / cache) is exercised without a
+# network and without patching internals.
+#
+# The end-to-end CLI runs use --offline, which is deterministic: scholar's
+# offline resolver never resolves, so nothing can be reported trustworthy.
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+from _citation_trust_cache import cache_path  # noqa: E402
+from check_citation_trust import (  # noqa: E402
+    STATUS_SEVERITY,
+    VerificationUnavailable,
+    effective_severity,
+    run_check,
+)
+
+_SCRIPT = ROOT_DIR / "scripts" / "python" / "check_citation_trust.py"
+
+_TEX = r"""
+\documentclass{article}
+\begin{document}
+Real \cite{Real2020}, bogus \cite{Bogus2099}, and bare \cite{NoIdent2021}.
+\bibliography{bibliography}
+\end{document}
+"""
+
+_BIB = """
+@article{Real2020,
+  title = {Attention is all you need},
+  author = {Vaswani, Ashish},
+  journal = {NeurIPS},
+  year = {2017},
+  doi = {10.48550/arXiv.1706.03762}
+}
+@article{Bogus2099,
+  title = {Quantum telepathic gradient descent in fungal networks},
+  author = {Nobody, A.},
+  journal = {Journal of Things That Do Not Exist},
+  year = {2099}
+}
+@book{NoIdent2021,
+  title = {A book with no identifier at all},
+  author = {Anon, B.},
+  year = {2021}
+}
+"""
+
+
+class _StubVerifier:
+    """Real callable injected through the verifier seam (not a mock).
+
+    Records how many times it was called and returns canned verdicts, so the
+    caching behaviour is observable without a network.
+    """
+
+    def __init__(self, verdicts=None, raises=None):
+        self.calls = 0
+        self.verdicts = verdicts or []
+        self.raises = raises
+
+    def __call__(self, project_dir, bib=None, offline=False, min_confidence=0.8):
+        self.calls += 1
+        if self.raises is not None:
+            raise self.raises
+        return [dict(v) for v in self.verdicts]
+
+
+def _project(tmp_path, bib_text=_BIB):
+    contents = tmp_path / "01_manuscript" / "contents"
+    contents.mkdir(parents=True)
+    (contents / "main.tex").write_text(_TEX, encoding="utf-8")
+    (contents / "bibliography.bib").write_text(bib_text, encoding="utf-8")
+    return tmp_path
+
+
+def _verdicts(real="verified", bogus="hallucinated", noident="unverified"):
+    return [
+        {"key": "Real2020", "status": real, "detail": "crossref", "confidence": 0.98},
+        {"key": "Bogus2099", "status": bogus, "detail": "no index hit"},
+        {"key": "NoIdent2021", "status": noident, "detail": "no identifier"},
+    ]
+
+
+# ----------------------------------------------------------- severity mapping
+
+
+def test_status_severity_mapping_matches_agreed_contract():
+    # Arrange
+    # Act
+    mapping = STATUS_SEVERITY
+    # Assert
+    assert mapping == {
+        "verified": "info",
+        "unverified": "warning",
+        "stub": "warning",
+        "unlinked": "warning",
+        "hallucinated": "error",
+    }
+
+
+def test_hallucinated_is_error_at_error_level():
+    # Arrange
+    # Act
+    severity = effective_severity("hallucinated", "error")
+    # Assert
+    assert severity == "error"
+
+
+def test_hallucinated_clamps_to_warning_at_warn_level():
+    # Arrange
+    # Act
+    severity = effective_severity("hallucinated", "warn")
+    # Assert
+    assert severity == "warning"
+
+
+def test_unverified_stays_warning_at_error_level():
+    # Arrange
+    # Act
+    severity = effective_severity("unverified", "error")
+    # Assert
+    assert severity == "warning"
+
+
+def test_unknown_status_is_treated_as_error_never_pass():
+    # Arrange
+    # Act
+    severity = effective_severity("some-future-status", "error")
+    # Assert
+    assert severity == "error"
+
+
+# ------------------------------------------------------------- classification
+
+
+def test_hallucinated_citation_fails_the_check_at_error_level(tmp_path):
+    # Arrange
+    project = _project(tmp_path)
+    # Act
+    code = run_check(
+        project, level="error", offline=True, verifier=_StubVerifier(_verdicts())
+    )
+    # Assert
+    assert code == 1
+
+
+def test_hallucinated_citation_does_not_block_at_warn_level(tmp_path):
+    # Arrange
+    project = _project(tmp_path)
+    # Act
+    code = run_check(
+        project, level="warn", offline=True, verifier=_StubVerifier(_verdicts())
+    )
+    # Assert
+    assert code == 0
+
+
+def test_all_verified_citations_pass_at_error_level(tmp_path):
+    # Arrange
+    project = _project(tmp_path)
+    verifier = _StubVerifier(_verdicts(bogus="verified", noident="verified"))
+    # Act
+    code = run_check(project, level="error", verifier=verifier)
+    # Assert
+    assert code == 0
+
+
+def test_hallucinated_key_is_named_in_the_report(tmp_path, capsys):
+    # Arrange
+    project = _project(tmp_path)
+    run_check(project, level="error", offline=True, verifier=_StubVerifier(_verdicts()))
+    # Act
+    out = capsys.readouterr().out
+    # Assert
+    assert "Bogus2099" in out
+
+
+def test_verified_citation_is_reported_as_a_pass(tmp_path, capsys):
+    # Arrange
+    project = _project(tmp_path)
+    run_check(project, level="warn", offline=True, verifier=_StubVerifier(_verdicts()))
+    # Act
+    out = capsys.readouterr().out
+    # Assert
+    assert "[PASS]" in out
+
+
+def test_level_off_disables_the_check(tmp_path, capsys):
+    # Arrange
+    project = _project(tmp_path)
+    verifier = _StubVerifier(_verdicts())
+    run_check(project, level="off", verifier=verifier)
+    # Act
+    calls = verifier.calls
+    # Assert
+    assert calls == 0
+
+
+# ------------------------------------------------------------------ fail-loud
+
+
+def test_absent_scholar_never_reports_citations_as_verified(tmp_path, capsys):
+    # Arrange
+    project = _project(tmp_path)
+    unavailable = VerificationUnavailable("scitex_scholar.verify_cites is unavailable")
+    run_check(project, level="warn", verifier=_StubVerifier(raises=unavailable))
+    # Act
+    out = capsys.readouterr().out
+    # Assert
+    assert "[PASS]" not in out
+
+
+def test_absent_scholar_warns_loudly_at_warn_level(tmp_path, capsys):
+    # Arrange
+    project = _project(tmp_path)
+    unavailable = VerificationUnavailable("scitex_scholar.verify_cites is unavailable")
+    run_check(project, level="warn", verifier=_StubVerifier(raises=unavailable))
+    # Act
+    out = capsys.readouterr().out
+    # Assert
+    assert "could NOT be verified" in out
+
+
+def test_absent_scholar_does_not_block_at_warn_level(tmp_path):
+    # Arrange
+    project = _project(tmp_path)
+    unavailable = VerificationUnavailable("scitex_scholar.verify_cites is unavailable")
+    # Act
+    code = run_check(project, level="warn", verifier=_StubVerifier(raises=unavailable))
+    # Assert
+    assert code == 0
+
+
+def test_absent_scholar_fails_the_build_at_error_level(tmp_path):
+    # Arrange
+    project = _project(tmp_path)
+    unavailable = VerificationUnavailable("scitex_scholar.verify_cites is unavailable")
+    # Act
+    code = run_check(project, level="error", verifier=_StubVerifier(raises=unavailable))
+    # Assert
+    assert code == 1
+
+
+def test_verifier_crash_is_reported_as_unrunnable_not_pass(tmp_path):
+    # Arrange
+    project = _project(tmp_path)
+    boom = VerificationUnavailable("verify_cites() failed: ConnectionError: no network")
+    # Act
+    code = run_check(project, level="error", verifier=_StubVerifier(raises=boom))
+    # Assert
+    assert code == 1
+
+
+def test_cite_key_without_a_verdict_is_reported_as_unverified(tmp_path, capsys):
+    # Arrange
+    project = _project(tmp_path)
+    partial = _StubVerifier([_verdicts()[0]])  # only Real2020 comes back
+    run_check(project, level="warn", offline=True, verifier=partial)
+    # Act
+    out = capsys.readouterr().out
+    # Assert
+    assert "NO verdict from scitex-scholar" in out
+
+
+# --------------------------------------------------------------------- cache
+
+
+def test_online_verdicts_are_written_to_the_cache(tmp_path):
+    # Arrange
+    project = _project(tmp_path)
+    run_check(project, level="warn", verifier=_StubVerifier(_verdicts()))
+    # Act
+    exists = cache_path(project).is_file()
+    # Assert
+    assert exists is True
+
+
+def test_offline_verdicts_are_never_cached(tmp_path):
+    # Arrange
+    project = _project(tmp_path)
+    run_check(project, level="warn", offline=True, verifier=_StubVerifier(_verdicts()))
+    # Act
+    exists = cache_path(project).exists()
+    # Assert
+    assert exists is False
+
+
+def test_second_run_serves_verdicts_from_the_cache(tmp_path):
+    # Arrange
+    project = _project(tmp_path)
+    verifier = _StubVerifier(_verdicts())
+    run_check(project, level="warn", verifier=verifier)
+    # Act
+    run_check(project, level="warn", verifier=verifier)
+    # Assert
+    assert verifier.calls == 1
+
+
+def test_editing_a_bib_entry_reverifies_that_citation(tmp_path):
+    # Arrange
+    project = _project(tmp_path)
+    verifier = _StubVerifier(_verdicts())
+    run_check(project, level="warn", verifier=verifier)
+    edited = _BIB.replace("Attention is all you need", "Attention is not all you need")
+    (project / "01_manuscript" / "contents" / "bibliography.bib").write_text(
+        edited, encoding="utf-8"
+    )
+    # Act
+    run_check(project, level="warn", verifier=verifier)
+    # Assert
+    assert verifier.calls == 2
+
+
+def test_no_cache_flag_forces_reverification(tmp_path):
+    # Arrange
+    project = _project(tmp_path)
+    verifier = _StubVerifier(_verdicts())
+    run_check(project, level="warn", verifier=verifier)
+    # Act
+    run_check(project, level="warn", use_cache=False, verifier=verifier)
+    # Assert
+    assert verifier.calls == 2
+
+
+def test_cached_hallucination_still_fails_at_error_level(tmp_path):
+    # Arrange
+    project = _project(tmp_path)
+    verifier = _StubVerifier(_verdicts())
+    run_check(project, level="warn", verifier=verifier)
+    # Act
+    code = run_check(project, level="error", verifier=verifier)
+    # Assert
+    assert code == 1
+
+
+# ----------------------------------------------------------------- end-to-end
+
+
+def _run_cli(project, *extra):
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "HOME": str(Path(project) / "_home"),
+    }
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), str(project), *extra],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_cli_offline_run_exits_zero_at_default_warn_level(tmp_path):
+    # Arrange
+    project = _project(tmp_path)
+    # Act
+    proc = _run_cli(project, "--offline")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_cli_offline_run_exits_one_at_error_level(tmp_path):
+    # Arrange
+    project = _project(tmp_path)
+    # Act
+    proc = _run_cli(project, "--offline", "--level", "error")
+    # Assert
+    assert proc.returncode == 1
+
+
+def test_cli_offline_run_never_reports_a_pass(tmp_path):
+    # Arrange
+    project = _project(tmp_path)
+    # Act
+    proc = _run_cli(project, "--offline", "--level", "warn")
+    # Assert
+    assert "[PASS]" not in proc.stdout
+
+
+def test_cli_level_off_exits_zero_and_says_disabled(tmp_path):
+    # Arrange
+    project = _project(tmp_path)
+    # Act
+    proc = _run_cli(project, "--level", "off")
+    # Assert
+    assert "disabled (level=off)" in proc.stdout
+
+
+# EOF


### PR DESCRIPTION
Closes the last open item on card `writer-precheck-framework`: beyond "does the `\cite` key exist in the `.bib`" (`check_ref_integrity`) and "is the entry a scholar stub" (`check_citations`), this verifies each citation resolves to a **real, trustworthy source** and flags the unverifiable ones.

## API consumed (scitex-scholar)

```python
from scitex_scholar.verify_cites import verify_cites   # VerifyReport
verify_cites(project_dir, bib=..., min_confidence=0.8, offline=..., write=False)
# -> report.statuses: [CiteStatus(key, status, provenance, match_confidence, ...)]
```
Import/module path only (their `scholar verify-cites` subcommand does not exist yet). `write=False` so scholar's own sidecar is not written into the manuscript tree. "Trustworthy" = resolves to a real source AND the claimed title fuzzy-matches the source (>= `min_confidence`).

## Severity mapping (the one agreed on `writer-dynamic-paper-findings-feed`)

| scholar status | writer severity |
|---|---|
| `verified` | info — suppressed, counted as PASS |
| `unverified` / `stub` / `unlinked` | warning |
| `hallucinated` (incl. DOI/title mismatch scholar calls hallucinated) | error |
| anything unrecognised | error (never a pass) |

A finding's severity is then **clamped by the resolved level**: at `warn` an error-mapped finding is still printed loudly but exits 0; at `error` it exits 1. Standard precedence via `_severity.resolve_level(check="citation_trust", ...)`: `--level` > `SCITEX_WRITER_CITATION_TRUST` > project `config.yaml` `citation_trust.level` > user config > **default `warn`** (a network-dependent check must not block a compile by default).

## Caching — and why

scitex-scholar has **no persistent cache** in the `verify_cites` path (they build fresh resolver engines per call and explicitly told us to cache verdicts ourselves), and a manuscript carries 100+ cites recompiled many times a day. So `_citation_trust_cache.py` stores verdicts in the project runtime dir `.scitex/writer/runtime/citation_trust.json` (same convention as the annotations DB / GUI runtime), keyed by **cite key + a sha256 content fingerprint of the bib entry** — edit any field of an entry and it re-verifies. Invariants: a cache **miss is never reported as verified** (it forces a real run); unknown statuses are never stored; verdicts expire after 30 days; a corrupt/foreign cache file reads as empty; **offline verdicts are never cached** (an offline "unverified" must not poison a later online run). If any cited key is uncached the whole manuscript is re-verified (scholar's API is per-manuscript, not per-key) and the fresh verdicts are written back.

## Fail-loud semantics (the hard requirement)

There is **no path that reports a citation as trustworthy without an actual verdict for it.** When verification is *un-runnable* — scitex-scholar not installed / too old, bib unresolvable, network down, resolver raises — `default_verifier` raises `VerificationUnavailable` and the check reports **that condition at the resolved level**: a loud `[WARN]` by default (exit 0, does not block), a `[FAIL]` at `level=error` (exit 1). It emits **zero PASS lines** in that case. Same for cite keys scholar returns no verdict for. `offline=True` is a legitimate mode, not a pass: scholar's offline resolver returns "unresolved", so entries land in `unverified` / `hallucinated`.

## Surfaces

- `scitex-writer check-citation-trust [-p PROJECT] [--level] [--offline] [--min-confidence] [--no-cache] [--json]`
- `scitex_writer.checks.citation_trust(...)` (with the `handler=` injection seam the sibling checks use)
- `handlers.check_citation_trust`
- pre-compile provenance stage (`run_provenance_checks.sh`), like every sibling check — default `warn` means it reports without blocking.

## End-to-end evidence (real CLI, real fixture, no mocks)

Fixture: `\cite{Vaswani2017}` (real DOI), `\cite{Bogus2099}` (fabricated), `\cite{NoIdent2021}` (no identifier).

**Offline + real scholar `verify_cites` (deterministic, network-free — what CI relies on), `--level error`:**
```
=== Citation Trustworthiness (level=error, offline) ===
    verifying via scitex-scholar: 3 uncached cite key(s), 0 cache hit(s)
  [FAIL] 2 citation(s) classified HALLUCINATED -- was not found in ANY source index:
    \cite{Bogus2099} no identifier and no resolver match by title/author/year
    \cite{NoIdent2021} no identifier and no resolver match by title/author/year
  [WARN] 1 citation(s) classified UNVERIFIED -- has an identifier but did NOT resolve:
    \cite{Vaswani2017} identifier present but did not resolve (retry / alt resolver)
Summary: 0 passed, 1 warnings, 1 errors      EXIT=1
```
**scholar absent (`verify_cites` is not in the released scitex-scholar 1.4.2 yet — the real degrade case), `--level warn`:**
```
  [WARN] citations could NOT be verified for this build: scitex_scholar.verify_cites is
         unavailable (ModuleNotFoundError...) -- install: pip install 'scitex-writer[scholar]'
    3 cited reference(s) are therefore UNVERIFIED (NOT proven trustworthy) -- this is NOT a pass.
Summary: 0 passed, 1 warnings, 0 errors      EXIT=0        # loud, non-blocking; zero PASS
```
Same condition at `--level error` -> `EXIT=1`.

**Online run** (real network): all three resolved but with `sim=0.0` weak title matches -> all `UNVERIFIED`, exit 0 at warn. Note it never fabricated a `verified`. **Cached rerun**: `all 3 cited key(s) served from the verdict cache` — zero network calls, identical verdicts.

## Tests

41 new (27 check + 14 cache) + 2 updated surfaces, all passing. **No mocks, no monkeypatch** (PA-306): the failure paths are driven through the real `verifier=` DI seam (`_compile/_validator.py::_validate_provenance(runners=...)` pattern), real `tmp_path` `.tex`/`.bib` fixtures, and scholar's real `offline=True`. Module-level PASS/WARN/FAIL globals were avoided entirely (a per-run `Reporter`), so exit codes depend only on the run under test. `scitex-dev ecosystem audit-all scitex-writer` exits 0.

## Known gap (not papered over)

scitex-scholar does **not** check retraction status or predatory venues. A resolvable, title-matching citation to a **retracted** paper still classifies as `verified` here. Upstream knows; it is out of scope for this check.
