### PR TITLE
feat(gui): name the process holding the port, and add --force

### DIFF
--- a/src/scitex_writer/_cli/commands/gui.py
+++ b/src/scitex_writer/_cli/commands/gui.py
@@ -50,19 +50,30 @@ def _port_is_free(host: str, port: int) -> bool:
     return True
 
 
-def _port_holder(port: int) -> str | None:
-    """Best-effort description of the process listening on ``port``."""
-    try:
-        proc = subprocess.run(
-            ["ss", "-ltnp"], capture_output=True, text=True, timeout=3
-        )
-    except (OSError, subprocess.SubprocessError):
-        return None
-    for line in proc.stdout.splitlines():
-        if f":{port} " in line:
-            _, _, users = line.partition("users:")
-            return (users.strip() or line.strip()) or None
-    return None
+def _port_taken_message(host: str, port: int) -> str:
+    """Explain who holds ``port`` and give paste-ready commands to fix it.
+
+    This path means the port is held by something we do NOT track — an
+    orphaned editor, or an unrelated process. `--force` only stops the editor
+    recorded in our own runtime state, so it is deliberately NOT offered here:
+    a hint that does not work is worse than no hint.
+    """
+    holder = _gui_runtime.port_holder(port)
+    lines = [f"Error: port {port} is already in use on {host}."]
+    if holder and holder.get("pid"):
+        lines.append(f"Held by: {holder['name']} (pid {holder['pid']})")
+    elif holder:
+        lines.append("Held by: a process owned by another user.")
+    else:
+        lines.append("Held by: unknown (the listening process could not be read).")
+
+    lines += ["", "Fix it with one of:"]
+    lines.append(
+        f"  scitex-writer gui serve --port {port + 1}   # serve on a free port"
+    )
+    if holder and holder.get("pid"):
+        lines.append(f"  kill {holder['pid']}{' ' * 26}# stop it, then serve again")
+    return "\n".join(lines)
 
 
 @main_group.group("gui")
@@ -84,18 +95,27 @@ def gui_group():
     help=f"Server port (default: {DEFAULT_PORT}).",
 )
 @click.option("--host", default="127.0.0.1", help="Host to bind (default: 127.0.0.1).")
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Stop a previous editor holding the port, then serve.",
+)
 @click.option("--dry-run", is_flag=True, default=False, help="Print, don't launch.")
 @click.option("--json", "as_json", is_flag=True, default=False, help="Emit JSON.")
-def gui_serve(project, port, host, dry_run, as_json):
+def gui_serve(project, port, host, force, dry_run, as_json):
     """Run the editor server in the foreground (Ctrl-C to stop).
 
     Binds exactly the requested port, and refuses to start when that port is
-    taken or when an editor server is already running.
+    taken or when an editor server is already running. `--force` stops a
+    previous editor of ours and takes the port back; it never kills a process
+    that is not ours.
 
     \b
     Example:
         $ scitex-writer gui serve
         $ scitex-writer gui serve ~/proj/my-paper --port 31299
+        $ scitex-writer gui serve --force
     """
     project_path = _resolve_project(project)
     if project_path is None:
@@ -108,22 +128,21 @@ def gui_serve(project, port, host, dry_run, as_json):
         return 0
     current = _gui_runtime.status()
     if current.get("running"):
-        click.echo(
-            f"Error: editor already running at {current['url']} "
-            f"(pid {current['pid']}).\n"
-            "Open that URL, or stop it first: scitex-writer gui stop -y",
-            err=True,
-        )
-        return 1
+        if not force:
+            click.echo(
+                f"Error: editor already running at {current['url']} "
+                f"(pid {current['pid']}).\n"
+                "\nFix it with one of:\n"
+                f"  open {current['url']}\n"
+                "  scitex-writer gui stop -y             # stop it\n"
+                "  scitex-writer gui serve --force       # stop it and serve here",
+                err=True,
+            )
+            return 1
+        click.echo(f"Stopping the editor at {current['url']} (pid {current['pid']}).")
+        _gui_runtime.stop()
     if not _port_is_free(host, port):
-        holder = _port_holder(port)
-        held_by = f"\nHeld by: {holder}" if holder else ""
-        click.echo(
-            f"Error: port {port} is already in use on {host}.{held_by}\n"
-            "Rerun on another port (--port <other>), free the port, or stop a "
-            "stray editor: scitex-writer gui stop -y",
-            err=True,
-        )
+        click.echo(_port_taken_message(host, port), err=True)
         return 1
     try:
         from ..._django._server import run as _run_editor

--- a/src/scitex_writer/_core/_gui_runtime.py
+++ b/src/scitex_writer/_core/_gui_runtime.py
@@ -128,6 +128,62 @@ def status(path: Optional[PathLike] = None) -> dict:
     return {"running": True, "url": url, **{k: state.get(k) for k in _STATE_FIELDS}}
 
 
+def _listening_socket_inodes(port: int) -> set[str]:
+    """Socket inodes of every process LISTENing on ``port``, from /proc/net."""
+    inodes: set[str] = set()
+    for proc_net in ("/proc/net/tcp", "/proc/net/tcp6"):
+        try:
+            lines = Path(proc_net).read_text().splitlines()[1:]
+        except OSError:
+            continue
+        for line in lines:
+            fields = line.split()
+            if len(fields) < 10:
+                continue
+            # local_address is "HEXADDR:HEXPORT"; state 0A == TCP_LISTEN.
+            _, _, hex_port = fields[1].rpartition(":")
+            if fields[3] != "0A" or int(hex_port, 16) != port:
+                continue
+            inodes.add(fields[9])
+    return inodes
+
+
+def port_holder(port: int) -> Optional[dict]:
+    """Identify the process LISTENing on ``port``: ``{pid, name}``, or None.
+
+    Reads /proc directly rather than shelling out to ``ss``/``lsof``, which
+    are absent from many containers — a hint that silently disappears in the
+    exact minimal environment where the operator most needs it is not a hint.
+
+    Only processes the caller can see are reported: an inode we cannot map to
+    a pid (another user's process) yields ``{pid: None}``, so the caller says
+    "another process" rather than inventing a wrong one.
+    """
+    inodes = _listening_socket_inodes(port)
+    if not inodes:
+        return None
+    for proc_dir in Path("/proc").iterdir():
+        if not proc_dir.name.isdigit():
+            continue
+        try:
+            fds = list((proc_dir / "fd").iterdir())
+        except OSError:
+            continue  # not ours / vanished — keep scanning
+        for fd in fds:
+            try:
+                target = os.readlink(fd)
+            except OSError:
+                continue
+            if target[8:-1] not in inodes or not target.startswith("socket:["):
+                continue
+            try:
+                name = (proc_dir / "comm").read_text().strip()
+            except OSError:
+                name = "?"
+            return {"pid": int(proc_dir.name), "name": name}
+    return {"pid": None, "name": None}
+
+
 def stop(path: Optional[PathLike] = None, timeout: float = 5.0) -> dict:
     """SIGTERM the recorded server and clear the state file. Idempotent."""
     current = status(path)

--- a/tests/scitex_writer/_core/test__gui_runtime.py
+++ b/tests/scitex_writer/_core/test__gui_runtime.py
@@ -5,6 +5,7 @@
 """Tests for the GUI runtime-state module (state file, pid checks, stop)."""
 
 import os
+import socket
 import subprocess
 import sys
 
@@ -154,3 +155,51 @@ def test_stop_clears_state_file(state_file):
     child.wait(timeout=5)
     # Assert
     assert not state_file.exists()
+
+
+# =========================================================================
+# port_holder — reads /proc, so the "who has my port" hint survives in a
+# container with no `ss` and no `lsof` (the old shell-out silently returned
+# nothing there, which is exactly where the operator needs the hint most).
+# =========================================================================
+
+
+@pytest.fixture
+def listening_socket():
+    """A real LISTEN socket on an OS-assigned port, held by THIS process."""
+    sock = socket.socket()
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    yield sock
+    sock.close()
+
+
+def test_port_holder_finds_our_own_listening_pid(listening_socket):
+    # Arrange
+    port = listening_socket.getsockname()[1]
+    # Act
+    holder = _gui_runtime.port_holder(port)
+    # Assert
+    assert holder["pid"] == os.getpid()
+
+
+def test_port_holder_reports_the_process_name(listening_socket):
+    # Arrange
+    port = listening_socket.getsockname()[1]
+    # Act
+    holder = _gui_runtime.port_holder(port)
+    # Assert
+    assert holder["name"]
+
+
+def test_port_holder_returns_none_when_port_is_free():
+    # Arrange
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    free_port = probe.getsockname()[1]
+    probe.close()
+    # Act
+    holder = _gui_runtime.port_holder(free_port)
+    # Assert
+    assert holder is None


### PR DESCRIPTION
Follow-up to the port fix, from the operator using it: when the port collides, the error should tell you what to type. Two gaps, both found by running the real CLI rather than the tests.

## 1. The "Held by:" hint silently disappeared where it mattered most

It shelled out to `ss`, which is **not installed in our own agent container** — so the hint quietly rendered nothing and left a bare "port in use" with nothing to act on. A hint that vanishes in a minimal container is worse than no hint, because it looks like the tool simply has nothing to say.

`_gui_runtime.port_holder()` now reads `/proc/net/tcp` + `/proc/<pid>/fd` directly: no external tool, works in a bare container. It reports only processes the caller can actually see — an inode it cannot map to a pid is reported as "owned by another user" rather than guessing.

## 2. The remedies were prose, not commands

Both refusals now print paste-ready lines:

```
Error: port 31298 is already in use on 127.0.0.1.
Held by: python (pid 50257)

Fix it with one of:
  scitex-writer gui serve --port 31299   # serve on a free port
  kill 50257                          # stop it, then serve again
```

```
Error: editor already running at http://127.0.0.1:31298 (pid 50219).

Fix it with one of:
  open http://127.0.0.1:31298
  scitex-writer gui stop -y             # stop it
  scitex-writer gui serve --force       # stop it and serve here
```

## `--force`

Stops a previous editor **of ours** and takes the port back. It deliberately does **not** kill a process it does not own — that could be the operator database — so for a foreign holder we print the `kill` command and let them decide. For the same reason `--force` is not offered as a remedy when the holder is foreign: it would not work there, and a hint that does not work is the bug we are fixing.

## Verification

Driven end-to-end against the real CLI, in a container with no `ss`:

- foreign socket on 31298 -> exit 1, `Held by: python (pid 50257)` matching the actual holder pid, paste-ready commands
- our editor running, no `--force` -> exit 1, refuses, offers the three remedies
- our editor running, with `--force` -> stops the old editor (pid 52102), serves, state file now records the new pid

42 tests pass. Tests use real listening sockets and real child processes; no mocks.
