### PR TITLE
chore(release): 2.32.0 — shell completion via the public scitex_dev.cli, unguarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.32.0] - 2026-07-14
+
+### Changed
+- **Shell completion is imported from the public `scitex_dev.cli`, and the import is no longer guarded.** It reached into `scitex_dev._cli._completion` — a peer's *private* module, which that peer is free to move without warning. The public name is the promise, and `attach_shell_completion` is in `scitex_dev.cli.__all__` behind a deliberate lazy re-export, so there was never a reason to reach past it.
+
+  The `try/except ImportError` around it is gone too. scitex-dev is a **hard** dependency of scitex-writer, not an optional one: if it cannot be imported, the install is broken and the right outcome is a loud `ImportError` naming the real cause. The guard turned that into a writer with silently missing completion leaves — a degraded CLI presented as a working one, which is the same defect as an extra that installs nothing. Raises the floor to `scitex-dev>=0.30.0`, the first release exposing the public re-export.
+
 ## [2.31.0] - 2026-07-13
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.31.0"
+version = "2.32.0"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Writer took `attach_shell_completion` from `scitex_dev._cli._completion` — a peer's **private** module — behind a `try/except ImportError`. Both halves were wrong.

**The private import.** `attach_shell_completion` is in `scitex_dev.cli.__all__`, behind a deliberate lazy re-export. The public name is the promise; the private path is something the peer may move without warning, and we had no claim on it.

**The guard.** scitex-dev is a **hard** dependency of scitex-writer, not an optional one. If it cannot be imported, the install is broken, and the correct outcome is a loud `ImportError` naming the real cause. The guard instead swallowed it and shipped a writer with silently missing completion leaves — a degraded CLI presented as a working one. Same defect as an extra that installs nothing: the user gets the broken thing and no signal that anything is wrong.

Floor raised to `scitex-dev>=0.30.0`, the first release exposing the public re-export. That is why this is a minor and not a patch — it changes what an install requires.

Also drops the now-stale `scitex_dev._cli._completion` entry from the auto-generated cross-package import gate, which PS-140 §2 flagged (and which was the only real CI failure on #325).

Tests read the source AST and fail if the private import or the guard ever returns.

Follows #325.