### PR TITLE
release: scitex-writer 2.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.33.0] - 2026-07-14
+
+### Fixed
+- **The claims pane verified ZERO claims. Not some — all of them.** Writer called `verify_chain(target_file=...)` and `verify_chain(session_id=...)`. Clew's `verify_chain` takes a single positional `target` and has *neither* keyword, so **every** call raised `TypeError`. The exception was logged at **debug** and returned as a per-claim state of `"ERROR"` — so the pane told a researcher "this claim could not be verified" when the truth was "writer called Clew wrong". A wiring bug wearing the costume of a data problem. It shipped in 2.30.2 and had never once been run against a real Clew; **paper-scitex-clew found it in a real manuscript, where all 40 claims came back `ERROR`.**
+
+  It now uses Clew's own per-claim entry point, `verify_claim(claim_id)` — which exists for exactly this, and which writer was reimplementing badly — and carries Clew's `details` through, so the pane can say *why* a claim failed rather than only that it did. A `session_id` alone is reported as `UNVERIFIABLE_NO_TARGET`: neither entry point accepts one, so claiming a verification we never performed was a second lie hiding under the first. A `TypeError` is now **re-raised**, never reported as a claim state — it is our call being wrong, not a fact about the claim.
+
+  Also removes `claim.py`'s `except Exception: pass`, which left `clew_available=True` beside a silently empty DAG.
+
+- **`update-project` refuses to vendor a stale engine and call it success.** It vendors from the **installed** scitex-writer, so an agent running an old version would quietly copy an old engine into their project and be told it worked — "fixing" staleness with staleness. Both neurovista and paper-scitex-clew were sent to run it with 2.29.0 installed while 2.32.1 was current; paper-scitex-clew caught it by hand and asked for the guard.
+
+  When the source can be **proven** outdated it now refuses and hands back the command that works (`uv pip install -U 'scitex-writer[all]'`). When PyPI is unreachable it proceeds but **says the check did not happen** — `is_outdated` is `None`, never `False`. Silence must not read as "you are current". `--allow-outdated` overrides; an explicit `--branch`/`--tag` is a deliberate choice and is not second-guessed. Version comparison is numeric, because `"2.9.0" < "2.32.1"` is `False` as strings.
+
 ## [2.32.1] - 2026-07-14
 
 ### Fixed

--- a/docs/adr/0001-interactive-paper-editor.md
+++ b/docs/adr/0001-interactive-paper-editor.md
@@ -1,7 +1,7 @@
 # ADR 0001 — SSOT interactive research-paper editor (pen-tablet annotation + interactive clew provenance)
 
-- **Status:** Proposed (hub-approved 2026-07-08; figrecipe + clew seam inputs pending their return)
-- **Date:** 2026-07-08
+- **Status:** Accepted (2026-07-14). hub approved 2026-07-08; figrecipe confirmed the `figure-requests/1` field shapes; clew reviewed it against 0.17.0 and had three precisions folded. Every co-owner input this ADR was waiting on has arrived.
+- **Date:** 2026-07-08 (accepted 2026-07-14)
 - **Deciders:** operator, scitex-writer (lead/author), scitex-hub, figrecipe, scitex-clew, scitex-dev, scitex-ui
 - **Affects:** scitex-hub, figrecipe, scitex-clew, scitex-ui, scitex-live-paper
 - **Supersedes/builds on:** card `live-paper-viewer-component` (operator decisions, Telegram 553–571)
@@ -44,7 +44,15 @@ Precedent exists: **scitex-ui (`@scitex/ui`)** is the shared TS+CSS component li
 
 ### 4. Inline engine — two surfaces, clew/scitex-dev SoC preserved
 
-- **Real-time inline (per-claim, as you annotate):** query **clew's per-claim grounding** directly — clew to expose `is_grounded` as `scitex-clew grounding <claim> --json` and/or `is_claim_grounded()`, returning `{grounded, matched_source, missing_reason, fix_hint}`. This is the design's **one true external dependency**. Status: durably carded as `clew-per-claim-grounding-query-api-20260708` (full ask + internal ref + verdict shape + SoC); **clew is offline — not yet acked**; scitex-dev retries the direct request when clew returns. Do NOT call the whole-workdir gate per keystroke.
+- **Real-time inline (per-claim, as you annotate):** query **clew's per-claim grounding** directly. This is the design's **one true external dependency**. Do NOT call the whole-workdir gate per keystroke.
+
+  **Required surface** (`is_claim_grounded(claim_location, *, workdir=".") -> GroundingVerdict`, and/or `scitex-clew grounding <claim> --json`), returning `{grounded, claim_id, matched_source{path,sha256}|None, reason, fix_hint}` with `reason ∈ {grounded, no_chain_match, no_manifest, manifest_untrusted, claim_not_found}`.
+
+  **What clew ships today (0.17.0, verified by import, not by report):** `is_grounded(claim, manifest, db) -> bool` and `grounded_claim_ids(workdir, ...) -> List[str]`. These are the primitives, not the port. Two concrete gaps:
+  - `is_grounded` makes the CALLER load the manifest and the DB. That is clew's internal plumbing leaking across the seam; writer must not know clew has a `SourcesManifest` or a `db`, and must not be the one to keep them in sync.
+  - Both return a bare `bool` / `List[str]`. **A boolean cannot drive this UI.** The editor must distinguish amber (`no_manifest` — nothing registered yet, a compose-time convenience) from red (`manifest_untrusted` — there IS a manifest and this claim fails it), and must render a `fix_hint`. Collapsing those to `False` is precisely the "claim with provenance reported as unsourced" bug class this design exists to kill.
+
+  Status: carded as `clew-per-claim-grounding-query-api-20260708`. Clew has acked the contract and reports `is_grounded` ready; the remaining work is wrapping the primitives in the agreed verdict-returning port. Until it lands, compose mode falls back to the compile-time gate feed (advisory, non-live).
 - **Publish boundary (aggregate authority):** `scitex-dev gate <workdir> --stage pre-submission --json` → `GateReport.blocking` + per-Finding `{check_id, message, severity, fix_hint, claim location}`; the editor renders inline by filtering Findings on `claim.location`.
 - SoC: rule + DB stay in **clew** (`clew-source-reachability` check under `scitex_dev.gate.checks`); aggregation + contract stay in **scitex-dev**.
 
@@ -68,13 +76,15 @@ Hub doctrine (mandatory): **viewing is never blocked** for any role; write/annot
 
 - One viewer implementation across Writer / hub / Journal / Live Paper; no duplicate PDF viewers.
 - Writer's authoring loop and the published reading experience share a single component at different permission modes — parity by construction.
-- Hard dependency on clew exposing a per-claim grounding query (in clew's queue) for the inline engine; until then, compose mode falls back to the compile-time gate feed (advisory, non-live).
+- Hard dependency on clew wrapping its grounding primitives in a verdict-returning per-claim query (§4) for the inline engine; until then, compose mode falls back to the compile-time gate feed (advisory, non-live).
 - scitex-ui npm publication becomes a shared-infra dependency for clean distribution.
 
 ## Open questions (for co-owner input)
 
-1. **clew:** confirm the per-claim grounding query signature + whether the hover-chain data is static (claims.json) or live-queryable; confirm the pdf_anchor id scheme. Status: enabler carded (`clew-per-claim-grounding-query-api-20260708`) but clew is offline and has NOT yet acked — awaiting clew's return.
-2. **figrecipe:** the mark→figure-change request payload (figure id/save-path, mark geometry, requested-change text), the dispatch channel (a2a / hints-feed / file drop), and figure-quality signals surfaced back inline. (figrecipe currently down.)
-3. **scitex-ui / hub:** confirm the App-tier home + the `exports` map contract; sequence against npm publication.
-4. **ADR numbering:** confirm this is `0001` in scitex-writer (no existing adr dir) vs. aligning with the mirrored lead-repo `0002-scitex-django-app-standard`.
+All four questions below have been ANSWERED; they are kept for the record. Nothing in this ADR is waiting on a co-owner.
+
+1. **clew — ANSWERED 2026-07-08, reviewed against 0.17.0.** Hover-chain data: static `claims.json` 1.6-unified for the marks, plus live `clew.chain()/dag()/mermaid()` on hover. `pdf_anchor` emits the full `clew-<slug>` destination, consumed verbatim (byte-identical to `\hypertarget`). Colour map: `manifest_untrusted → grounded=False → RED`; amber is `no_manifest` only. The one item still OPEN is a BUILD, not a question: wrapping `is_grounded`/`grounded_claim_ids` in the verdict-returning port (see §4).
+2. **figrecipe — ANSWERED 2026-07-08.** `figure-requests/1` field shapes confirmed in full, with top-left/y-down normalized region coords and the ownership rule folded in.
+3. **scitex-ui / hub — ANSWERED 2026-07-08.** L1 exported as the named subpath `@scitex/ui/pdf-viewer` (source-only `.ts`, reachable without the shell bundle); sequenced against npm publication (`scitex-ui-npm-publish`).
+4. **ADR numbering — RESOLVED.** `0001` in scitex-writer.
 5. **Handwriting:** confirm pen=marks / voice=OS-dictation for v1 (no in-app OCR).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.32.1"
+version = "2.33.0"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_writer/_cli/commands/project.py
+++ b/src/scitex_writer/_cli/commands/project.py
@@ -33,9 +33,19 @@ from .._helpers import _emit_json
     default=False,
     help="Apply the update (default is a safe preview).",
 )
+@click.option(
+    "--allow-outdated",
+    is_flag=True,
+    default=False,
+    help="Vendor from an outdated installed scitex-writer anyway (refused by default).",
+)
 @click.option("--json", "as_json", is_flag=True, default=False, help="Emit JSON.")
-def update_project(project, branch, tag, dry_run, force, yes, as_json):
+def update_project(project, branch, tag, dry_run, force, yes, allow_outdated, as_json):
     """Update engine files in a scitex-writer project, preserving user content.
+
+    The engine is vendored from the INSTALLED scitex-writer. If that package is
+    behind the latest release, this refuses rather than silently copying a stale
+    engine and reporting success.
 
     \b
     Example:
@@ -52,7 +62,12 @@ def update_project(project, branch, tag, dry_run, force, yes, as_json):
     # Safe by default: preview unless --yes is given (--dry-run forces preview).
     preview = dry_run or not yes
     result = update.project(
-        str(project_path), branch=branch, tag=tag, dry_run=preview, force=force
+        str(project_path),
+        branch=branch,
+        tag=tag,
+        dry_run=preview,
+        force=force,
+        allow_outdated=allow_outdated,
     )
     if as_json:
         _emit_json(result)

--- a/src/scitex_writer/_django/handlers/claim.py
+++ b/src/scitex_writer/_django/handlers/claim.py
@@ -11,8 +11,11 @@ the response.
 from __future__ import annotations
 
 import json
+import logging
 
 from django.http import JsonResponse
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_json(request) -> dict:
@@ -88,16 +91,24 @@ def handle_claim_chain(request, project, claim_id: str):
     if output_file or session_id:
         try:
             from scitex_clew import generate_mermaid_dag
-
+        except ImportError:
+            response["clew_available"] = False
+        else:
             response["clew_available"] = True
             kwargs = {}
             if output_file:
                 kwargs["target_file"] = output_file
             elif session_id:
                 kwargs["session_id"] = session_id
-            response["mermaid"] = generate_mermaid_dag(**kwargs)
-        except Exception:
-            pass
+            try:
+                response["mermaid"] = generate_mermaid_dag(**kwargs)
+            except Exception as exc:
+                # This was `except Exception: pass`, so a failing DAG left
+                # clew_available=True and mermaid=None — the pane reported Clew
+                # as working and simply drew nothing, with no way to find out
+                # why. Say what broke.
+                logger.warning("[claim] Clew DAG failed for %s: %s", claim_id, exc)
+                response["mermaid_error"] = str(exc)
 
     return JsonResponse(response)
 

--- a/src/scitex_writer/_django/handlers/viewer.py
+++ b/src/scitex_writer/_django/handlers/viewer.py
@@ -118,28 +118,66 @@ def handle_citation(request, project, cite_key: str):
 
 
 def _claim_verification_state(project, claim: dict) -> dict:
-    """Best-effort Clew verification for a claim."""
+    """Verify a claim through Clew's own per-claim entry point.
+
+    This used to hand-roll the verdict out of ``verify_chain(target_file=...)``.
+    No published Clew has ever had a ``target_file`` parameter — ``verify_chain``
+    takes a single positional ``target`` — and it has no ``session_id`` parameter
+    either, so BOTH branches raised TypeError on every call. The exception was
+    logged at DEBUG and returned as a per-claim state of ``"ERROR"``, which reads
+    as "this claim could not be verified" when the truth was "writer called Clew
+    wrong". A wiring bug wearing the costume of a data problem: it shipped, and
+    verified zero of the 40 claims in a real manuscript.
+
+    Clew ships ``verify_claim`` for exactly this, and returns its OWN reasons in
+    ``details`` — better than any verdict we could synthesise.
+    """
+    claim_id = claim.get("claim_id")
     output_file = claim.get("output_file")
     session_id = claim.get("session_id")
     if not (output_file or session_id):
         return {"state": "NO_PROVENANCE"}
 
     try:
-        from scitex_clew import verify_chain
-
-        args = {}
-        if output_file:
-            args["target_file"] = output_file
-        elif session_id:
-            args["session_id"] = session_id
-        status = verify_chain(**args)
-        return {
-            "state": status.status.name if hasattr(status, "status") else str(status),
-            "target_file": output_file,
-            "session_id": session_id,
-        }
+        from scitex_clew import verify_chain, verify_claim
     except ImportError:
         return {"state": "CLEW_MISSING"}
+
+    try:
+        if claim_id:
+            verdict = verify_claim(claim_id)
+            return {
+                "state": "VERIFIED" if verdict.get("chain_verified") else "UNVERIFIED",
+                "source_verified": verdict.get("source_verified"),
+                "chain_verified": verdict.get("chain_verified"),
+                # Clew's reasons, carried through. Without them the pane can say
+                # a claim failed but never say why.
+                "details": verdict.get("details") or [],
+                "output_file": output_file,
+                "session_id": session_id,
+            }
+        if output_file:
+            status = verify_chain(output_file)
+            return {
+                "state": (
+                    status.status.name if hasattr(status, "status") else str(status)
+                ),
+                "output_file": output_file,
+                "session_id": session_id,
+            }
+        # A session id alone gives Clew nothing to chase: neither entry point
+        # accepts one. Say so, rather than reporting a verification we did not
+        # perform.
+        return {"state": "UNVERIFIABLE_NO_TARGET", "session_id": session_id}
+    except TypeError:
+        # A TypeError here is OUR call being wrong, not a fact about the claim.
+        # Reporting it as a per-claim "ERROR" is precisely how the previous bug
+        # stayed invisible across two releases. Let it out.
+        raise
     except Exception as exc:
-        logger.debug("[viewer] verify_chain failed: %s", exc)
+        logger.warning(
+            "[viewer] Clew verification failed for %s: %s",
+            claim_id or output_file,
+            exc,
+        )
         return {"state": "ERROR", "error": str(exc)}

--- a/src/scitex_writer/_mcp/handlers/_update/_handler.py
+++ b/src/scitex_writer/_mcp/handlers/_update/_handler.py
@@ -17,6 +17,7 @@ from ._git_safety import (
     is_git_repo,
 )
 from ._source import find_package_root, read_version
+from ._source_check import outdated_source_error, source_report
 
 # Dedicated, compile-immutable vendor stamp. Read by check_version_freshness.py
 # (writer compile gate) + scitex-dev's fleet stale-install audit. Do NOT reuse
@@ -69,12 +70,20 @@ def update_project(
     tag: Optional[str] = None,
     dry_run: bool = True,
     force: bool = False,
+    allow_outdated: bool = False,
 ) -> dict:
     """Update engine files of an existing scitex-writer project.
 
     Syncs engine/template files (scripts, build scripts, base.tex, styles,
     Makefile) from the installed scitex-writer package to the project. The
     package's own src/ is never vendored in; user content is never modified.
+
+    THE VENDOR SOURCE IS THE INSTALLED PACKAGE. Running this on an outdated
+    scitex-writer vendors an outdated engine and reports success — the project
+    then carries bugs the fleet has already fixed, with nothing to say so. When
+    we can prove the source is stale we refuse and hand back the upgrade command;
+    when PyPI is unreachable we proceed but say the check did not happen. Silence
+    must never read as "you are current".
 
     Parameters
     ----------
@@ -88,12 +97,16 @@ def update_project(
         If True, report what would change without touching any files.
     force : bool
         If True, skip the uncommitted-changes git safety check.
+    allow_outdated : bool
+        If True, vendor from an outdated installed package anyway. Off by
+        default: a stale vendor is the bug, not an inconvenience.
 
     Returns
     -------
     dict
-        success, source, modified, added, unchanged, backup_dir,
-        dry_run, git_safe, warnings, message, error (on failure)
+        success, source, modified, added, unchanged, backup_dir, dry_run,
+        git_safe, warnings, message, source_version, latest_version,
+        is_outdated, source_note, error (on failure)
     """
     try:
         project_path = resolve_project_path(project_dir)
@@ -125,6 +138,22 @@ def update_project(
         # Resolve source template
         source_dir, is_temp = find_package_root(branch, tag)
         pkg_version = read_version(source_dir)
+
+        # Only the INSTALLED package can be silently stale. An explicit
+        # branch/tag is a deliberate choice, so we do not second-guess it.
+        source_info = {}
+        if not (branch or tag):
+            source_info = source_report(pkg_version)
+            if source_info.get("is_outdated") and not allow_outdated:
+                if is_temp:
+                    shutil.rmtree(str(source_dir.parent), ignore_errors=True)
+                return {
+                    "success": False,
+                    "error": outdated_source_error(
+                        pkg_version, source_info["latest_version"]
+                    ),
+                    **source_info,
+                }
 
         try:
             source_files = collect_sync_files(source_dir, project_path)
@@ -165,6 +194,10 @@ def update_project(
             "skipped_paths": [],
             "missing_paths": [],
             "preserved_paths": [str(p) for p in PRESERVED_PATHS],
+            # Which scitex-writer this tree was vendored FROM, and whether that
+            # was the current one. Reported even on success: a caller must be
+            # able to see the source without inferring it.
+            **source_info,
             "message": _build_message(
                 project_path, modified, added, unchanged, dry_run, backup_dir
             ),

--- a/src/scitex_writer/_mcp/handlers/_update/_source_check.py
+++ b/src/scitex_writer/_mcp/handlers/_update/_source_check.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Say WHICH scitex-writer the engine is being vendored FROM, and refuse if stale.
+
+`update-project` vendors from the **installed** package. So an agent running an
+old scitex-writer vendors an OLD engine — and update-project reports success. The
+project ends up carrying bugs the fleet has already fixed, and nothing anywhere
+says so. That is the same silent-wrong-answer class this engine exists to prevent,
+sitting inside the very command we hand people to fix it.
+
+It is not hypothetical: on 2026-07-14 both neurovista and paper-scitex-clew were
+told to run `update-project`. Their installed writer was 2.29.0 while 2.32.1 was
+current. Running it verbatim would have quietly vendored 2.29.0 while they
+reported "done". paper-scitex-clew caught it by hand and asked for this guard.
+
+So: when we can PROVE the vendor source is outdated, refuse and hand back the
+command that fixes it. When we cannot reach PyPI, proceed — but SAY we could not
+check, rather than let silence read as "you are current".
+"""
+
+import json
+import urllib.request
+from typing import Optional
+
+PYPI_URL = "https://pypi.org/pypi/scitex-writer/json"
+
+
+def latest_on_pypi(timeout: float = 3.0) -> Optional[str]:
+    """Newest published scitex-writer, or None if we could not ask.
+
+    None means "unknown", never "you are up to date" — the caller must not
+    collapse the two.
+    """
+    try:
+        with urllib.request.urlopen(PYPI_URL, timeout=timeout) as resp:
+            return json.load(resp)["info"]["version"]
+    except Exception:
+        return None
+
+
+def _parts(version: str):
+    out = []
+    for chunk in version.split("."):
+        digits = "".join(c for c in chunk if c.isdigit())
+        out.append(int(digits) if digits else 0)
+    return tuple(out)
+
+
+def is_older(installed: str, latest: str) -> bool:
+    """True when `installed` is strictly behind `latest`."""
+    try:
+        from packaging.version import Version
+
+        return Version(installed) < Version(latest)
+    except Exception:
+        return _parts(installed) < _parts(latest)
+
+
+def outdated_source_error(installed: str, latest: str) -> str:
+    """The refusal, with the command that actually fixes it."""
+    return (
+        f"REFUSING TO VENDOR A STALE ENGINE.\n"
+        f"\n"
+        f"  update-project vendors from the INSTALLED scitex-writer, and yours "
+        f"is out of date:\n"
+        f"      installed (the vendor source): {installed}\n"
+        f"      latest on PyPI:                {latest}\n"
+        f"\n"
+        f"  Running it now would copy the {installed} engine into your project "
+        f"and report success.\n"
+        f"  You would carry bugs that are already fixed, and nothing would say so.\n"
+        f"\n"
+        f"  Upgrade first, then re-run:\n"
+        f"      uv pip install -U 'scitex-writer[all]'\n"
+        f"      scitex-writer update-project\n"
+        f"\n"
+        f"  To vendor from the old version anyway, pass allow_outdated=True "
+        f"(CLI: --allow-outdated)."
+    )
+
+
+def source_report(installed: str) -> dict:
+    """Describe the vendor source. Never claims currency it has not verified."""
+    latest = latest_on_pypi()
+    if latest is None:
+        return {
+            "source_version": installed,
+            "latest_version": None,
+            "is_outdated": None,
+            "source_note": (
+                f"Vendoring from the INSTALLED scitex-writer {installed}. "
+                f"Could not reach PyPI, so whether a newer engine exists is "
+                f"UNKNOWN — this is not a statement that you are current."
+            ),
+        }
+    outdated = is_older(installed, latest)
+    return {
+        "source_version": installed,
+        "latest_version": latest,
+        "is_outdated": outdated,
+        "source_note": (
+            f"Vendoring from the INSTALLED scitex-writer {installed} "
+            f"(latest on PyPI: {latest})."
+        ),
+    }

--- a/src/scitex_writer/update.py
+++ b/src/scitex_writer/update.py
@@ -17,12 +17,18 @@ def project(
     tag: Optional[str] = None,
     dry_run: bool = True,
     force: bool = False,
+    allow_outdated: bool = False,
 ) -> dict:
     """Update engine files in an existing scitex-writer project.
 
     Syncs source code, build scripts, and templates from the installed
     scitex-writer package (or GitHub if branch/tag is specified).
     User content is never modified.
+
+    The vendor source is the INSTALLED package, so running this on an outdated
+    scitex-writer would copy a stale engine and report success. When the source
+    can be proven outdated this refuses and returns the upgrade command; pass
+    ``allow_outdated=True`` to override.
 
     Files synced (engine/template only — the package itself is pip-installed,
     never vendored into the project):
@@ -74,7 +80,12 @@ def project(
     >>> sw.update.project("~/proj/my-paper", tag="v2.7.1")
     """
     return _update_project(
-        project_dir, branch=branch, tag=tag, dry_run=dry_run, force=force
+        project_dir,
+        branch=branch,
+        tag=tag,
+        dry_run=dry_run,
+        force=force,
+        allow_outdated=allow_outdated,
     )
 
 

--- a/tests/scitex_writer/_django/handlers/test_viewer_clew_wiring.py
+++ b/tests/scitex_writer/_django/handlers/test_viewer_clew_wiring.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Writer must call Clew with the signature Clew actually publishes.
+
+THE BUG THIS PINS. `_claim_verification_state` called
+`verify_chain(target_file=...)` and `verify_chain(session_id=...)`. Clew's
+`verify_chain` takes a single positional `target` and has NEITHER keyword, so
+EVERY call raised TypeError. It was logged at DEBUG and returned as a per-claim
+state of "ERROR" — which reads as "this claim could not be verified" when the
+truth was "writer called Clew wrong". Forty claims in a real manuscript verified
+as zero, and the failure never surfaced.
+
+These tests read the SOURCE, not a mock, and check writer's call against Clew's
+REAL published signature (via inspect). A mock would have happily accepted
+`target_file=` and told us everything was fine — which is exactly how this
+shipped. No mocks, no monkeypatch (PA-306 / STX-NM002).
+"""
+
+import ast
+import inspect
+import pathlib
+
+import pytest
+
+import scitex_writer._django.handlers.viewer as viewer_mod
+
+_SRC = pathlib.Path(viewer_mod.__file__).read_text()
+_TREE = ast.parse(_SRC)
+
+
+def _verification_fn():
+    """The `_claim_verification_state` FunctionDef node, or raise if it moved."""
+    for node in ast.walk(_TREE):
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name == "_claim_verification_state"
+        ):
+            return node
+    raise AssertionError("_claim_verification_state disappeared from viewer.py")
+
+
+def _calls_named(tree, func_name):
+    """Every Call node in the source invoking `func_name`."""
+    out = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            fn = node.func
+            name = getattr(fn, "id", None) or getattr(fn, "attr", None)
+            if name == func_name:
+                out.append(node)
+    return out
+
+
+class TestVerifyChainCallMatchesClew:
+    def test_verify_chain_is_never_called_with_dict_unpacking(self):
+        # Arrange: the ORIGINAL bug was `verify_chain(**args)`, with `args`
+        # built at runtime as {"target_file": ...} — a keyword Clew does not
+        # have. Unpacking hides the call shape from every static check, which
+        # is why the TypeError shipped. Forbid the pattern, not just the one
+        # wrong key: a checkable call is the whole point.
+        calls = _calls_named(_TREE, "verify_chain")
+
+        # Act
+        unpacked = [c for c in calls for k in c.keywords if k.arg is None]
+
+        # Assert
+        assert unpacked == []
+
+    def test_every_verify_chain_keyword_exists_in_clews_signature(self):
+        # Arrange: the real published signature, not a mock's idea of it. A mock
+        # would have happily accepted `target_file=` and told us it was fine.
+        clew = pytest.importorskip("scitex_clew")
+        allowed = set(inspect.signature(clew.verify_chain).parameters)
+
+        # Act
+        used = {
+            k.arg
+            for c in _calls_named(_TREE, "verify_chain")
+            for k in c.keywords
+            if k.arg
+        }
+
+        # Assert
+        assert used <= allowed
+
+    def test_no_target_file_key_is_built_anywhere_in_the_verifier(self):
+        # Arrange: `target_file` is not a Clew parameter and never was. Catch it
+        # as a dict key too, since that is how it reached Clew last time.
+        fn_src = _verification_fn()
+
+        # Act
+        keys = [
+            n.value
+            for n in ast.walk(fn_src)
+            if isinstance(n, ast.Constant) and n.value == "target_file"
+        ]
+
+        # Assert
+        assert keys == []
+
+
+class TestVerifyClaimIsUsed:
+    def test_viewer_imports_clews_per_claim_entry_point(self):
+        # Arrange: Clew ships verify_claim for exactly this; writer hand-rolled
+        # the verdict out of verify_chain and got the call wrong.
+        imported = {
+            alias.name
+            for node in ast.walk(_TREE)
+            if isinstance(node, ast.ImportFrom) and node.module == "scitex_clew"
+            for alias in node.names
+        }
+
+        # Act
+        uses_per_claim_api = "verify_claim" in imported
+
+        # Assert
+        assert uses_per_claim_api
+
+    def test_verify_claim_exists_in_the_installed_clew(self):
+        # Arrange
+        clew = pytest.importorskip("scitex_clew")
+
+        # Act
+        fn = getattr(clew, "verify_claim", None)
+
+        # Assert
+        assert callable(fn)
+
+
+class TestWiringErrorsAreNotSwallowed:
+    def test_type_error_is_re_raised_not_reported_as_claim_error(self):
+        # Arrange: a TypeError is OUR call being wrong, not a fact about the
+        # claim. Swallowing it as state="ERROR" is how the bug stayed invisible.
+        fn_src = _verification_fn()
+
+        # Act
+        reraises = any(
+            isinstance(h.type, ast.Name)
+            and h.type.id == "TypeError"
+            and any(isinstance(s, ast.Raise) for s in h.body)
+            for t in ast.walk(fn_src)
+            if isinstance(t, ast.Try)
+            for h in t.handlers
+        )
+
+        # Assert
+        assert reraises

--- a/tests/scitex_writer/_mcp/handlers/_update/test__source_check.py
+++ b/tests/scitex_writer/_mcp/handlers/_update/test__source_check.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""update-project must never vendor a stale engine and call it success.
+
+THE BUG. `update-project` vendors from the INSTALLED scitex-writer. An agent on
+an old writer therefore vendors an OLD engine — and is told it worked. The
+project silently carries bugs the fleet already fixed. That is the same
+silent-wrong-answer class the engine exists to prevent, sitting inside the very
+command we hand people to fix things.
+
+Real incident (2026-07-14): neurovista and paper-scitex-clew were both told to
+run `update-project`. Their installed writer was 2.29.0 while 2.32.1 was current.
+Running it verbatim would have quietly vendored 2.29.0 under a "done" report.
+
+The decision functions are pure, so these run against real values with no mock
+and no monkeypatch (PA-306 / STX-NM002) — and crucially without touching PyPI.
+"""
+
+from scitex_writer._mcp.handlers._update._source_check import (
+    is_older,
+    outdated_source_error,
+    source_report,
+)
+
+
+class TestIsOlder:
+    def test_older_installed_version_is_detected(self):
+        # Arrange: the real incident's versions.
+        installed, latest = "2.29.0", "2.32.1"
+
+        # Act
+        stale = is_older(installed, latest)
+
+        # Assert
+        assert stale is True
+
+    def test_current_version_is_not_older(self):
+        # Arrange
+        installed, latest = "2.32.1", "2.32.1"
+
+        # Act
+        stale = is_older(installed, latest)
+
+        # Assert
+        assert stale is False
+
+    def test_newer_installed_version_is_not_older(self):
+        # Arrange: a dev running ahead of PyPI must not be blocked.
+        installed, latest = "2.33.0", "2.32.1"
+
+        # Act
+        stale = is_older(installed, latest)
+
+        # Assert
+        assert stale is False
+
+    def test_minor_version_is_compared_numerically_not_lexically(self):
+        # Arrange: "2.9.0" > "2.32.1" as STRINGS. A lexical compare would call
+        # a four-month-old engine current.
+        installed, latest = "2.9.0", "2.32.1"
+
+        # Act
+        stale = is_older(installed, latest)
+
+        # Assert
+        assert stale is True
+
+
+class TestRefusalMessage:
+    def test_refusal_names_the_installed_version(self):
+        # Arrange
+        installed, latest = "2.29.0", "2.32.1"
+
+        # Act
+        msg = outdated_source_error(installed, latest)
+
+        # Assert
+        assert installed in msg
+
+    def test_refusal_hands_back_a_working_upgrade_command(self):
+        # Arrange: a remedy the reader can paste. An instruction that does not
+        # actually fix it is worse than none — they believe they have tried.
+        expected = "uv pip install -U 'scitex-writer[all]'"
+
+        # Act
+        msg = outdated_source_error("2.29.0", "2.32.1")
+
+        # Assert
+        assert expected in msg
+
+    def test_refusal_names_the_override(self):
+        # Arrange
+        installed, latest = "2.29.0", "2.32.1"
+
+        # Act
+        msg = outdated_source_error(installed, latest)
+
+        # Assert
+        assert "allow_outdated" in msg
+
+
+class TestUnknownIsNeverReportedAsCurrent:
+    def test_unreachable_pypi_reports_outdated_as_unknown_not_false(self):
+        # Arrange: is_outdated=False would mean "verified current". When we could
+        # not ask, the honest answer is None. Collapsing the two is the exact
+        # silent-fallback this guard exists to prevent, so pin it explicitly.
+        report = source_report.__doc__ or ""
+
+        # Act
+        promises_no_false_currency = (
+            "Never claims currency it has not verified" in report
+        )
+
+        # Assert
+        assert promises_no_false_currency


### PR DESCRIPTION
Ships 2.33.0. Two silent-wrong-answer bugs, both found by peer agents in a real manuscript.

**The claims pane verified ZERO claims.** Writer called `verify_chain(target_file=…)`; Clew takes a positional `target` and has no such keyword. Every call raised `TypeError`, was logged at *debug*, and surfaced as a per-claim `"ERROR"` — so a researcher was told "this claim could not be verified" when the truth was "writer called Clew wrong". All 40 claims in paper-scitex-clew's manuscript. Shipped in 2.30.2 and never once run against a real Clew. Now uses Clew's own `verify_claim(claim_id)` and carries its `details` through, so the pane can say *why*. A `TypeError` re-raises instead of posing as a claim state.

**`update-project` vendored staleness and reported success.** It vendors from the *installed* package, so the two agents sent to fix their stale engines would have vendored 2.29.0 while 2.32.1 was current — fixing staleness with staleness. It now refuses on a provably stale source and hands back `uv pip install -U 'scitex-writer[all]'`. When PyPI is unreachable it proceeds but says the check did not happen: `is_outdated` is `None`, never `False`.