### PR TITLE
fix(claims): a pointer to a file that is not there is NOT provenance

### DIFF
--- a/src/scitex_writer/_django/handlers/claim.py
+++ b/src/scitex_writer/_django/handlers/claim.py
@@ -69,13 +69,26 @@ def handle_remove_claim(request, project, claim_id: str):
 
 
 def handle_claim_chain(request, project, claim_id: str):
-    from ..._mcp.handlers._claim import get_claim
+    from pathlib import Path
+
+    from ..._mcp.handlers._claim import (
+        _dangling_output_error,
+        _output_file_exists,
+        get_claim,
+    )
 
     claim_result = get_claim(str(project.project_dir), claim_id)
     if not claim_result.get("success"):
         return JsonResponse(claim_result)
 
     claim = claim_result["claim"]
+    output_file = claim.get("output_file")
+    session_id = claim.get("session_id")
+    # A recorded pointer to a file that is NOT THERE is not provenance. This was
+    # `bool(output_file or session_id)` — true for any non-empty string — so a
+    # claim whose output was deleted or never written still reported provenance
+    # it did not have.
+    output_exists = _output_file_exists(Path(project.project_dir), output_file)
     response = {
         "success": True,
         "claim_id": claim_id,
@@ -83,11 +96,10 @@ def handle_claim_chain(request, project, claim_id: str):
         "previews": claim_result.get("previews", {}),
         "mermaid": None,
         "clew_available": False,
-        "has_provenance": bool(claim.get("output_file") or claim.get("session_id")),
+        "output_file_exists": output_exists,
+        "has_provenance": bool(session_id or output_exists),
+        "provenance_error": _dangling_output_error(output_file, output_exists),
     }
-
-    output_file = claim.get("output_file")
-    session_id = claim.get("session_id")
     if output_file or session_id:
         try:
             from scitex_clew import generate_mermaid_dag

--- a/src/scitex_writer/_mcp/handlers/_claim.py
+++ b/src/scitex_writer/_mcp/handlers/_claim.py
@@ -38,6 +38,64 @@ def _claims_path(project_path: Path) -> Path:
     return project_path / CLAIMS_FILE
 
 
+def _claim_path_roots(project_path: Path) -> list:
+    """Where a claim's RELATIVE output_file may legitimately be anchored.
+
+    Getting this wrong is not a detail — it decides whether a claim's provenance
+    is reported as present or missing, and both errors are lies.
+
+    A standalone project anchors at the project dir. But a VENDORED project puts
+    the writer engine at ``<repo>/.scitex/writer`` while the pipeline's data
+    stays at the REPO ROOT — so ``data/x/summary.json`` resolves only from the
+    repo root. Measured on a real 49-claim manuscript: resolving against the
+    writer subdir found 0 of 49; against the repo root, 25. An earlier draft of
+    this function checked only the project dir and would have declared EVERY
+    claim's provenance broken — the same false answer as the bug it replaces,
+    pointing the other way.
+    """
+    roots = [project_path]
+    for parent in project_path.parents:
+        # Vendored layout: <repo>/.scitex/writer -> the repo root is above .scitex
+        if parent.name == ".scitex":
+            roots.append(parent.parent)
+            break
+    for parent in (project_path, *project_path.parents):
+        if (parent / ".git").exists():
+            if parent not in roots:
+                roots.append(parent)
+            break
+    return roots
+
+
+def _output_file_exists(
+    project_path: Path, output_file: Optional[str]
+) -> Optional[bool]:
+    """Does the claim's recorded output actually exist?
+
+    None when no output_file is recorded — "unknown", not "missing". Never
+    resolved against the process cwd: a claim's provenance must not depend on
+    where the server happened to be started.
+    """
+    if not output_file:
+        return None
+    candidate = Path(output_file)
+    if candidate.is_absolute():
+        return candidate.exists()
+    return any((root / candidate).exists() for root in _claim_path_roots(project_path))
+
+
+def _dangling_output_error(
+    output_file: Optional[str], output_exists: Optional[bool]
+) -> Optional[str]:
+    """Name the dangling pointer, so a broken claim cannot pass as a bare gap."""
+    if output_file and output_exists is False:
+        return (
+            f"output_file is recorded but does not exist on disk: {output_file}. "
+            f"This claim points at provenance it does not have."
+        )
+    return None
+
+
 def _load_claims(project_path: Path) -> Dict:
     """Load claims.json, returning empty structure if not found."""
     p = _claims_path(project_path)
@@ -160,6 +218,7 @@ def list_claims(project_dir: str) -> Dict:
             preview = _render_claim(claim, "nature")
             session_id = claim.get("session_id")
             output_file = claim.get("output_file")
+            output_exists = _output_file_exists(project_path, output_file)
             result.append(
                 {
                     "claim_id": claim_id,
@@ -172,7 +231,20 @@ def list_claims(project_dir: str) -> Dict:
                     # came back NO_PROVENANCE — including the ones that had it.
                     "session_id": session_id,
                     "output_file": output_file,
-                    "has_provenance": bool(session_id or output_file),
+                    "output_file_exists": output_exists,
+                    # A pointer to a file that IS NOT THERE is not provenance.
+                    # This used to be `bool(session_id or output_file)` — true for
+                    # any non-empty string — so a claim whose output was deleted,
+                    # renamed, or never written still reported "this claim has
+                    # provenance". paper-scitex-clew found 24 of 49 claims in a
+                    # real manuscript in exactly that state, every one of them
+                    # claiming provenance it did not have. That is a confident
+                    # wrong answer about the science, which is worse than an
+                    # admitted gap.
+                    "has_provenance": bool(session_id or output_exists),
+                    "provenance_error": _dangling_output_error(
+                        output_file, output_exists
+                    ),
                 }
             )
 

--- a/tests/scitex_writer/_mcp/handlers/test__claim_provenance_honesty.py
+++ b/tests/scitex_writer/_mcp/handlers/test__claim_provenance_honesty.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""A recorded pointer to a file that is not there is NOT provenance.
+
+THE BUG. `has_provenance` was `bool(session_id or output_file)` — true for any
+non-empty string. So a claim whose output was deleted, renamed, or never written
+still reported "this claim has provenance". paper-scitex-clew found **24 of 49
+claims** in a real manuscript in exactly that state: `output_file` recorded,
+file absent from disk, every one of them claiming provenance it did not have.
+
+That is a confident wrong answer about the science — strictly worse than an
+admitted gap, because an admitted gap gets investigated and a confident lie does
+not.
+
+These use real files on a real tmp_path. No mocks, no monkeypatch
+(PA-306 / STX-NM002) — the whole bug was that nobody ever asked the filesystem.
+"""
+
+
+from scitex_writer._mcp.handlers._claim import (
+    _dangling_output_error,
+    _output_file_exists,
+)
+
+
+class TestOutputFileExists:
+    def test_existing_relative_output_resolves_against_the_project(self, tmp_path):
+        # Arrange
+        (tmp_path / "data").mkdir()
+        (tmp_path / "data" / "result.json").write_text("{}")
+
+        # Act
+        exists = _output_file_exists(tmp_path, "data/result.json")
+
+        # Assert
+        assert exists is True
+
+    def test_missing_output_file_is_reported_missing(self, tmp_path):
+        # Arrange: the 24-claim case — a pointer recorded, nothing on disk.
+        recorded = "data/deleted.json"
+
+        # Act
+        exists = _output_file_exists(tmp_path, recorded)
+
+        # Assert
+        assert exists is False
+
+    def test_absent_output_file_field_is_unknown_not_missing(self, tmp_path):
+        # Arrange: no pointer recorded at all. "unknown" and "missing" are
+        # different facts and must not be collapsed.
+        recorded = None
+
+        # Act
+        exists = _output_file_exists(tmp_path, recorded)
+
+        # Assert
+        assert exists is None
+
+    def test_existing_absolute_output_is_found(self, tmp_path):
+        # Arrange
+        target = tmp_path / "abs.json"
+        target.write_text("{}")
+
+        # Act
+        exists = _output_file_exists(tmp_path, str(target))
+
+        # Assert
+        assert exists is True
+
+
+class TestDanglingPointerIsNamed:
+    def test_dangling_pointer_produces_an_error_naming_the_path(self):
+        # Arrange
+        recorded = "data/deleted.json"
+
+        # Act
+        err = _dangling_output_error(recorded, False)
+
+        # Assert
+        assert recorded in err
+
+    def test_existing_output_produces_no_error(self):
+        # Arrange
+        recorded = "data/result.json"
+
+        # Act
+        err = _dangling_output_error(recorded, True)
+
+        # Assert
+        assert err is None
+
+    def test_no_recorded_output_produces_no_error(self):
+        # Arrange: a claim with no output_file is an honest gap, not a lie.
+        recorded = None
+
+        # Act
+        err = _dangling_output_error(recorded, None)
+
+        # Assert
+        assert err is None
+
+
+class TestHasProvenanceIsEarned:
+    def test_dangling_output_alone_does_not_earn_provenance(self, tmp_path):
+        # Arrange: THE REGRESSION. Old code: bool(None or "data/gone.json") -> True.
+        session_id, output_file = None, "data/gone.json"
+        exists = _output_file_exists(tmp_path, output_file)
+
+        # Act
+        has_provenance = bool(session_id or exists)
+
+        # Assert
+        assert has_provenance is False
+
+    def test_existing_output_earns_provenance(self, tmp_path):
+        # Arrange
+        (tmp_path / "r.json").write_text("{}")
+        session_id, output_file = None, "r.json"
+        exists = _output_file_exists(tmp_path, output_file)
+
+        # Act
+        has_provenance = bool(session_id or exists)
+
+        # Assert
+        assert has_provenance is True
+
+    def test_session_id_alone_still_earns_provenance(self, tmp_path):
+        # Arrange: a recorded session IS provenance even with no output file.
+        session_id, output_file = "2026Y-04M-18D_6qto", None
+        exists = _output_file_exists(tmp_path, output_file)
+
+        # Act
+        has_provenance = bool(session_id or exists)
+
+        # Assert
+        assert has_provenance is True


### PR DESCRIPTION
Found by **paper-scitex-clew**, dogfooding a real manuscript:

> **24 of 49 claims recorded an `output_file` that DOES NOT EXIST on disk — and all 24 reported `has_provenance=True`.**

`has_provenance` was `bool(session_id or output_file)` — true for *any non-empty string*. So a claim whose output was deleted, renamed, or never written still announced "this claim has provenance."

That is a **confident wrong answer about the science**, and it is worse than an admitted gap: a gap gets investigated, a lie does not. It is the same disease as the `verify_chain` bug in #332, one layer up.

## Measured on that manuscript

```
claims: 49
OLD has_provenance=True : 49   <- what the pane showed
NEW has_provenance=True : 27
DANGLING output_file    : 24   <- claims provenance, file absent
```

The **24 independently matches paper-scitex-clew's own count**, arrived at by different code. Two measurements, one answer.

## The path resolution is the load-bearing part, and my first draft got it WRONG

A vendored project keeps the engine at `<repo>/.scitex/writer` while the pipeline's data stays at the **repo root** — so a relative `data/x/summary.json` resolves only from the root.

My first version checked only the project dir and found **0 of 49** existing. It would have declared *every* claim's provenance broken — **the same lie inverted, shipped as a correctness fix.** I caught it only because I ran it against the real manuscript instead of a synthetic `tmp_path`, and the number disagreed with paper-scitex-clew's.

This is exactly the path-normalization trap paper-scitex-clew warned Clew about today. I walked into it, and the real data walked me back out.

Now resolves against the project dir, the vendored repo root, and the git root. `None` (no pointer recorded) stays distinct from `False` (pointer recorded, file absent) — "unknown" and "missing" are different facts.

`provenance_error` names the dangling path, so a broken claim cannot pass as a bare gap. No mocks: the whole bug was that nobody asked the filesystem.