### PR TITLE
fix(gui): never downgrade the editor silently on ImportError

### DIFF
--- a/src/scitex_writer/_django/_server.py
+++ b/src/scitex_writer/_django/_server.py
@@ -30,9 +30,9 @@ def run(
 ) -> None:
     """Launch the Django editor server locally on exactly ``port``.
 
-    Tries `scitex_app._standalone.run_standalone` first (gets the full
-    workspace shell from scitex-ui). Falls back to a bare runserver
-    bootstrap if scitex-app is not installed.
+    Uses `scitex_app._standalone.run_standalone` (gets the full workspace
+    shell from scitex-ui). When scitex-app is not installed, says so and
+    serves bare Django instead; every other error propagates.
 
     The requested port is bound as given: when it is already in use the
     server fails instead of drifting to the next free port (which used to
@@ -54,16 +54,24 @@ def run(
     print("Press Ctrl+C to stop")
 
     try:
-        import django
-
-        django.setup()
-
-        from django.core.management import call_command
-
-        call_command("migrate", "--run-syncdb", verbosity=0)
-
         from scitex_app._standalone import run_standalone
+    except ImportError:
+        run_standalone = None
+        print(
+            "Note: scitex-app is not installed, so the workspace shell is "
+            "unavailable; serving bare Django instead.\n"
+            "      Install it with: pip install scitex-writer[editor]"
+        )
 
+    import django
+
+    django.setup()
+
+    from django.core.management import call_command
+
+    call_command("migrate", "--run-syncdb", verbosity=0)
+
+    if run_standalone is not None:
         run_standalone(
             app_module="scitex_writer._django",
             port=port,
@@ -74,14 +82,6 @@ def run(
             desktop=desktop,
         )
         return
-    except ImportError:
-        pass
-
-    # Fallback: no scitex-app available, run bare Django
-    import django
-
-    django.setup()
-    from django.core.management import call_command
 
     if open_browser and not desktop:
         threading.Timer(1.0, webbrowser.open, args=[f"http://{host}:{port}"]).start()

--- a/tests/scitex_writer/_django/test__server.py
+++ b/tests/scitex_writer/_django/test__server.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: src/scitex_writer/_django/_server.py
+
+"""`run()` must not hide a broken editor behind a working-looking one.
+
+Why this file exists: `run()` used to wrap `django.setup()`, the `migrate`
+call, AND the `scitex_app` import in a single `try/except ImportError: pass`.
+Any ImportError raised anywhere in that block — a broken Django app, a
+half-installed dependency — was swallowed, and the editor silently downgraded
+to a bare runserver without the workspace shell. The operator saw a server
+come up with no way to know it was the degraded one.
+
+The optional-dependency downgrade is legitimate, but it must be the ONLY thing
+that except clause can catch, and it must announce itself. Everything else
+propagates. This is the same silent-fallback family as the port slide that
+`gui serve` used to do (bind the next free port instead of failing).
+
+These tests read the function's own syntax tree, so a future edit that widens
+the except back over `django.setup()` fails HERE instead of in production.
+"""
+
+import ast
+import inspect
+import textwrap
+
+from scitex_writer._django import _server
+
+_RUN_TREE = ast.parse(textwrap.dedent(inspect.getsource(_server.run)))
+
+
+def _import_guarded_try_blocks() -> list[ast.Try]:
+    """Every `try` in `run()` whose handlers catch ImportError."""
+    return [
+        node
+        for node in ast.walk(_RUN_TREE)
+        if isinstance(node, ast.Try)
+        and any(
+            isinstance(handler.type, ast.Name) and handler.type.id == "ImportError"
+            for handler in node.handlers
+        )
+    ]
+
+
+def test_import_guard_protects_only_import_statements():
+    # Arrange
+    guarded_statements = [
+        statement for block in _import_guarded_try_blocks() for statement in block.body
+    ]
+    # Act
+    non_imports = [
+        statement
+        for statement in guarded_statements
+        if not isinstance(statement, (ast.Import, ast.ImportFrom))
+    ]
+    # Assert
+    assert non_imports == []
+
+
+def test_import_guard_announces_the_degraded_fallback():
+    # Arrange
+    handlers = [
+        handler for block in _import_guarded_try_blocks() for handler in block.handlers
+    ]
+    # Act
+    handler_source = " ".join(
+        ast.dump(statement) for handler in handlers for statement in handler.body
+    )
+    # Assert
+    assert "print" in handler_source
+
+
+def test_django_setup_is_never_import_guarded():
+    # Arrange
+    guarded_nodes = {
+        id(node)
+        for block in _import_guarded_try_blocks()
+        for statement in block.body
+        for node in ast.walk(statement)
+    }
+    # Act
+    guarded_setup_calls = [
+        node
+        for node in ast.walk(_RUN_TREE)
+        if isinstance(node, ast.Attribute)
+        and node.attr == "setup"
+        and id(node) in guarded_nodes
+    ]
+    # Assert
+    assert guarded_setup_calls == []


### PR DESCRIPTION
The editor launcher had a second silent fallback, in the same family as the port slide that `gui serve` used to do.

## The bug

`_django/_server.run()` wrapped three unrelated things in one guard:

```python
try:
    import django
    django.setup()
    call_command("migrate", "--run-syncdb", verbosity=0)
    from scitex_app._standalone import run_standalone
    run_standalone(...)
    return
except ImportError:
    pass          # <- swallows ALL of the above

# bare Django, no workspace shell
```

An `ImportError` raised by `django.setup()` (a broken app in `INSTALLED_APPS`) or by `migrate` was swallowed exactly like a missing `scitex-app`. The editor then came up as a bare runserver with no workspace shell, and nothing said so. A degraded server, presented as a working one.

## The fix

The optional-dependency downgrade is legitimate, so it stays — but it is now the only thing the guard can catch, and it announces itself. `django.setup()` and `migrate` run unguarded, so their errors propagate.

## Verification

The tests read `run()`s own syntax tree, so widening the guard back over `django.setup()` fails in CI rather than in production. Both directions were checked:

- against the pre-fix code: **3 failed** (`assert "print" in "Pass()"` — it catches the literal silent `pass`)
- against the fixed code: **3 passed**

The third test was vacuous on the first draft (it parsed the source twice, so its identity check never matched); that was caught by the fail-on-old-code run and fixed.
