### PR TITLE
fix(claims): carry provenance pointers through list_claims

### DIFF
--- a/src/scitex_writer/_mcp/handlers/_claim.py
+++ b/src/scitex_writer/_mcp/handlers/_claim.py
@@ -158,15 +158,21 @@ def list_claims(project_dir: str) -> Dict:
         result = []
         for claim_id, claim in claims.items():
             preview = _render_claim(claim, "nature")
+            session_id = claim.get("session_id")
+            output_file = claim.get("output_file")
             result.append(
                 {
                     "claim_id": claim_id,
                     "type": claim.get("type", "unknown"),
                     "context": claim.get("context", ""),
                     "preview_nature": preview,
-                    "has_provenance": bool(
-                        claim.get("session_id") or claim.get("output_file")
-                    ),
+                    # The POINTERS, not just the boolean: callers verify a claim's
+                    # chain with these. Summarising them away as `has_provenance`
+                    # left the viewer unable to verify anything, so every claim
+                    # came back NO_PROVENANCE — including the ones that had it.
+                    "session_id": session_id,
+                    "output_file": output_file,
+                    "has_provenance": bool(session_id or output_file),
                 }
             )
 

--- a/tests/scitex_writer/_mcp/handlers/test__claim.py
+++ b/tests/scitex_writer/_mcp/handlers/test__claim.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: src/scitex_writer/_mcp/handlers/_claim.py
+
+"""`list_claims` must carry a claim's provenance POINTERS, not just a boolean.
+
+Why this file exists: `list_claims` computed `has_provenance` from a claim's
+`session_id` / `output_file` and then DROPPED both fields from the projection it
+returned. The live-paper viewer verifies each claim's chain by passing those
+pointers to `scitex_clew.verify_chain` — so with nothing to pass, every claim
+came back `NO_PROVENANCE`, including the claims that HAD provenance and would
+have verified. A wrong answer, delivered confidently, with no error anywhere.
+
+That is the same failure shape as the silent port slide and the silent editor
+downgrade: a degraded result presented as a real one. `has_provenance: true`
+with no pointers is not a summary, it is a dead end.
+"""
+
+import json
+
+from scitex_writer._mcp.handlers._claim import list_claims
+
+
+def _project_with_claims(tmp_path, claims: dict):
+    """A real project tree with a real 00_shared/claims.json."""
+    shared = tmp_path / "00_shared"
+    shared.mkdir(parents=True)
+    (shared / "claims.json").write_text(json.dumps({"claims": claims}))
+    return tmp_path
+
+
+def _claim_named(result, claim_id):
+    return next(c for c in result["claims"] if c["claim_id"] == claim_id)
+
+
+CLAIM_WITH_BOTH = {
+    "type": "value",
+    "context": "accuracy",
+    "value": "0.91",
+    "session_id": "sess-2026-07-13",
+    "output_file": "scripts/eval/out/accuracy.json",
+}
+CLAIM_WITH_NEITHER = {"type": "value", "context": "hand-typed", "value": "42"}
+
+
+def test_list_claims_carries_the_output_file_pointer(tmp_path):
+    # Arrange
+    project = _project_with_claims(tmp_path, {"acc": CLAIM_WITH_BOTH})
+    # Act
+    result = list_claims(str(project))
+    # Assert
+    assert _claim_named(result, "acc")["output_file"] == (
+        "scripts/eval/out/accuracy.json"
+    )
+
+
+def test_list_claims_carries_the_session_id_pointer(tmp_path):
+    # Arrange
+    project = _project_with_claims(tmp_path, {"acc": CLAIM_WITH_BOTH})
+    # Act
+    result = list_claims(str(project))
+    # Assert
+    assert _claim_named(result, "acc")["session_id"] == "sess-2026-07-13"
+
+
+def test_list_claims_still_reports_has_provenance_true(tmp_path):
+    # Arrange
+    project = _project_with_claims(tmp_path, {"acc": CLAIM_WITH_BOTH})
+    # Act
+    result = list_claims(str(project))
+    # Assert
+    assert _claim_named(result, "acc")["has_provenance"] is True
+
+
+def test_list_claims_reports_has_provenance_false_without_pointers(tmp_path):
+    # Arrange
+    project = _project_with_claims(tmp_path, {"bare": CLAIM_WITH_NEITHER})
+    # Act
+    result = list_claims(str(project))
+    # Assert
+    assert _claim_named(result, "bare")["has_provenance"] is False
+
+
+def test_list_claims_leaves_pointers_none_when_the_claim_has_none(tmp_path):
+    # Arrange
+    project = _project_with_claims(tmp_path, {"bare": CLAIM_WITH_NEITHER})
+    # Act
+    result = list_claims(str(project))
+    # Assert
+    assert _claim_named(result, "bare")["output_file"] is None


### PR DESCRIPTION
The live-paper viewer has been reporting **NO_PROVENANCE for every claim** — including claims that have provenance and would verify.

## Root cause

`list_claims` builds a projection of each claim. It computed `has_provenance` from `session_id` / `output_file`, then **dropped both fields**:

```python
"has_provenance": bool(claim.get("session_id") or claim.get("output_file")),
# ...session_id and output_file themselves never make it into the dict
```

`handle_claims_metadata` then calls `_claim_verification_state(project, claim)`, which does:

```python
if not (output_file or session_id):
    return {"state": "NO_PROVENANCE"}
```

So it took that branch every time. `scitex_clew.verify_chain` was never reached for any claim. No exception, no log line — just a confident wrong answer. Same family as the silent port slide and the silent editor downgrade we shipped fixes for in 2.30.0.

`has_provenance: true` with no pointers is not a summary; it is a dead end.

## Fix

The projection now carries `session_id` and `output_file`. The boolean stays for callers that only want the flag, and the viewer needs no change — it already reads those keys.

## Provenance of this patch

Recovered from a `rescue: pre-stop autosave` commit on `writer-livepaper-wt`, an abandoned worktree branch from an agent that was stopped on 2026-06-24. It never got a PR, so the fix sat unmerged for three weeks. I did not merge that draft: it worked around the bug by re-reading `claims.json` inside the viewer, behind `list_claims`, and wrapped the reread in a bare `except Exception` — a silent fallback, the exact thing this repo has spent the week deleting. Fixed at the source instead.

## Verification

Tests build a real project with a real `00_shared/claims.json`; no mocks. Checked in both directions:

- against current develop: **3 failed** (the pointer tests), 2 passed (the `has_provenance` booleans, whose behavior is deliberately unchanged)
- with the fix: **5 passed**
