### PR TITLE
release: scitex-writer 2.30.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.30.2] - 2026-07-13
+
+### Fixed
+- **The live-paper viewer reported `NO_PROVENANCE` for every claim — including claims that had provenance and would have verified.** `list_claims` computed `has_provenance` from a claim's `session_id` / `output_file` and then DROPPED both fields from the projection it returned. `_claim_verification_state` verifies a claim by handing those pointers to `scitex_clew.verify_chain`; with nothing to hand it, it took its `if not (output_file or session_id)` branch every time and `verify_chain` was never reached for any claim. No exception, no log line — a confident wrong answer, the same shape as the port slide and the silent editor downgrade. The projection now carries `session_id` and `output_file`; the boolean stays for callers that only want the flag. (Recovered from a `rescue: pre-stop autosave` on an abandoned worktree branch that never got a PR — that draft patched the viewer to re-read `claims.json` behind `list_claims`' back and swallowed the reread in a bare `except Exception`, so it was rewritten to fix the source instead.)
+
 ## [2.30.1] - 2026-07-13
 
 Follow-up to 2.30.0, from the operator using it: when the port collides, the error should tell you what to type.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.30.1"
+version = "2.30.2"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_writer/_mcp/handlers/_claim.py
+++ b/src/scitex_writer/_mcp/handlers/_claim.py
@@ -158,15 +158,21 @@ def list_claims(project_dir: str) -> Dict:
         result = []
         for claim_id, claim in claims.items():
             preview = _render_claim(claim, "nature")
+            session_id = claim.get("session_id")
+            output_file = claim.get("output_file")
             result.append(
                 {
                     "claim_id": claim_id,
                     "type": claim.get("type", "unknown"),
                     "context": claim.get("context", ""),
                     "preview_nature": preview,
-                    "has_provenance": bool(
-                        claim.get("session_id") or claim.get("output_file")
-                    ),
+                    # The POINTERS, not just the boolean: callers verify a claim's
+                    # chain with these. Summarising them away as `has_provenance`
+                    # left the viewer unable to verify anything, so every claim
+                    # came back NO_PROVENANCE — including the ones that had it.
+                    "session_id": session_id,
+                    "output_file": output_file,
+                    "has_provenance": bool(session_id or output_file),
                 }
             )
 

--- a/tests/scitex_writer/_mcp/handlers/test__claim.py
+++ b/tests/scitex_writer/_mcp/handlers/test__claim.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: src/scitex_writer/_mcp/handlers/_claim.py
+
+"""`list_claims` must carry a claim's provenance POINTERS, not just a boolean.
+
+Why this file exists: `list_claims` computed `has_provenance` from a claim's
+`session_id` / `output_file` and then DROPPED both fields from the projection it
+returned. The live-paper viewer verifies each claim's chain by passing those
+pointers to `scitex_clew.verify_chain` — so with nothing to pass, every claim
+came back `NO_PROVENANCE`, including the claims that HAD provenance and would
+have verified. A wrong answer, delivered confidently, with no error anywhere.
+
+That is the same failure shape as the silent port slide and the silent editor
+downgrade: a degraded result presented as a real one. `has_provenance: true`
+with no pointers is not a summary, it is a dead end.
+"""
+
+import json
+
+from scitex_writer._mcp.handlers._claim import list_claims
+
+
+def _project_with_claims(tmp_path, claims: dict):
+    """A real project tree with a real 00_shared/claims.json."""
+    shared = tmp_path / "00_shared"
+    shared.mkdir(parents=True)
+    (shared / "claims.json").write_text(json.dumps({"claims": claims}))
+    return tmp_path
+
+
+def _claim_named(result, claim_id):
+    return next(c for c in result["claims"] if c["claim_id"] == claim_id)
+
+
+CLAIM_WITH_BOTH = {
+    "type": "value",
+    "context": "accuracy",
+    "value": "0.91",
+    "session_id": "sess-2026-07-13",
+    "output_file": "scripts/eval/out/accuracy.json",
+}
+CLAIM_WITH_NEITHER = {"type": "value", "context": "hand-typed", "value": "42"}
+
+
+def test_list_claims_carries_the_output_file_pointer(tmp_path):
+    # Arrange
+    project = _project_with_claims(tmp_path, {"acc": CLAIM_WITH_BOTH})
+    # Act
+    result = list_claims(str(project))
+    # Assert
+    assert _claim_named(result, "acc")["output_file"] == (
+        "scripts/eval/out/accuracy.json"
+    )
+
+
+def test_list_claims_carries_the_session_id_pointer(tmp_path):
+    # Arrange
+    project = _project_with_claims(tmp_path, {"acc": CLAIM_WITH_BOTH})
+    # Act
+    result = list_claims(str(project))
+    # Assert
+    assert _claim_named(result, "acc")["session_id"] == "sess-2026-07-13"
+
+
+def test_list_claims_still_reports_has_provenance_true(tmp_path):
+    # Arrange
+    project = _project_with_claims(tmp_path, {"acc": CLAIM_WITH_BOTH})
+    # Act
+    result = list_claims(str(project))
+    # Assert
+    assert _claim_named(result, "acc")["has_provenance"] is True
+
+
+def test_list_claims_reports_has_provenance_false_without_pointers(tmp_path):
+    # Arrange
+    project = _project_with_claims(tmp_path, {"bare": CLAIM_WITH_NEITHER})
+    # Act
+    result = list_claims(str(project))
+    # Assert
+    assert _claim_named(result, "bare")["has_provenance"] is False
+
+
+def test_list_claims_leaves_pointers_none_when_the_claim_has_none(tmp_path):
+    # Arrange
+    project = _project_with_claims(tmp_path, {"bare": CLAIM_WITH_NEITHER})
+    # Act
+    result = list_claims(str(project))
+    # Assert
+    assert _claim_named(result, "bare")["output_file"] is None


### PR DESCRIPTION
Promotes 2.30.2 to main.

The live-paper viewer had been reporting `NO_PROVENANCE` for every claim, including claims that had provenance and would have verified. `list_claims` summarised the `session_id` / `output_file` pointers into a `has_provenance` boolean and dropped them, so `verify_chain` was never reached. No exception, no log line.

Same family as the port slide and the silent editor downgrade fixed in 2.30.0.
