### PR TITLE
release: scitex-writer 2.32.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.32.1] - 2026-07-14
+
+### Fixed
+- **The editor no longer says "scitex-app is not installed" when scitex-app IS installed.** The guard around `scitex_app.embed` catches two different failures — the package being absent, and the package being present but older than 0.4.0, the release that added `.embed` — and reported the first for both.
+
+  Found by running the real entry point against a real environment that had **scitex-app 0.2.11** sitting right there. The remedy it offers (`uv pip install 'scitex-writer[all]'`) happens to fix either case, which is exactly why this survived: the message *worked*, so nobody checked whether it was *true*. But a user who reads "not installed", runs `pip show scitex-app`, and finds the package present concludes the message is lying and goes to debug something else. A wrong diagnosis costs more than a missing one. It now names the installed version and the version required.
+
 ## [2.32.0] - 2026-07-14
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.32.0"
+version = "2.32.1"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_writer/_django/_server.py
+++ b/src/scitex_writer/_django/_server.py
@@ -30,8 +30,9 @@ def run(
 ) -> None:
     """Launch the Django editor server locally on exactly ``port``.
 
-    Uses `scitex_app._standalone.run_standalone` (gets the full workspace
-    shell from scitex-ui). When scitex-app is not installed, says so and
+    Uses `scitex_app.embed.run_standalone` (gets the full workspace shell
+    from scitex-ui). When that import fails, names WHICH failure it was —
+    scitex-app absent, or present but too old to expose `.embed` — and
     serves bare Django instead; every other error propagates.
 
     The requested port is bound as given: when it is already in use the
@@ -56,11 +57,13 @@ def run(
     try:
         from scitex_app.embed import run_standalone
     except ImportError:
+        from ._workspace_shell import REMEDY, probe_missing_shell
+
         run_standalone = None
         print(
-            "Note: scitex-app is not installed, so the workspace shell is "
+            f"Note: {probe_missing_shell()}, so the workspace shell is "
             "unavailable; serving bare Django instead.\n"
-            "      Get it with: uv pip install 'scitex-writer[all]'"
+            f"      Get it with: {REMEDY}"
         )
 
     import django

--- a/src/scitex_writer/_django/_workspace_shell.py
+++ b/src/scitex_writer/_django/_workspace_shell.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Why the scitex-app workspace shell is unavailable, stated precisely.
+
+An ``except ImportError`` around ``scitex_app.embed`` catches two different
+failures and cannot tell them apart:
+
+- scitex-app is ABSENT, or
+- scitex-app is PRESENT but predates ``.embed`` (added in 0.4.0).
+
+Reporting the first when the second is true sends the reader to
+``pip show scitex-app``, where the package is sitting right there — so the
+message reads as a lie and they go debug something else. The remedy is the
+same for both, but the diagnosis is not, and a wrong diagnosis costs more
+than a missing one.
+
+The decision is a pure function of two facts so it can be tested against real
+values; only ``probe_missing_shell`` touches the interpreter.
+"""
+
+import importlib.metadata
+import importlib.util
+from typing import Optional
+
+# First scitex-app release exposing the public ``scitex_app.embed`` module.
+MIN_SCITEX_APP = "0.4.0"
+
+REMEDY = "uv pip install 'scitex-writer[all]'"
+
+
+def describe_missing_shell(spec_found: bool, installed_version: Optional[str]) -> str:
+    """Name which of the two failures actually happened."""
+    if not spec_found:
+        return "scitex-app is not installed"
+    shown = installed_version or "an unknown version"
+    return (
+        f"scitex-app {shown} is installed but does not expose "
+        f"scitex_app.embed, which arrived in {MIN_SCITEX_APP}"
+    )
+
+
+def probe_missing_shell() -> str:
+    """Read the two facts off the live interpreter, then describe them."""
+    try:
+        spec_found = importlib.util.find_spec("scitex_app") is not None
+    except (ImportError, ValueError):
+        # A half-installed package can raise rather than return None.
+        spec_found = False
+
+    installed_version = None
+    if spec_found:
+        try:
+            installed_version = importlib.metadata.version("scitex-app")
+        except importlib.metadata.PackageNotFoundError:
+            installed_version = None
+
+    return describe_missing_shell(spec_found, installed_version)

--- a/src/scitex_writer/_django/apps.py
+++ b/src/scitex_writer/_django/apps.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 import warnings
 
+from ._workspace_shell import REMEDY, probe_missing_shell
+
 try:
     from scitex_app.embed import ScitexAppConfig
 except ImportError:
@@ -12,8 +14,8 @@ except ImportError:
     from django.apps import AppConfig as ScitexAppConfig
 
     warnings.warn(
-        "scitex-app is not installed: the writer editor is running without "
-        "the workspace shell. Get it with: uv pip install 'scitex-writer[all]'",
+        f"{probe_missing_shell()}: the writer editor is running without "
+        f"the workspace shell. Get it with: {REMEDY}",
         RuntimeWarning,
         stacklevel=2,
     )

--- a/tests/scitex_writer/_django/test__workspace_shell.py
+++ b/tests/scitex_writer/_django/test__workspace_shell.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""The workspace-shell downgrade message must name the RIGHT failure.
+
+`except ImportError` around `scitex_app.embed` catches two failures — the
+package being absent, and the package being present but older than the release
+that added `.embed` — and the old code reported the first for both. A user who
+reads "scitex-app is not installed", runs `pip show scitex-app`, and finds it
+sitting right there concludes the message is lying, and goes and debugs
+something else. That is the same defect as a remedy that does nothing: the
+signal is present and wrong, which is worse than absent.
+
+`describe_missing_shell` is pure so these run against real values with no mock
+and no monkeypatch (PA-306 / STX-NM002).
+"""
+
+from scitex_writer._django._workspace_shell import (
+    MIN_SCITEX_APP,
+    REMEDY,
+    describe_missing_shell,
+)
+
+
+class TestAbsentPackage:
+    def test_absent_package_is_reported_as_not_installed(self):
+        # Arrange
+        spec_found = False
+
+        # Act
+        reason = describe_missing_shell(spec_found, installed_version=None)
+
+        # Assert
+        assert reason == "scitex-app is not installed"
+
+
+class TestPresentButTooOld:
+    def test_present_but_old_package_names_the_installed_version(self):
+        # Arrange
+        installed = "0.2.11"
+
+        # Act
+        reason = describe_missing_shell(True, installed_version=installed)
+
+        # Assert
+        assert installed in reason
+
+    def test_present_but_old_package_never_claims_not_installed(self):
+        # This is the regression. The old code said exactly this, and it was
+        # false: the package WAS installed, just too old to expose `.embed`.
+        # Arrange
+        installed = "0.2.11"
+
+        # Act
+        reason = describe_missing_shell(True, installed_version=installed)
+
+        # Assert
+        assert "not installed" not in reason
+
+    def test_present_but_old_package_names_the_required_floor(self):
+        # Arrange
+        installed = "0.2.11"
+
+        # Act
+        reason = describe_missing_shell(True, installed_version=installed)
+
+        # Assert
+        assert MIN_SCITEX_APP in reason
+
+    def test_present_with_unknown_version_still_avoids_not_installed(self):
+        # Arrange: a package on sys.path with no distribution metadata. We
+        # still know it is THERE, so calling it absent would be just as wrong.
+        unknown = None
+
+        # Act
+        reason = describe_missing_shell(True, installed_version=unknown)
+
+        # Assert
+        assert "not installed" not in reason
+
+
+class TestRemedy:
+    def test_remedy_installs_the_all_extra(self):
+        # Arrange: extras are all-or-nothing. A remedy naming a retired
+        # fine-grained extra would install nothing at all.
+        expected = "uv pip install 'scitex-writer[all]'"
+
+        # Act
+        offered = REMEDY
+
+        # Assert
+        assert offered == expected


### PR DESCRIPTION
Ships 2.32.1.

**The editor stops claiming scitex-app is absent when it is merely old.**

The guard around `scitex_app.embed` catches two different failures — the package being absent, and the package being present but older than 0.4.0 (the release that added `.embed`) — and reported the first for both.

Found by running the real entry point against an environment that had **scitex-app 0.2.11** sitting right there, saying "not installed". The remedy it offers fixes either case, which is exactly why it survived: the message *worked*, so nobody checked whether it was *true*. A user who reads it, runs `pip show scitex-app`, and finds the package present concludes the message is lying and goes to debug something else. A wrong diagnosis costs more than a missing one.

It now names the installed version and the version required.