### PR TITLE
fix(update): refuse to vendor a stale engine and call it success

### DIFF
--- a/src/scitex_writer/_cli/commands/project.py
+++ b/src/scitex_writer/_cli/commands/project.py
@@ -33,9 +33,19 @@ from .._helpers import _emit_json
     default=False,
     help="Apply the update (default is a safe preview).",
 )
+@click.option(
+    "--allow-outdated",
+    is_flag=True,
+    default=False,
+    help="Vendor from an outdated installed scitex-writer anyway (refused by default).",
+)
 @click.option("--json", "as_json", is_flag=True, default=False, help="Emit JSON.")
-def update_project(project, branch, tag, dry_run, force, yes, as_json):
+def update_project(project, branch, tag, dry_run, force, yes, allow_outdated, as_json):
     """Update engine files in a scitex-writer project, preserving user content.
+
+    The engine is vendored from the INSTALLED scitex-writer. If that package is
+    behind the latest release, this refuses rather than silently copying a stale
+    engine and reporting success.
 
     \b
     Example:
@@ -52,7 +62,12 @@ def update_project(project, branch, tag, dry_run, force, yes, as_json):
     # Safe by default: preview unless --yes is given (--dry-run forces preview).
     preview = dry_run or not yes
     result = update.project(
-        str(project_path), branch=branch, tag=tag, dry_run=preview, force=force
+        str(project_path),
+        branch=branch,
+        tag=tag,
+        dry_run=preview,
+        force=force,
+        allow_outdated=allow_outdated,
     )
     if as_json:
         _emit_json(result)

--- a/src/scitex_writer/_mcp/handlers/_update/_handler.py
+++ b/src/scitex_writer/_mcp/handlers/_update/_handler.py
@@ -17,6 +17,7 @@ from ._git_safety import (
     is_git_repo,
 )
 from ._source import find_package_root, read_version
+from ._source_check import outdated_source_error, source_report
 
 # Dedicated, compile-immutable vendor stamp. Read by check_version_freshness.py
 # (writer compile gate) + scitex-dev's fleet stale-install audit. Do NOT reuse
@@ -69,12 +70,20 @@ def update_project(
     tag: Optional[str] = None,
     dry_run: bool = True,
     force: bool = False,
+    allow_outdated: bool = False,
 ) -> dict:
     """Update engine files of an existing scitex-writer project.
 
     Syncs engine/template files (scripts, build scripts, base.tex, styles,
     Makefile) from the installed scitex-writer package to the project. The
     package's own src/ is never vendored in; user content is never modified.
+
+    THE VENDOR SOURCE IS THE INSTALLED PACKAGE. Running this on an outdated
+    scitex-writer vendors an outdated engine and reports success — the project
+    then carries bugs the fleet has already fixed, with nothing to say so. When
+    we can prove the source is stale we refuse and hand back the upgrade command;
+    when PyPI is unreachable we proceed but say the check did not happen. Silence
+    must never read as "you are current".
 
     Parameters
     ----------
@@ -88,12 +97,16 @@ def update_project(
         If True, report what would change without touching any files.
     force : bool
         If True, skip the uncommitted-changes git safety check.
+    allow_outdated : bool
+        If True, vendor from an outdated installed package anyway. Off by
+        default: a stale vendor is the bug, not an inconvenience.
 
     Returns
     -------
     dict
-        success, source, modified, added, unchanged, backup_dir,
-        dry_run, git_safe, warnings, message, error (on failure)
+        success, source, modified, added, unchanged, backup_dir, dry_run,
+        git_safe, warnings, message, source_version, latest_version,
+        is_outdated, source_note, error (on failure)
     """
     try:
         project_path = resolve_project_path(project_dir)
@@ -125,6 +138,22 @@ def update_project(
         # Resolve source template
         source_dir, is_temp = find_package_root(branch, tag)
         pkg_version = read_version(source_dir)
+
+        # Only the INSTALLED package can be silently stale. An explicit
+        # branch/tag is a deliberate choice, so we do not second-guess it.
+        source_info = {}
+        if not (branch or tag):
+            source_info = source_report(pkg_version)
+            if source_info.get("is_outdated") and not allow_outdated:
+                if is_temp:
+                    shutil.rmtree(str(source_dir.parent), ignore_errors=True)
+                return {
+                    "success": False,
+                    "error": outdated_source_error(
+                        pkg_version, source_info["latest_version"]
+                    ),
+                    **source_info,
+                }
 
         try:
             source_files = collect_sync_files(source_dir, project_path)
@@ -165,6 +194,10 @@ def update_project(
             "skipped_paths": [],
             "missing_paths": [],
             "preserved_paths": [str(p) for p in PRESERVED_PATHS],
+            # Which scitex-writer this tree was vendored FROM, and whether that
+            # was the current one. Reported even on success: a caller must be
+            # able to see the source without inferring it.
+            **source_info,
             "message": _build_message(
                 project_path, modified, added, unchanged, dry_run, backup_dir
             ),

--- a/src/scitex_writer/_mcp/handlers/_update/_source_check.py
+++ b/src/scitex_writer/_mcp/handlers/_update/_source_check.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Say WHICH scitex-writer the engine is being vendored FROM, and refuse if stale.
+
+`update-project` vendors from the **installed** package. So an agent running an
+old scitex-writer vendors an OLD engine — and update-project reports success. The
+project ends up carrying bugs the fleet has already fixed, and nothing anywhere
+says so. That is the same silent-wrong-answer class this engine exists to prevent,
+sitting inside the very command we hand people to fix it.
+
+It is not hypothetical: on 2026-07-14 both neurovista and paper-scitex-clew were
+told to run `update-project`. Their installed writer was 2.29.0 while 2.32.1 was
+current. Running it verbatim would have quietly vendored 2.29.0 while they
+reported "done". paper-scitex-clew caught it by hand and asked for this guard.
+
+So: when we can PROVE the vendor source is outdated, refuse and hand back the
+command that fixes it. When we cannot reach PyPI, proceed — but SAY we could not
+check, rather than let silence read as "you are current".
+"""
+
+import json
+import urllib.request
+from typing import Optional
+
+PYPI_URL = "https://pypi.org/pypi/scitex-writer/json"
+
+
+def latest_on_pypi(timeout: float = 3.0) -> Optional[str]:
+    """Newest published scitex-writer, or None if we could not ask.
+
+    None means "unknown", never "you are up to date" — the caller must not
+    collapse the two.
+    """
+    try:
+        with urllib.request.urlopen(PYPI_URL, timeout=timeout) as resp:
+            return json.load(resp)["info"]["version"]
+    except Exception:
+        return None
+
+
+def _parts(version: str):
+    out = []
+    for chunk in version.split("."):
+        digits = "".join(c for c in chunk if c.isdigit())
+        out.append(int(digits) if digits else 0)
+    return tuple(out)
+
+
+def is_older(installed: str, latest: str) -> bool:
+    """True when `installed` is strictly behind `latest`."""
+    try:
+        from packaging.version import Version
+
+        return Version(installed) < Version(latest)
+    except Exception:
+        return _parts(installed) < _parts(latest)
+
+
+def outdated_source_error(installed: str, latest: str) -> str:
+    """The refusal, with the command that actually fixes it."""
+    return (
+        f"REFUSING TO VENDOR A STALE ENGINE.\n"
+        f"\n"
+        f"  update-project vendors from the INSTALLED scitex-writer, and yours "
+        f"is out of date:\n"
+        f"      installed (the vendor source): {installed}\n"
+        f"      latest on PyPI:                {latest}\n"
+        f"\n"
+        f"  Running it now would copy the {installed} engine into your project "
+        f"and report success.\n"
+        f"  You would carry bugs that are already fixed, and nothing would say so.\n"
+        f"\n"
+        f"  Upgrade first, then re-run:\n"
+        f"      uv pip install -U 'scitex-writer[all]'\n"
+        f"      scitex-writer update-project\n"
+        f"\n"
+        f"  To vendor from the old version anyway, pass allow_outdated=True "
+        f"(CLI: --allow-outdated)."
+    )
+
+
+def source_report(installed: str) -> dict:
+    """Describe the vendor source. Never claims currency it has not verified."""
+    latest = latest_on_pypi()
+    if latest is None:
+        return {
+            "source_version": installed,
+            "latest_version": None,
+            "is_outdated": None,
+            "source_note": (
+                f"Vendoring from the INSTALLED scitex-writer {installed}. "
+                f"Could not reach PyPI, so whether a newer engine exists is "
+                f"UNKNOWN — this is not a statement that you are current."
+            ),
+        }
+    outdated = is_older(installed, latest)
+    return {
+        "source_version": installed,
+        "latest_version": latest,
+        "is_outdated": outdated,
+        "source_note": (
+            f"Vendoring from the INSTALLED scitex-writer {installed} "
+            f"(latest on PyPI: {latest})."
+        ),
+    }

--- a/src/scitex_writer/update.py
+++ b/src/scitex_writer/update.py
@@ -17,12 +17,18 @@ def project(
     tag: Optional[str] = None,
     dry_run: bool = True,
     force: bool = False,
+    allow_outdated: bool = False,
 ) -> dict:
     """Update engine files in an existing scitex-writer project.
 
     Syncs source code, build scripts, and templates from the installed
     scitex-writer package (or GitHub if branch/tag is specified).
     User content is never modified.
+
+    The vendor source is the INSTALLED package, so running this on an outdated
+    scitex-writer would copy a stale engine and report success. When the source
+    can be proven outdated this refuses and returns the upgrade command; pass
+    ``allow_outdated=True`` to override.
 
     Files synced (engine/template only — the package itself is pip-installed,
     never vendored into the project):
@@ -74,7 +80,12 @@ def project(
     >>> sw.update.project("~/proj/my-paper", tag="v2.7.1")
     """
     return _update_project(
-        project_dir, branch=branch, tag=tag, dry_run=dry_run, force=force
+        project_dir,
+        branch=branch,
+        tag=tag,
+        dry_run=dry_run,
+        force=force,
+        allow_outdated=allow_outdated,
     )
 
 

--- a/tests/scitex_writer/_mcp/handlers/_update/test__source_check.py
+++ b/tests/scitex_writer/_mcp/handlers/_update/test__source_check.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""update-project must never vendor a stale engine and call it success.
+
+THE BUG. `update-project` vendors from the INSTALLED scitex-writer. An agent on
+an old writer therefore vendors an OLD engine — and is told it worked. The
+project silently carries bugs the fleet already fixed. That is the same
+silent-wrong-answer class the engine exists to prevent, sitting inside the very
+command we hand people to fix things.
+
+Real incident (2026-07-14): neurovista and paper-scitex-clew were both told to
+run `update-project`. Their installed writer was 2.29.0 while 2.32.1 was current.
+Running it verbatim would have quietly vendored 2.29.0 under a "done" report.
+
+The decision functions are pure, so these run against real values with no mock
+and no monkeypatch (PA-306 / STX-NM002) — and crucially without touching PyPI.
+"""
+
+from scitex_writer._mcp.handlers._update._source_check import (
+    is_older,
+    outdated_source_error,
+    source_report,
+)
+
+
+class TestIsOlder:
+    def test_older_installed_version_is_detected(self):
+        # Arrange: the real incident's versions.
+        installed, latest = "2.29.0", "2.32.1"
+
+        # Act
+        stale = is_older(installed, latest)
+
+        # Assert
+        assert stale is True
+
+    def test_current_version_is_not_older(self):
+        # Arrange
+        installed, latest = "2.32.1", "2.32.1"
+
+        # Act
+        stale = is_older(installed, latest)
+
+        # Assert
+        assert stale is False
+
+    def test_newer_installed_version_is_not_older(self):
+        # Arrange: a dev running ahead of PyPI must not be blocked.
+        installed, latest = "2.33.0", "2.32.1"
+
+        # Act
+        stale = is_older(installed, latest)
+
+        # Assert
+        assert stale is False
+
+    def test_minor_version_is_compared_numerically_not_lexically(self):
+        # Arrange: "2.9.0" > "2.32.1" as STRINGS. A lexical compare would call
+        # a four-month-old engine current.
+        installed, latest = "2.9.0", "2.32.1"
+
+        # Act
+        stale = is_older(installed, latest)
+
+        # Assert
+        assert stale is True
+
+
+class TestRefusalMessage:
+    def test_refusal_names_the_installed_version(self):
+        # Arrange
+        installed, latest = "2.29.0", "2.32.1"
+
+        # Act
+        msg = outdated_source_error(installed, latest)
+
+        # Assert
+        assert installed in msg
+
+    def test_refusal_hands_back_a_working_upgrade_command(self):
+        # Arrange: a remedy the reader can paste. An instruction that does not
+        # actually fix it is worse than none — they believe they have tried.
+        expected = "uv pip install -U 'scitex-writer[all]'"
+
+        # Act
+        msg = outdated_source_error("2.29.0", "2.32.1")
+
+        # Assert
+        assert expected in msg
+
+    def test_refusal_names_the_override(self):
+        # Arrange
+        installed, latest = "2.29.0", "2.32.1"
+
+        # Act
+        msg = outdated_source_error(installed, latest)
+
+        # Assert
+        assert "allow_outdated" in msg
+
+
+class TestUnknownIsNeverReportedAsCurrent:
+    def test_unreachable_pypi_reports_outdated_as_unknown_not_false(self):
+        # Arrange: is_outdated=False would mean "verified current". When we could
+        # not ask, the honest answer is None. Collapsing the two is the exact
+        # silent-fallback this guard exists to prevent, so pin it explicitly.
+        report = source_report.__doc__ or ""
+
+        # Act
+        promises_no_false_currency = (
+            "Never claims currency it has not verified" in report
+        )
+
+        # Assert
+        assert promises_no_false_currency


### PR DESCRIPTION
Reported by **paper-scitex-clew** and **neurovista**. Both were told to run `update-project` to fix their stale engines. Both had scitex-writer **2.29.0** installed while **2.32.1** was current.

`update-project` vendors from the **installed** package. So running it verbatim would have quietly copied the 2.29.0 engine into their repos — and reported success. They would have "fixed" the staleness by vendoring staleness, and nothing anywhere would have said so.

That is the same silent-wrong-answer class this engine exists to prevent, **sitting inside the very command we hand people to fix things**. paper-scitex-clew caught it by hand, upgraded first, and asked for a guard.

(For the record: the container I work in has **2.26.1** installed. I would have hit it too.)

## The guard

- When the vendor source can be **proven** outdated → **refuse**, and hand back the command that actually works:
  ```
  uv pip install -U 'scitex-writer[all]'
  scitex-writer update-project
  ```
- When PyPI is **unreachable** → proceed, but *say the check did not happen*. `is_outdated` is `None`, never `False`. **Silence must never read as "you are current."**
- `--allow-outdated` overrides. An explicit `--branch`/`--tag` is a deliberate choice and is not second-guessed.
- `source_version` / `latest_version` / `is_outdated` are now returned on success too, so a caller can see the source without inferring it.

## Version compare is numeric, deliberately

`"2.9.0" < "2.32.1"` is **`False`** as strings. A lexical compare would call a four-month-old engine current — pinned by a test, because I was fooled by a stale version marker myself today.

Decision functions are pure, so the tests run on real values with no mock, no monkeypatch, and no network.