### PR TITLE
fix(clew): verify claims through Clew's real API — the viewer verified ZERO claims

### DIFF
--- a/src/scitex_writer/_django/handlers/claim.py
+++ b/src/scitex_writer/_django/handlers/claim.py
@@ -11,8 +11,11 @@ the response.
 from __future__ import annotations
 
 import json
+import logging
 
 from django.http import JsonResponse
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_json(request) -> dict:
@@ -88,16 +91,24 @@ def handle_claim_chain(request, project, claim_id: str):
     if output_file or session_id:
         try:
             from scitex_clew import generate_mermaid_dag
-
+        except ImportError:
+            response["clew_available"] = False
+        else:
             response["clew_available"] = True
             kwargs = {}
             if output_file:
                 kwargs["target_file"] = output_file
             elif session_id:
                 kwargs["session_id"] = session_id
-            response["mermaid"] = generate_mermaid_dag(**kwargs)
-        except Exception:
-            pass
+            try:
+                response["mermaid"] = generate_mermaid_dag(**kwargs)
+            except Exception as exc:
+                # This was `except Exception: pass`, so a failing DAG left
+                # clew_available=True and mermaid=None — the pane reported Clew
+                # as working and simply drew nothing, with no way to find out
+                # why. Say what broke.
+                logger.warning("[claim] Clew DAG failed for %s: %s", claim_id, exc)
+                response["mermaid_error"] = str(exc)
 
     return JsonResponse(response)
 

--- a/src/scitex_writer/_django/handlers/viewer.py
+++ b/src/scitex_writer/_django/handlers/viewer.py
@@ -118,28 +118,66 @@ def handle_citation(request, project, cite_key: str):
 
 
 def _claim_verification_state(project, claim: dict) -> dict:
-    """Best-effort Clew verification for a claim."""
+    """Verify a claim through Clew's own per-claim entry point.
+
+    This used to hand-roll the verdict out of ``verify_chain(target_file=...)``.
+    No published Clew has ever had a ``target_file`` parameter — ``verify_chain``
+    takes a single positional ``target`` — and it has no ``session_id`` parameter
+    either, so BOTH branches raised TypeError on every call. The exception was
+    logged at DEBUG and returned as a per-claim state of ``"ERROR"``, which reads
+    as "this claim could not be verified" when the truth was "writer called Clew
+    wrong". A wiring bug wearing the costume of a data problem: it shipped, and
+    verified zero of the 40 claims in a real manuscript.
+
+    Clew ships ``verify_claim`` for exactly this, and returns its OWN reasons in
+    ``details`` — better than any verdict we could synthesise.
+    """
+    claim_id = claim.get("claim_id")
     output_file = claim.get("output_file")
     session_id = claim.get("session_id")
     if not (output_file or session_id):
         return {"state": "NO_PROVENANCE"}
 
     try:
-        from scitex_clew import verify_chain
-
-        args = {}
-        if output_file:
-            args["target_file"] = output_file
-        elif session_id:
-            args["session_id"] = session_id
-        status = verify_chain(**args)
-        return {
-            "state": status.status.name if hasattr(status, "status") else str(status),
-            "target_file": output_file,
-            "session_id": session_id,
-        }
+        from scitex_clew import verify_chain, verify_claim
     except ImportError:
         return {"state": "CLEW_MISSING"}
+
+    try:
+        if claim_id:
+            verdict = verify_claim(claim_id)
+            return {
+                "state": "VERIFIED" if verdict.get("chain_verified") else "UNVERIFIED",
+                "source_verified": verdict.get("source_verified"),
+                "chain_verified": verdict.get("chain_verified"),
+                # Clew's reasons, carried through. Without them the pane can say
+                # a claim failed but never say why.
+                "details": verdict.get("details") or [],
+                "output_file": output_file,
+                "session_id": session_id,
+            }
+        if output_file:
+            status = verify_chain(output_file)
+            return {
+                "state": (
+                    status.status.name if hasattr(status, "status") else str(status)
+                ),
+                "output_file": output_file,
+                "session_id": session_id,
+            }
+        # A session id alone gives Clew nothing to chase: neither entry point
+        # accepts one. Say so, rather than reporting a verification we did not
+        # perform.
+        return {"state": "UNVERIFIABLE_NO_TARGET", "session_id": session_id}
+    except TypeError:
+        # A TypeError here is OUR call being wrong, not a fact about the claim.
+        # Reporting it as a per-claim "ERROR" is precisely how the previous bug
+        # stayed invisible across two releases. Let it out.
+        raise
     except Exception as exc:
-        logger.debug("[viewer] verify_chain failed: %s", exc)
+        logger.warning(
+            "[viewer] Clew verification failed for %s: %s",
+            claim_id or output_file,
+            exc,
+        )
         return {"state": "ERROR", "error": str(exc)}

--- a/tests/scitex_writer/_django/handlers/test_viewer_clew_wiring.py
+++ b/tests/scitex_writer/_django/handlers/test_viewer_clew_wiring.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Writer must call Clew with the signature Clew actually publishes.
+
+THE BUG THIS PINS. `_claim_verification_state` called
+`verify_chain(target_file=...)` and `verify_chain(session_id=...)`. Clew's
+`verify_chain` takes a single positional `target` and has NEITHER keyword, so
+EVERY call raised TypeError. It was logged at DEBUG and returned as a per-claim
+state of "ERROR" — which reads as "this claim could not be verified" when the
+truth was "writer called Clew wrong". Forty claims in a real manuscript verified
+as zero, and the failure never surfaced.
+
+These tests read the SOURCE, not a mock, and check writer's call against Clew's
+REAL published signature (via inspect). A mock would have happily accepted
+`target_file=` and told us everything was fine — which is exactly how this
+shipped. No mocks, no monkeypatch (PA-306 / STX-NM002).
+"""
+
+import ast
+import inspect
+import pathlib
+
+import pytest
+
+import scitex_writer._django.handlers.viewer as viewer_mod
+
+_SRC = pathlib.Path(viewer_mod.__file__).read_text()
+_TREE = ast.parse(_SRC)
+
+
+def _verification_fn():
+    """The `_claim_verification_state` FunctionDef node, or raise if it moved."""
+    for node in ast.walk(_TREE):
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name == "_claim_verification_state"
+        ):
+            return node
+    raise AssertionError("_claim_verification_state disappeared from viewer.py")
+
+
+def _calls_named(tree, func_name):
+    """Every Call node in the source invoking `func_name`."""
+    out = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            fn = node.func
+            name = getattr(fn, "id", None) or getattr(fn, "attr", None)
+            if name == func_name:
+                out.append(node)
+    return out
+
+
+class TestVerifyChainCallMatchesClew:
+    def test_verify_chain_is_never_called_with_dict_unpacking(self):
+        # Arrange: the ORIGINAL bug was `verify_chain(**args)`, with `args`
+        # built at runtime as {"target_file": ...} — a keyword Clew does not
+        # have. Unpacking hides the call shape from every static check, which
+        # is why the TypeError shipped. Forbid the pattern, not just the one
+        # wrong key: a checkable call is the whole point.
+        calls = _calls_named(_TREE, "verify_chain")
+
+        # Act
+        unpacked = [c for c in calls for k in c.keywords if k.arg is None]
+
+        # Assert
+        assert unpacked == []
+
+    def test_every_verify_chain_keyword_exists_in_clews_signature(self):
+        # Arrange: the real published signature, not a mock's idea of it. A mock
+        # would have happily accepted `target_file=` and told us it was fine.
+        clew = pytest.importorskip("scitex_clew")
+        allowed = set(inspect.signature(clew.verify_chain).parameters)
+
+        # Act
+        used = {
+            k.arg
+            for c in _calls_named(_TREE, "verify_chain")
+            for k in c.keywords
+            if k.arg
+        }
+
+        # Assert
+        assert used <= allowed
+
+    def test_no_target_file_key_is_built_anywhere_in_the_verifier(self):
+        # Arrange: `target_file` is not a Clew parameter and never was. Catch it
+        # as a dict key too, since that is how it reached Clew last time.
+        fn_src = _verification_fn()
+
+        # Act
+        keys = [
+            n.value
+            for n in ast.walk(fn_src)
+            if isinstance(n, ast.Constant) and n.value == "target_file"
+        ]
+
+        # Assert
+        assert keys == []
+
+
+class TestVerifyClaimIsUsed:
+    def test_viewer_imports_clews_per_claim_entry_point(self):
+        # Arrange: Clew ships verify_claim for exactly this; writer hand-rolled
+        # the verdict out of verify_chain and got the call wrong.
+        imported = {
+            alias.name
+            for node in ast.walk(_TREE)
+            if isinstance(node, ast.ImportFrom) and node.module == "scitex_clew"
+            for alias in node.names
+        }
+
+        # Act
+        uses_per_claim_api = "verify_claim" in imported
+
+        # Assert
+        assert uses_per_claim_api
+
+    def test_verify_claim_exists_in_the_installed_clew(self):
+        # Arrange
+        clew = pytest.importorskip("scitex_clew")
+
+        # Act
+        fn = getattr(clew, "verify_claim", None)
+
+        # Assert
+        assert callable(fn)
+
+
+class TestWiringErrorsAreNotSwallowed:
+    def test_type_error_is_re_raised_not_reported_as_claim_error(self):
+        # Arrange: a TypeError is OUR call being wrong, not a fact about the
+        # claim. Swallowing it as state="ERROR" is how the bug stayed invisible.
+        fn_src = _verification_fn()
+
+        # Act
+        reraises = any(
+            isinstance(h.type, ast.Name)
+            and h.type.id == "TypeError"
+            and any(isinstance(s, ast.Raise) for s in h.body)
+            for t in ast.walk(fn_src)
+            if isinstance(t, ast.Try)
+            for h in t.handlers
+        )
+
+        # Assert
+        assert reraises


### PR DESCRIPTION
Found by **paper-scitex-clew**, in a real manuscript: all 40 claims returned `ERROR`. Not some of them. All of them.

## The bug

```python
args["target_file"] = output_file      # clew.verify_chain has no such parameter
args["session_id"]  = session_id       # nor this one
status = verify_chain(**args)          # -> TypeError, every single time
...
logger.debug("[viewer] verify_chain failed: %s", exc)   # at DEBUG
return {"state": "ERROR", ...}
```

`scitex_clew.verify_chain` takes a single positional `target`. It has neither keyword. So **every** call raised `TypeError` — and the failure was logged at **debug** and returned as a per-claim state of `"ERROR"`.

That is the whole disease in one line: *a wiring bug wearing the costume of a data problem.* The pane said "this claim could not be verified," when the truth was "writer called Clew wrong." It shipped in 2.30.2, and **it had never once been run against a real clew.**

## The fix

Use Clew's own per-claim entry point — `verify_claim(claim_id)` — which exists precisely for this and which writer was reimplementing badly. Its verdict carries `details` (Clew's own reasons, e.g. `"Source file missing: …"`), so the pane can now say *why* a claim failed rather than just that it did. Return shape confirmed by **calling it against a real clew project**, not by reading a docstring.

- A `session_id` alone is now `UNVERIFIABLE_NO_TARGET` — neither entry point accepts one. Say so, rather than report a verification we did not perform.
- A `TypeError` is **re-raised**, never reported as a claim state. It is our call being wrong, not a fact about the claim. Had this been here, the bug would have screamed on day one.
- `claim.py`'s `except Exception: pass` is gone; it left `clew_available=True` with a silently empty DAG.

## On the tests

They forbid `**`-unpacking into Clew's API — the pattern that hid the call shape from every static check.

**My first draft of these tests was vacuous.** It inspected AST keyword nodes, which `verify_chain(**args)` does not produce — so it passed against the bug. I caught it only by running the suite against the unfixed code first, which is the one habit that keeps catching this. Corrected; now all four checks **FAIL on develop and PASS here**.

No mocks (PA-306): a mock would have cheerfully accepted `target_file=` and reported everything green — which is exactly how this shipped.