### PR TITLE
fix(deps): scitex-ui floor 0.5.1 (GUI 500'd on context_processors)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,15 @@ dependencies = [
     # scitex-ui ships `standalone_shell.html` + shell CSS that the editor
     # and viewer templates extend. Loading either page without scitex-ui
     # installed raises TemplateDoesNotExist.
-    "scitex-ui>=0.1.0",
+    #
+    # FLOOR IS 0.5.1, not 0.1.0: settings.py registers the context processor
+    # `scitex_ui.context_processors.element_inspector`, and that module does
+    # not exist before 0.5.x. With the old >=0.1.0 floor, pip happily
+    # installed 0.4.5 and the editor 500'd at RENDER time with
+    # ModuleNotFoundError — a runtime failure that should have been an
+    # install-time resolution failure. Raise this floor whenever settings.py
+    # starts consuming a newer scitex-ui symbol.
+    "scitex-ui>=0.5.1",
     # Pillow powers the thumbnail service for figure/table previews in the
     # editor's insert panel. Core — removing it breaks `api/thumbnail` and
     # the fig/table grid renders empty rectangles.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,13 @@ scholar = [
     # (tests/scripts/python/test_check_citation_trust.py, opt-in via
     # SCITEX_WRITER_NETWORK_TESTS=1) is what proves the upstream can actually
     # produce a VERIFIED verdict.
-    "scitex-scholar>=1.5.0",
+    #
+    # 1.5.1 raises it again: before it, arXiv DOIs (10.48550/arXiv.*) could not
+    # verify either — and arXiv is the dominant citation form in ML/CS, so the
+    # check was noisiest exactly where it matters most. Live-verified: an arXiv
+    # DOI now classifies VERIFIED. (A BARE `eprint` + `archivePrefix` entry
+    # still does not — known upstream gap, reported.)
+    "scitex-scholar>=1.5.1",
 ]
 dev = [
     "pytest>=7.0.0",
@@ -86,9 +92,9 @@ dev = [
     # users opt in via `pip install scitex-writer[scholar]`. See
     # _skills/general/01_ecosystem_02_dependency-and-version-pinning.md
     # `[dev]` extras completeness.
-    # Same >=1.5.0 floor as the [scholar] extra: a fresh `pip install -e .[dev]`
+    # Same >=1.5.1 floor as the [scholar] extra: a fresh `pip install -e .[dev]`
     # in CI must get a scholar whose verify_cites can actually return VERIFIED.
-    "scitex-scholar>=1.5.0",  # tested via [scholar] integration tests
+    "scitex-scholar>=1.5.1",  # tested via [scholar] integration tests
     "openpyxl",           # writes the .xlsx fixture for the tables xlsx stage
 ]
 docs = [

--- a/tests/scitex_writer/_django/test_settings.py
+++ b/tests/scitex_writer/_django/test_settings.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: src/scitex_writer/_django/settings.py
+
+"""Settings must only reference symbols the INSTALLED dependencies provide.
+
+Why this file exists: writer pinned `scitex-ui>=0.1.0` while settings.py
+registered `scitex_ui.context_processors.element_inspector` — a module that
+does not exist before scitex-ui 0.5.x. pip therefore resolved 0.4.5 happily
+and the editor 500'd at RENDER time with ModuleNotFoundError. The dependency
+floor was a promise the code had already outgrown, and nothing checked it.
+
+These tests import every context processor settings names, so a floor that is
+too low fails HERE (loudly, in CI, on a fresh [dev] install) instead of in the
+operator's browser.
+"""
+
+import importlib
+import importlib.util
+
+import pytest
+
+from .conftest import _init_django
+
+_init_django()
+
+from django.conf import settings  # noqa: E402
+
+
+def _context_processor_paths() -> list[str]:
+    return settings.TEMPLATES[0]["OPTIONS"]["context_processors"]
+
+
+@pytest.mark.parametrize("dotted_path", _context_processor_paths())
+def test_every_context_processor_is_importable(dotted_path):
+    # Arrange
+    module_path, _, attr = dotted_path.rpartition(".")
+    # Act
+    module = importlib.import_module(module_path)
+    # Assert
+    assert hasattr(module, attr)
+
+
+def test_scitex_ui_context_processors_module_exists():
+    # Arrange
+    name = "scitex_ui.context_processors"
+    # Act
+    spec = importlib.util.find_spec(name)
+    # Assert
+    assert spec is not None


### PR DESCRIPTION
## The failure
The operator's standalone GUI returned 500: `ModuleNotFoundError: No module named 'scitex_ui.context_processors'`.

## Root cause — ours, not upstream drift
`settings.py` registers `scitex_ui.context_processors.element_inspector`, but the pin was `scitex-ui>=0.1.0`. That module doesn't exist before 0.5.x, so pip legitimately resolved **0.4.5** into the operator's venv. The dependency floor was a promise the code had already outgrown — and nothing checked it, so the breakage surfaced at **render time in a browser** instead of at **install time**.

## Fix
- Floor raised to `scitex-ui>=0.5.1` (first version carrying `context_processors`), with a comment saying to raise it again whenever settings starts consuming a newer symbol.
- New `tests/scitex_writer/_django/test_settings.py`: imports **every** context processor settings names, parametrized. A too-low floor now fails loudly in CI on a fresh `[dev]` install.

## Operator unblocked already
Upgraded scitex-ui to 0.6.3 in their venv; the GUI now serves **HTTP 200**. This PR stops it recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)