### PR TITLE
chore(release): 2.33.0 — the claims pane actually verifies claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.33.0] - 2026-07-14
+
+### Fixed
+- **The claims pane verified ZERO claims. Not some — all of them.** Writer called `verify_chain(target_file=...)` and `verify_chain(session_id=...)`. Clew's `verify_chain` takes a single positional `target` and has *neither* keyword, so **every** call raised `TypeError`. The exception was logged at **debug** and returned as a per-claim state of `"ERROR"` — so the pane told a researcher "this claim could not be verified" when the truth was "writer called Clew wrong". A wiring bug wearing the costume of a data problem. It shipped in 2.30.2 and had never once been run against a real Clew; **paper-scitex-clew found it in a real manuscript, where all 40 claims came back `ERROR`.**
+
+  It now uses Clew's own per-claim entry point, `verify_claim(claim_id)` — which exists for exactly this, and which writer was reimplementing badly — and carries Clew's `details` through, so the pane can say *why* a claim failed rather than only that it did. A `session_id` alone is reported as `UNVERIFIABLE_NO_TARGET`: neither entry point accepts one, so claiming a verification we never performed was a second lie hiding under the first. A `TypeError` is now **re-raised**, never reported as a claim state — it is our call being wrong, not a fact about the claim.
+
+  Also removes `claim.py`'s `except Exception: pass`, which left `clew_available=True` beside a silently empty DAG.
+
+- **`update-project` refuses to vendor a stale engine and call it success.** It vendors from the **installed** scitex-writer, so an agent running an old version would quietly copy an old engine into their project and be told it worked — "fixing" staleness with staleness. Both neurovista and paper-scitex-clew were sent to run it with 2.29.0 installed while 2.32.1 was current; paper-scitex-clew caught it by hand and asked for the guard.
+
+  When the source can be **proven** outdated it now refuses and hands back the command that works (`uv pip install -U 'scitex-writer[all]'`). When PyPI is unreachable it proceeds but **says the check did not happen** — `is_outdated` is `None`, never `False`. Silence must not read as "you are current". `--allow-outdated` overrides; an explicit `--branch`/`--tag` is a deliberate choice and is not second-guessed. Version comparison is numeric, because `"2.9.0" < "2.32.1"` is `False` as strings.
+
 ## [2.32.1] - 2026-07-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.32.1"
+version = "2.33.0"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Ships #332 and #333. Both were found by peer agents, in a real manuscript, and both are the same disease: **a failure that reports itself as fine.**

**The claims pane verified zero claims.** `verify_chain(target_file=…)` — Clew takes a positional `target` and has no such keyword, so every call raised `TypeError`, was logged at *debug*, and came back as a per-claim `"ERROR"`. A researcher was told "this claim could not be verified" when the truth was "writer called Clew wrong". All 40 claims in paper-scitex-clew's manuscript. Shipped in 2.30.2, never once run against a real Clew.

**`update-project` vendored staleness and reported success.** It vendors from the *installed* package — so the two agents I sent to fix their stale engines would have vendored 2.29.0 while 2.32.1 was current, and been told it worked.

Both now fail loud, and both hand back a command that actually works.