### PR TITLE
chore(release): 2.32.1 — stop claiming scitex-app is absent when it is merely old

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.32.1] - 2026-07-14
+
+### Fixed
+- **The editor no longer says "scitex-app is not installed" when scitex-app IS installed.** The guard around `scitex_app.embed` catches two different failures — the package being absent, and the package being present but older than 0.4.0, the release that added `.embed` — and reported the first for both.
+
+  Found by running the real entry point against a real environment that had **scitex-app 0.2.11** sitting right there. The remedy it offers (`uv pip install 'scitex-writer[all]'`) happens to fix either case, which is exactly why this survived: the message *worked*, so nobody checked whether it was *true*. But a user who reads "not installed", runs `pip show scitex-app`, and finds the package present concludes the message is lying and goes to debug something else. A wrong diagnosis costs more than a missing one. It now names the installed version and the version required.
+
 ## [2.32.0] - 2026-07-14
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.32.0"
+version = "2.32.1"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Ships the fix from #328.

The editor said `scitex-app is not installed` on an environment where scitex-app **was** installed — just at 0.2.11, older than the 0.4.0 that added `scitex_app.embed`. One `except ImportError` covered both failures and reported the absent one for both.

The remedy it hands back fixes either case, which is why this survived unnoticed: the message *worked*, so nobody checked whether it was *true*. But "not installed" sends a user to `pip show scitex-app`, where they find the package present, conclude the message is lying, and go debug something else. A wrong diagnosis costs more than a missing one — which is precisely the finding we filed against a peer today, so we do not get to carry it ourselves.

Now names the installed version and the required one. Verified through the real entry point, not just the unit.