### PR TITLE
fix(gui): bind writer's fixed port 31298 or fail loud, never silently drift

### DIFF
--- a/docs/01_GUIDE_INSTALLATION.md
+++ b/docs/01_GUIDE_INSTALLATION.md
@@ -160,8 +160,8 @@ services:
 # Build GUI image (includes Flask + LaTeX)
 docker build -f scripts/containers/Dockerfile.gui -t scitex-writer-gui .
 
-# Run (opens on http://localhost:5050)
-docker run --rm -p 5050:5050 -v $(pwd):/workspace scitex-writer-gui
+# Run (opens on http://localhost:31298)
+docker run --rm -p 31298:31298 -v $(pwd):/workspace scitex-writer-gui
 ```
 
 #### Singularity (HPC)

--- a/scripts/containers/Dockerfile.gui
+++ b/scripts/containers/Dockerfile.gui
@@ -9,13 +9,13 @@
 #   docker build -f scripts/containers/Dockerfile.gui -t scitex-writer-gui .
 #
 # Run (mount your project directory):
-#   docker run --rm -p 5050:5050 -v $(pwd):/workspace scitex-writer-gui
+#   docker run --rm -p 31298:31298 -v $(pwd):/workspace scitex-writer-gui
 #
 # Run with custom port:
 #   docker run --rm -p 8080:8080 -v $(pwd):/workspace scitex-writer-gui --port 8080
 #
 # Run without auto-opening browser:
-#   docker run --rm -p 5050:5050 -v $(pwd):/workspace scitex-writer-gui --no-browser
+#   docker run --rm -p 31298:31298 -v $(pwd):/workspace scitex-writer-gui --no-browser
 
 FROM ubuntu:24.04
 
@@ -60,11 +60,11 @@ RUN pip3 install --no-cache-dir --break-system-packages \
 WORKDIR /workspace
 
 # Expose default port
-EXPOSE 5050
+EXPOSE 31298
 
 # Health check via Flask ping endpoint
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=2 \
-    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:5050/ping')" || exit 1
+    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:31298/ping')" || exit 1
 
 # Launch GUI editor, bind to 0.0.0.0 for Docker networking
 ENTRYPOINT ["scitex-writer", "gui", "--host", "0.0.0.0", "--no-browser", "/workspace"]

--- a/scripts/containers/docker-compose.gui.yml
+++ b/scripts/containers/docker-compose.gui.yml
@@ -8,7 +8,7 @@
 #   cd /path/to/your/manuscript
 #   docker compose -f /path/to/scitex-writer/scripts/containers/docker-compose.gui.yml up
 #
-# Then open http://localhost:5050 in your browser.
+# Then open http://localhost:31298 in your browser.
 
 services:
   writer-gui:
@@ -16,7 +16,7 @@ services:
       context: ../..
       dockerfile: scripts/containers/Dockerfile.gui
     ports:
-      - "${SCITEX_GUI_PORT:-5050}:5050"
+      - "${SCITEX_GUI_PORT:-31298}:31298"
     volumes:
       - ${SCITEX_PROJECT_DIR:-.}:/workspace
     restart: unless-stopped

--- a/src/scitex_writer/_cli/commands/gui.py
+++ b/src/scitex_writer/_cli/commands/gui.py
@@ -16,6 +16,7 @@ cycle.
 from __future__ import annotations
 
 import os
+import socket
 import subprocess
 import sys
 import time
@@ -24,9 +25,11 @@ from pathlib import Path
 
 import click
 
+from ..._core import _gui_runtime
 from .._core import main_group
 from .._helpers import _emit_json
-from ..._core import _gui_runtime
+
+DEFAULT_PORT = _gui_runtime.DEFAULT_PORT
 
 
 def _resolve_project(project: str) -> Path | None:
@@ -35,6 +38,31 @@ def _resolve_project(project: str) -> Path | None:
         click.echo(f"Error: Project not found: {project_path}", err=True)
         return None
     return project_path
+
+
+def _port_is_free(host: str, port: int) -> bool:
+    """True when ``host:port`` can be bound right now."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind((host, port))
+        except OSError:
+            return False
+    return True
+
+
+def _port_holder(port: int) -> str | None:
+    """Best-effort description of the process listening on ``port``."""
+    try:
+        proc = subprocess.run(
+            ["ss", "-ltnp"], capture_output=True, text=True, timeout=3
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    for line in proc.stdout.splitlines():
+        if f":{port} " in line:
+            _, _, users = line.partition("users:")
+            return (users.strip() or line.strip()) or None
+    return None
 
 
 @main_group.group("gui")
@@ -49,17 +77,25 @@ def gui_group():
 
 @gui_group.command("serve")
 @click.argument("project", default=".", required=False)
-@click.option("--port", type=int, default=5050, help="Server port (default: 5050).")
+@click.option(
+    "--port",
+    type=int,
+    default=DEFAULT_PORT,
+    help=f"Server port (default: {DEFAULT_PORT}).",
+)
 @click.option("--host", default="127.0.0.1", help="Host to bind (default: 127.0.0.1).")
 @click.option("--dry-run", is_flag=True, default=False, help="Print, don't launch.")
 @click.option("--json", "as_json", is_flag=True, default=False, help="Emit JSON.")
 def gui_serve(project, port, host, dry_run, as_json):
     """Run the editor server in the foreground (Ctrl-C to stop).
 
+    Binds exactly the requested port, and refuses to start when that port is
+    taken or when an editor server is already running.
+
     \b
     Example:
         $ scitex-writer gui serve
-        $ scitex-writer gui serve ~/proj/my-paper --port 5051
+        $ scitex-writer gui serve ~/proj/my-paper --port 31299
     """
     project_path = _resolve_project(project)
     if project_path is None:
@@ -70,14 +106,32 @@ def gui_serve(project, port, host, dry_run, as_json):
         else:
             click.echo(f"Would serve editor at http://{host}:{port}.")
         return 0
+    current = _gui_runtime.status()
+    if current.get("running"):
+        click.echo(
+            f"Error: editor already running at {current['url']} "
+            f"(pid {current['pid']}).\n"
+            "Open that URL, or stop it first: scitex-writer gui stop -y",
+            err=True,
+        )
+        return 1
+    if not _port_is_free(host, port):
+        holder = _port_holder(port)
+        held_by = f"\nHeld by: {holder}" if holder else ""
+        click.echo(
+            f"Error: port {port} is already in use on {host}.{held_by}\n"
+            "Rerun on another port (--port <other>), free the port, or stop a "
+            "stray editor: scitex-writer gui stop -y",
+            err=True,
+        )
+        return 1
     try:
-        from ..._django._server import _find_available_port, run as _run_editor
+        from ..._django._server import run as _run_editor
     except ImportError as e:
         click.echo(
             f"Error: {e}\nInstall with: pip install scitex-writer[editor]", err=True
         )
         return 1
-    port = _find_available_port(host, port)
     _gui_runtime.write_state(os.getpid(), port, host, str(project_path))
     try:
         _run_editor(
@@ -113,9 +167,7 @@ def _autoserve(project_path: Path, port: int, host: str) -> dict:
         host,
     ]
     with open(log_path, "ab") as log:
-        subprocess.Popen(
-            cmd, stdout=log, stderr=log, start_new_session=True
-        )
+        subprocess.Popen(cmd, stdout=log, stderr=log, start_new_session=True)
     deadline = time.monotonic() + 30.0
     while time.monotonic() < deadline:
         current = _gui_runtime.status()
@@ -127,7 +179,12 @@ def _autoserve(project_path: Path, port: int, host: str) -> dict:
 
 @gui_group.command("open")
 @click.argument("project", default=".", required=False)
-@click.option("--port", type=int, default=5050, help="Server port (default: 5050).")
+@click.option(
+    "--port",
+    type=int,
+    default=DEFAULT_PORT,
+    help=f"Server port (default: {DEFAULT_PORT}).",
+)
 @click.option("--host", default="127.0.0.1", help="Host to bind (default: 127.0.0.1).")
 @click.option("--no-browser", is_flag=True, default=False, help="Don't open browser.")
 @click.option(
@@ -144,7 +201,7 @@ def gui_open(project, port, host, no_browser, desktop, dry_run, as_json):
     \b
     Example:
         $ scitex-writer gui open
-        $ scitex-writer gui open ~/proj/my-paper --port 5051
+        $ scitex-writer gui open ~/proj/my-paper --port 31299
     """
     project_path = _resolve_project(project)
     if project_path is None:
@@ -268,7 +325,7 @@ def gui_stop(dry_run, yes, as_json):
 
 @main_group.command("launch-gui", hidden=True)
 @click.argument("project", default=".", required=False)
-@click.option("--port", type=int, default=5050)
+@click.option("--port", type=int, default=DEFAULT_PORT)
 @click.option("--host", default="127.0.0.1")
 @click.option("--no-browser", is_flag=True, default=False)
 @click.option("--desktop", is_flag=True, default=False)
@@ -278,9 +335,7 @@ def gui_stop(dry_run, yes, as_json):
 @click.pass_context
 def launch_gui(ctx, project, port, host, no_browser, desktop, dry_run, yes, as_json):
     """Deprecated alias for `gui open`."""
-    click.echo(
-        "Warning: `launch-gui` is deprecated; use `gui open` instead.", err=True
-    )
+    click.echo("Warning: `launch-gui` is deprecated; use `gui open` instead.", err=True)
     return ctx.invoke(
         gui_open,
         project=project,

--- a/src/scitex_writer/_core/_gui_runtime.py
+++ b/src/scitex_writer/_core/_gui_runtime.py
@@ -23,6 +23,11 @@ from typing import Optional, Union
 
 PathLike = Union[str, Path]
 
+#: Writer's fixed slot in the fleet-wide GUI port scheme. The GUI binds
+#: exactly this port (or an explicit ``--port``) and fails loud when it is
+#: taken — it never silently drifts to the next free port.
+DEFAULT_PORT = 31298
+
 _STATE_FIELDS = ("pid", "port", "host", "project", "started_at")
 
 

--- a/src/scitex_writer/_django/README.md
+++ b/src/scitex_writer/_django/README.md
@@ -34,7 +34,7 @@ _django/
 
 ```bash
 scitex-writer gui ./my-paper
-# → http://127.0.0.1:5050
+# → http://127.0.0.1:31298
 ```
 
 Launches a local Django server bound to `_django.settings`. The project path is

--- a/src/scitex_writer/_django/_server.py
+++ b/src/scitex_writer/_django/_server.py
@@ -13,37 +13,30 @@ into their own Django project.
 from __future__ import annotations
 
 import os
-import socket
 import threading
 import webbrowser
 from pathlib import Path
 
-
-def _find_available_port(host: str, start_port: int) -> int:
-    port = start_port
-    for _ in range(100):
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.bind((host, port))
-                return port
-        except OSError:
-            port += 1
-    return start_port
+from .._core._gui_runtime import DEFAULT_PORT
 
 
 def run(
     project_dir: str,
-    port: int = 5050,
+    port: int = DEFAULT_PORT,
     host: str = "127.0.0.1",
     open_browser: bool = True,
     desktop: bool = False,
     hot_reload: bool = False,
 ) -> None:
-    """Launch the Django editor server locally.
+    """Launch the Django editor server locally on exactly ``port``.
 
     Tries `scitex_app._standalone.run_standalone` first (gets the full
     workspace shell from scitex-ui). Falls back to a bare runserver
     bootstrap if scitex-app is not installed.
+
+    The requested port is bound as given: when it is already in use the
+    server fails instead of drifting to the next free port (which used to
+    leave a stack of duplicate instances behind).
     """
     project_path = Path(project_dir).resolve()
     if not project_path.exists():
@@ -56,7 +49,6 @@ def run(
     os.environ["SCITEX_WORKING_DIR"] = str(project_path)
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "scitex_writer._django.settings")
 
-    port = _find_available_port(host, port)
     print(f"SciTeX Writer GUI: http://{host}:{port}")
     print(f"Project: {project_path}")
     print("Press Ctrl+C to stop")

--- a/src/scitex_writer/_django/manifest.json
+++ b/src/scitex_writer/_django/manifest.json
@@ -20,7 +20,7 @@
   "wip": false,
   "standalone": true,
   "standalone_command": "scitex-writer gui",
-  "standalone_port": 5050,
+  "standalone_port": 31298,
   "frontend_type": "vanilla",
   "embedded_package": true,
   "dependencies": {

--- a/tests/scitex_writer/_cli/commands/test_gui.py
+++ b/tests/scitex_writer/_cli/commands/test_gui.py
@@ -6,6 +6,9 @@
 
 import json
 import os
+import socket
+import subprocess
+import sys
 
 import pytest
 from click.testing import CliRunner
@@ -26,6 +29,49 @@ def isolated_state(tmp_path):
     os.environ["SCITEX_WRITER_GUI_STATE"] = str(state_file)
     yield state_file
     os.environ.pop("SCITEX_WRITER_GUI_STATE", None)
+
+
+@pytest.fixture
+def held_port():
+    """Bind a real listening socket and yield the port it holds."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    try:
+        yield sock.getsockname()[1]
+    finally:
+        sock.close()
+
+
+@pytest.fixture
+def live_pid():
+    """A real, live child process whose pid can stand in for a running server."""
+    child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        yield child.pid
+    finally:
+        child.kill()
+        child.wait()
+
+
+@pytest.fixture
+def dead_pid():
+    """A pid of a real process that has already exited and been reaped."""
+    child = subprocess.Popen([sys.executable, "-c", "pass"])
+    child.wait()
+    return child.pid
+
+
+def _serve(state_file, project, *args):
+    """Run `gui serve` as a real subprocess against an isolated state file."""
+    env = dict(os.environ, SCITEX_WRITER_GUI_STATE=str(state_file))
+    return subprocess.run(
+        [sys.executable, "-m", "scitex_writer", "gui", "serve", str(project), *args],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
 
 
 def test_gui_group_registered_on_main_group():
@@ -142,7 +188,7 @@ def test_gui_stop_json_idempotent(runner, isolated_state):
 
 def test_gui_stop_dry_run_reports_would_stop(runner, isolated_state):
     # Arrange
-    _gui_runtime.write_state(os.getpid(), 5050, "127.0.0.1", "/proj", isolated_state)
+    _gui_runtime.write_state(os.getpid(), 31298, "127.0.0.1", "/proj", isolated_state)
     args = ["gui", "stop", "--dry-run", "--json"]
     # Act
     result = runner.invoke(main_group, args)
@@ -153,7 +199,7 @@ def test_gui_stop_dry_run_reports_would_stop(runner, isolated_state):
 
 def test_gui_stop_dry_run_leaves_server_state(runner, isolated_state):
     # Arrange
-    _gui_runtime.write_state(os.getpid(), 5050, "127.0.0.1", "/proj", isolated_state)
+    _gui_runtime.write_state(os.getpid(), 31298, "127.0.0.1", "/proj", isolated_state)
     args = ["gui", "stop", "--dry-run"]
     # Act
     runner.invoke(main_group, args)
@@ -163,9 +209,89 @@ def test_gui_stop_dry_run_leaves_server_state(runner, isolated_state):
 
 def test_gui_stop_without_yes_refuses(runner, isolated_state):
     # Arrange
-    _gui_runtime.write_state(os.getpid(), 5050, "127.0.0.1", "/proj", isolated_state)
+    _gui_runtime.write_state(os.getpid(), 31298, "127.0.0.1", "/proj", isolated_state)
     args = ["gui", "stop"]
     # Act
     result = runner.invoke(main_group, args)
     # Assert
     assert "without --yes" in result.output and isolated_state.exists()
+
+
+# =========================================================================
+# Fixed port: bind exactly what was asked for, or fail loud
+# =========================================================================
+
+
+def test_gui_serve_default_port_is_fixed_slot(runner):
+    # Arrange
+    args = ["gui", "serve", "--dry-run", "--json"]
+    # Act
+    result = runner.invoke(main_group, args)
+    payload = json.loads(result.output)
+    # Assert
+    assert payload["port"] == 31298
+
+
+def test_gui_open_default_port_is_fixed_slot(runner):
+    # Arrange
+    args = ["gui", "open", "--dry-run", "--json"]
+    # Act
+    result = runner.invoke(main_group, args)
+    payload = json.loads(result.output)
+    # Assert
+    assert payload["port"] == 31298
+
+
+def test_gui_serve_fails_when_port_held(isolated_state, held_port, tmp_path):
+    # Arrange
+    project = tmp_path
+    # Act
+    result = _serve(isolated_state, project, "--port", str(held_port))
+    # Assert
+    assert result.returncode != 0 and "already in use" in result.stderr
+
+
+def test_gui_serve_never_drifts_to_another_port(isolated_state, held_port, tmp_path):
+    # Arrange
+    project = tmp_path
+    # Act
+    _serve(isolated_state, project, "--port", str(held_port))
+    # Assert
+    assert not isolated_state.exists()
+
+
+def test_gui_serve_refuses_second_running_instance(isolated_state, live_pid, tmp_path):
+    # Arrange
+    _gui_runtime.write_state(
+        live_pid, 31298, "127.0.0.1", str(tmp_path), isolated_state
+    )
+    # Act
+    result = _serve(isolated_state, tmp_path)
+    # Assert
+    assert result.returncode != 0 and "already running" in result.stderr
+
+
+def test_gui_serve_names_running_instance_url(isolated_state, live_pid, tmp_path):
+    # Arrange
+    _gui_runtime.write_state(
+        live_pid, 31298, "127.0.0.1", str(tmp_path), isolated_state
+    )
+    # Act
+    result = _serve(isolated_state, tmp_path)
+    # Assert
+    assert "http://127.0.0.1:31298" in result.stderr
+
+
+def test_gui_serve_proceeds_after_stale_state(
+    isolated_state, dead_pid, held_port, tmp_path
+):
+    # Arrange — the recorded pid is really dead, so status() self-heals and
+    # serving proceeds; the port guard is then what stops us, proving we got
+    # past the state check rather than being blocked by the stale file.
+    _gui_runtime.write_state(
+        dead_pid, 31298, "127.0.0.1", str(tmp_path), isolated_state
+    )
+    # Act
+    result = _serve(isolated_state, tmp_path, "--port", str(held_port))
+    # Assert
+    assert "already in use" in result.stderr

--- a/tests/scitex_writer/_core/test__gui_runtime.py
+++ b/tests/scitex_writer/_core/test__gui_runtime.py
@@ -38,13 +38,13 @@ def test_read_state_corrupt_returns_none(state_file):
 
 def test_write_state_roundtrips_fields(state_file):
     # Arrange
-    _gui_runtime.write_state(123, 5050, "127.0.0.1", "/proj", state_file)
+    _gui_runtime.write_state(123, 31298, "127.0.0.1", "/proj", state_file)
     # Act
     state = _gui_runtime.read_state(state_file)
     # Assert
     assert (state["pid"], state["port"], state["host"], state["project"]) == (
         123,
-        5050,
+        31298,
         "127.0.0.1",
         "/proj",
     )
@@ -52,7 +52,7 @@ def test_write_state_roundtrips_fields(state_file):
 
 def test_write_state_records_started_at(state_file):
     # Arrange
-    _gui_runtime.write_state(123, 5050, "127.0.0.1", "/proj", state_file)
+    _gui_runtime.write_state(123, 31298, "127.0.0.1", "/proj", state_file)
     # Act
     state = _gui_runtime.read_state(state_file)
     # Assert
@@ -107,18 +107,18 @@ def test_status_missing_state_reports_not_running(state_file):
 
 def test_status_live_pid_reports_running_url(state_file):
     # Arrange
-    _gui_runtime.write_state(os.getpid(), 5050, "127.0.0.1", "/proj", state_file)
+    _gui_runtime.write_state(os.getpid(), 31298, "127.0.0.1", "/proj", state_file)
     # Act
     result = _gui_runtime.status(state_file)
     # Assert
-    assert result["url"] == "http://127.0.0.1:5050"
+    assert result["url"] == "http://127.0.0.1:31298"
 
 
 def test_status_dead_pid_self_heals_state(state_file):
     # Arrange
     child = subprocess.Popen([sys.executable, "-c", ""])
     child.wait()
-    _gui_runtime.write_state(child.pid, 5050, "127.0.0.1", "/proj", state_file)
+    _gui_runtime.write_state(child.pid, 31298, "127.0.0.1", "/proj", state_file)
     # Act
     result = _gui_runtime.status(state_file)
     # Assert
@@ -137,7 +137,7 @@ def test_stop_without_state_is_idempotent(state_file):
 def test_stop_terminates_recorded_process(state_file):
     # Arrange
     child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
-    _gui_runtime.write_state(child.pid, 5050, "127.0.0.1", "/proj", state_file)
+    _gui_runtime.write_state(child.pid, 31298, "127.0.0.1", "/proj", state_file)
     # Act
     result = _gui_runtime.stop(state_file, timeout=5.0)
     child.wait(timeout=5)
@@ -148,7 +148,7 @@ def test_stop_terminates_recorded_process(state_file):
 def test_stop_clears_state_file(state_file):
     # Arrange
     child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
-    _gui_runtime.write_state(child.pid, 5050, "127.0.0.1", "/proj", state_file)
+    _gui_runtime.write_state(child.pid, 31298, "127.0.0.1", "/proj", state_file)
     # Act
     _gui_runtime.stop(state_file, timeout=5.0)
     child.wait(timeout=5)


### PR DESCRIPTION
## The bug

`gui serve` called `_find_available_port(host, port)`, which **silently walks to the next free port** when the default is taken. Re-running `gui serve` therefore stacked duplicate live instances on 5057, 5058, 5059… — the operator's 「ポートが汚い」 complaint. Same silent-fallback family as the other bugs killed this week: a degraded outcome presented as a success.

Writer is the reference implementation the other three SciTeX GUI tools copy, so this matters beyond writer.

## What changed

**1. Fixed port = 31298.** Writer's slot in the corrected fleet-wide port scheme (the old 5050 default collided with figrecipe). Updated the CLI defaults (`gui serve`, `gui open`, the hidden `launch-gui` alias), the library default (`_django._server.run`, i.e. the public `scitex_writer.gui`), plus `manifest.json`, `Dockerfile.gui`, `docker-compose.gui.yml`, and the docs. The number now lives once, as `_core/_gui_runtime.DEFAULT_PORT`.

**2. Bind-or-fail.** `_find_available_port` is **deleted**. It had two call sites — the CLI serve path *and* `_server.run` itself, which is the thing that actually binds — and both are gone, so the library can no longer drift either. `gui serve` preflights the port with a real bind; when it is taken it names the port, names the holder when `ss` can tell us, points at `--port <other>` / `gui stop`, and exits non-zero. No fallback, no retry.

**3. Idempotent re-run.** `gui serve` consults the `GuiRuntime` state file first. A LIVE pid means an editor is already up, so it prints that instance's URL and pid, refuses, and exits non-zero. Stale/dead state self-heals via the existing zombie-aware `status()` and serving proceeds.

The two guards are complementary: the state file catches "our own server is already up"; the bind check catches "somebody else, or an orphan we lost track of, holds the port".

## Verification — real CLI, not just units

```
[1] serve on a free 31298      -> state written; HTTP probe returns 200
[2] second serve while up      -> "Error: editor already running at http://127.0.0.1:31298 (pid 171425)."  exit=1
[3] gui stop -y                -> "Stopped (pid 171425)."  exit=0
[4] foreign socket holds 31298 -> "Error: port 31298 is already in use on 127.0.0.1."  exit=1
                                  state file afterwards: (none - no silent instance recorded)
```

## Checks

- Tests: 8 new (no mocks, no monkeypatch - real sockets, real subprocesses, `SCITEX_WRITER_GUI_STATE` for isolation). Full local suite: **1869 passed, 6 skipped**.
- `scitex-dev ecosystem audit-all scitex-writer`: **exit 0**.
- Pyright: 0 errors, 0 warnings on the touched files.

## Note (pre-existing, not touched here)

`scripts/containers/Dockerfile.gui`'s ENTRYPOINT is `scitex-writer gui --host ... /workspace` - a bare `gui` group with no verb, which just prints help. It predates this PR; flagging rather than silently widening scope.
