### PR TITLE
release: scitex-writer 2.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.32.0] - 2026-07-14
+
+### Changed
+- **Shell completion is imported from the public `scitex_dev.cli`, and the import is no longer guarded.** It reached into `scitex_dev._cli._completion` — a peer's *private* module, which that peer is free to move without warning. The public name is the promise, and `attach_shell_completion` is in `scitex_dev.cli.__all__` behind a deliberate lazy re-export, so there was never a reason to reach past it.
+
+  The `try/except ImportError` around it is gone too. scitex-dev is a **hard** dependency of scitex-writer, not an optional one: if it cannot be imported, the install is broken and the right outcome is a loud `ImportError` naming the real cause. The guard turned that into a writer with silently missing completion leaves — a degraded CLI presented as a working one, which is the same defect as an extra that installs nothing. Raises the floor to `scitex-dev>=0.30.0`, the first release exposing the public re-export.
+
 ## [2.31.0] - 2026-07-13
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,15 @@ classifiers = [
 dependencies = [
     "click>=8.0",
     "fastmcp>=2.0.0",
-    "scitex-dev>=0.11.7",
+    # FLOOR IS 0.30.0, not 0.11.7: `_cli/commands/__init__.py` imports
+    # `attach_shell_completion` from the PUBLIC `scitex_dev.cli` (in its
+    # __all__, behind a lazy re-export) rather than the private
+    # `_cli._completion`. That public name does not exist on older releases,
+    # and the import is deliberately UNGUARDED — scitex-dev is a hard
+    # dependency, so a guard would swallow a real breakage rather than cover a
+    # missing optional. Below this floor the CLI fails to import at all, which
+    # is why the floor has to carry the promise instead of a try/except.
+    "scitex-dev>=0.30.0",
     "django>=4.2",
     # scitex-ui ships `standalone_shell.html` + shell CSS that the editor
     # and viewer templates extend. Loading either page without scitex-ui

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.31.0"
+version = "2.32.0"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_writer/_cli/__init__.py
+++ b/src/scitex_writer/_cli/__init__.py
@@ -46,8 +46,10 @@ def _is_bare_version_invocation(argv: list[str]) -> bool:
 #
 # Root cause this guards against (fixes the CI regression that appeared once
 # scitex-dev 0.27.0 was installed): importing ``.commands`` eagerly pulls in
-# ``scitex_dev._cli._completion`` to attach shell-completion leaves, which
-# imports ``scitex_dev._cli`` — and *that* package's ``__init__`` has its own
+# ``scitex_dev.cli.attach_shell_completion`` to attach the shell-completion
+# leaves. That public name lazily re-exports from ``scitex_dev._cli._completion``,
+# so the same import chain still reaches ``scitex_dev._cli`` — and *that*
+# package's ``__init__`` has its own
 # module-level fast-path that, when ``sys.argv[1:]`` is a bare
 # ``--version``/``-V``, prints ``scitex-dev <ver>`` and ``raise
 # SystemExit(0)``. So without this guard, ``scitex-writer --version`` (and

--- a/src/scitex_writer/_cli/commands/__init__.py
+++ b/src/scitex_writer/_cli/commands/__init__.py
@@ -60,12 +60,20 @@ _mount_optional_subcommands()
 
 
 # §1a: install-shell-completion + print-shell-completion (canonical leaves)
-try:
-    from scitex_dev._cli._completion import attach_shell_completion
+#
+# Imported from the PUBLIC `scitex_dev.cli` (it is in that module's __all__,
+# behind a deliberate lazy re-export), not the private `_cli._completion`.
+# A peer can move a private module without notice; the public name is the
+# promise.
+#
+# NO ImportError GUARD. scitex-dev is a HARD dependency of writer, so it is
+# always installed — a guard here would not be protecting against a missing
+# optional package, it would be SWALLOWING a real breakage: if the peer ever
+# drops or renames this symbol, shell completion would silently stop existing
+# and nothing would say why. Let it raise.
+from scitex_dev.cli import attach_shell_completion  # noqa: E402
 
-    attach_shell_completion(main_group, prog_name="scitex-writer")
-except ImportError:
-    pass
+attach_shell_completion(main_group, prog_name="scitex-writer")
 
 
 # Wire in the skills group (list/get/install).

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -25,7 +25,6 @@ CROSS_PACKAGE_IMPORTS = [
     "scitex_config._ecosystem",
     "scitex_container.apptainer",
     "scitex_dev",
-    "scitex_dev._cli._completion",
     "scitex_dev.cli",
     "scitex_dev.decorators",
     "scitex_dev.skills",

--- a/tests/scitex_writer/_cli/commands/test___init__.py
+++ b/tests/scitex_writer/_cli/commands/test___init__.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: src/scitex_writer/_cli/commands/__init__.py
+
+"""The shell-completion wiring must come from a PUBLIC peer name, unguarded.
+
+Why this file exists — two defects lived in six lines here:
+
+1. PRIVATE IMPORT. It reached into `scitex_dev._cli._completion`, a peer's
+   underscore module. A peer can rename or move a private path without notice;
+   the public name is the promise. `scitex_dev.cli.attach_shell_completion` is
+   in that module's `__all__`, so it is the supported surface.
+
+2. `except ImportError: pass`. scitex-dev is a HARD dependency of writer — it is
+   always installed — so that guard was not protecting against a missing
+   optional package. It was SWALLOWING a real breakage: if the peer ever dropped
+   or renamed the symbol, shell completion would silently stop existing and
+   nothing would say why. The same shape as the port that silently slid and the
+   install hint that installed nothing.
+
+The guard is gone and the floor carries the promise instead (scitex-dev>=0.30.0,
+the first release exposing the public name). Below it, the CLI fails to import —
+loudly, at install time, which is where a dependency problem belongs.
+"""
+
+import ast
+import inspect
+from pathlib import Path
+
+import tomllib
+
+from scitex_writer._cli import commands
+
+_ROOT = Path(__file__).resolve().parents[4]
+_SOURCE = inspect.getsource(commands)
+_TREE = ast.parse(_SOURCE)
+
+
+def _imported_modules() -> list[str]:
+    return [
+        node.module
+        for node in ast.walk(_TREE)
+        if isinstance(node, ast.ImportFrom) and node.module
+    ]
+
+
+def test_no_private_scitex_dev_module_is_imported():
+    # Arrange
+    imports = _imported_modules()
+    # Act
+    private = [m for m in imports if m.startswith("scitex_dev._")]
+    # Assert
+    assert private == []
+
+
+def test_shell_completion_comes_from_the_public_scitex_dev_cli():
+    # Arrange
+    imports = _imported_modules()
+    # Act
+    public = [m for m in imports if m == "scitex_dev.cli"]
+    # Assert
+    assert public != []
+
+
+def test_the_completion_import_is_not_swallowed_by_an_import_guard():
+    # Arrange
+    guarded = {
+        id(node)
+        for try_node in ast.walk(_TREE)
+        if isinstance(try_node, ast.Try)
+        for statement in try_node.body
+        for node in ast.walk(statement)
+    }
+    # Act
+    guarded_completion_imports = [
+        node
+        for node in ast.walk(_TREE)
+        if isinstance(node, ast.ImportFrom)
+        and node.module == "scitex_dev.cli"
+        and id(node) in guarded
+    ]
+    # Assert
+    assert guarded_completion_imports == []
+
+
+def test_the_scitex_dev_floor_carries_the_public_name_promise():
+    # Arrange
+    data = tomllib.loads((_ROOT / "pyproject.toml").read_text())
+    # Act
+    pins = [
+        req for req in data["project"]["dependencies"] if req.startswith("scitex-dev")
+    ]
+    # Assert
+    assert pins == ["scitex-dev>=0.30.0"]


### PR DESCRIPTION
Ships 2.32.0.

**Shell completion is imported from the public `scitex_dev.cli`, and the import is no longer guarded.**

Writer reached into `scitex_dev._cli._completion` — a peer's **private** module — behind a `try/except ImportError`. Both halves were wrong. `attach_shell_completion` is in `scitex_dev.cli.__all__` behind a deliberate lazy re-export, so the public name was always available; and scitex-dev is a **hard** dependency, so a swallowed `ImportError` shipped a writer with silently missing completion leaves instead of a loud error naming the real cause.

Floor raised to `scitex-dev>=0.30.0` (first release exposing the public re-export) — that is why this is a minor, not a patch: it changes what an install requires.

Also drops the stale `scitex_dev._cli._completion` entry from the auto-generated cross-package import gate.

Tests read the source AST and fail if either the private import or the guard returns.