### PR TITLE
release: scitex-writer 2.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.34.0] - 2026-07-14
+
+### Fixed
+- **A pointer to a file that is not there is NOT provenance.** `has_provenance` was `bool(session_id or output_file)` — true for *any non-empty string*. So a claim whose output was deleted, renamed, or never written still announced "this claim has provenance". paper-scitex-clew found it by dogfooding a real manuscript: **24 of 49 claims recorded an `output_file` that does not exist on disk, and all 24 reported `has_provenance=True`.** A confident wrong answer about the science, which is worse than an admitted gap — a gap gets investigated, a lie does not.
+
+  Measured on that manuscript, the pane claimed provenance for **49 of 49**. The truth is **27**, with **24 dangling**. The 24 independently matches paper-scitex-clew's own count, reached by different code.
+
+  `provenance_error` now names the dangling path, so a broken claim cannot pass as a bare gap, and `output_file_exists` distinguishes *unknown* (no pointer recorded) from *missing* (pointer recorded, file absent) — different facts that must not be collapsed.
+
+  **The path resolution is the load-bearing part**, and the first draft of this fix got it wrong in the opposite direction: a vendored project keeps the engine at `<repo>/.scitex/writer` while the pipeline's data stays at the **repo root**, so a relative `data/x/summary.json` resolves only from the root. Checking just the project dir found **0 of 49** and would have declared every claim broken — the same lie, inverted, shipped as a correctness fix. It was caught only by running against the real manuscript rather than a synthetic fixture. Paths now resolve against the project dir, the vendored repo root, and the git root.
+
+### Changed
+- **ADR 0001 §4: the grounding verdict is a `Dict`, not an importable `GroundingVerdict`.** The ADR named a type scitex-clew does not export, so a reader following the contract would write `from scitex_clew import GroundingVerdict` and get an `ImportError`. A contract that names a type nobody ships is the same defect as calling a function with a keyword it does not have — the bug that made the claims pane verify zero claims in 2.30.2. Corrected after verifying Clew's real surface by import.
+
 ## [2.33.0] - 2026-07-14
 
 ### Fixed

--- a/docs/adr/0001-interactive-paper-editor.md
+++ b/docs/adr/0001-interactive-paper-editor.md
@@ -46,7 +46,9 @@ Precedent exists: **scitex-ui (`@scitex/ui`)** is the shared TS+CSS component li
 
 - **Real-time inline (per-claim, as you annotate):** query **clew's per-claim grounding** directly. This is the design's **one true external dependency**. Do NOT call the whole-workdir gate per keystroke.
 
-  **Required surface** (`is_claim_grounded(claim_location, *, workdir=".") -> GroundingVerdict`, and/or `scitex-clew grounding <claim> --json`), returning `{grounded, claim_id, matched_source{path,sha256}|None, reason, fix_hint}` with `reason ∈ {grounded, no_chain_match, no_manifest, manifest_untrusted, claim_not_found}`.
+  **Required surface** (`is_claim_grounded(claim_location, *, workdir=".") -> Dict`, and/or `scitex-clew grounding <claim> --json`), returning `{grounded, claim_id, matched_source{path,sha256}|None, reason, fix_hint}` with `reason ∈ scitex_clew.GROUNDING_REASONS` = `{grounded, no_chain_match, no_manifest, manifest_untrusted, claim_not_found}`.
+
+  The return is a plain **`Dict`**, not an importable type. This ADR previously wrote it as `-> GroundingVerdict`, which named a symbol Clew does not export — so a reader following the contract would write `from scitex_clew import GroundingVerdict` and get an ImportError. A contract that names a type nobody ships is the same trap as calling a function with a keyword it does not have; corrected here after verifying the real surface by import.
 
   **What clew ships today (0.17.0, verified by import, not by report):** `is_grounded(claim, manifest, db) -> bool` and `grounded_claim_ids(workdir, ...) -> List[str]`. These are the primitives, not the port. Two concrete gaps:
   - `is_grounded` makes the CALLER load the manifest and the DB. That is clew's internal plumbing leaking across the seam; writer must not know clew has a `SourcesManifest` or a `db`, and must not be the one to keep them in sync.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.33.0"
+version = "2.34.0"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_writer/_django/handlers/claim.py
+++ b/src/scitex_writer/_django/handlers/claim.py
@@ -69,13 +69,26 @@ def handle_remove_claim(request, project, claim_id: str):
 
 
 def handle_claim_chain(request, project, claim_id: str):
-    from ..._mcp.handlers._claim import get_claim
+    from pathlib import Path
+
+    from ..._mcp.handlers._claim import (
+        _dangling_output_error,
+        _output_file_exists,
+        get_claim,
+    )
 
     claim_result = get_claim(str(project.project_dir), claim_id)
     if not claim_result.get("success"):
         return JsonResponse(claim_result)
 
     claim = claim_result["claim"]
+    output_file = claim.get("output_file")
+    session_id = claim.get("session_id")
+    # A recorded pointer to a file that is NOT THERE is not provenance. This was
+    # `bool(output_file or session_id)` — true for any non-empty string — so a
+    # claim whose output was deleted or never written still reported provenance
+    # it did not have.
+    output_exists = _output_file_exists(Path(project.project_dir), output_file)
     response = {
         "success": True,
         "claim_id": claim_id,
@@ -83,11 +96,10 @@ def handle_claim_chain(request, project, claim_id: str):
         "previews": claim_result.get("previews", {}),
         "mermaid": None,
         "clew_available": False,
-        "has_provenance": bool(claim.get("output_file") or claim.get("session_id")),
+        "output_file_exists": output_exists,
+        "has_provenance": bool(session_id or output_exists),
+        "provenance_error": _dangling_output_error(output_file, output_exists),
     }
-
-    output_file = claim.get("output_file")
-    session_id = claim.get("session_id")
     if output_file or session_id:
         try:
             from scitex_clew import generate_mermaid_dag

--- a/src/scitex_writer/_mcp/handlers/_claim.py
+++ b/src/scitex_writer/_mcp/handlers/_claim.py
@@ -38,6 +38,64 @@ def _claims_path(project_path: Path) -> Path:
     return project_path / CLAIMS_FILE
 
 
+def _claim_path_roots(project_path: Path) -> list:
+    """Where a claim's RELATIVE output_file may legitimately be anchored.
+
+    Getting this wrong is not a detail — it decides whether a claim's provenance
+    is reported as present or missing, and both errors are lies.
+
+    A standalone project anchors at the project dir. But a VENDORED project puts
+    the writer engine at ``<repo>/.scitex/writer`` while the pipeline's data
+    stays at the REPO ROOT — so ``data/x/summary.json`` resolves only from the
+    repo root. Measured on a real 49-claim manuscript: resolving against the
+    writer subdir found 0 of 49; against the repo root, 25. An earlier draft of
+    this function checked only the project dir and would have declared EVERY
+    claim's provenance broken — the same false answer as the bug it replaces,
+    pointing the other way.
+    """
+    roots = [project_path]
+    for parent in project_path.parents:
+        # Vendored layout: <repo>/.scitex/writer -> the repo root is above .scitex
+        if parent.name == ".scitex":
+            roots.append(parent.parent)
+            break
+    for parent in (project_path, *project_path.parents):
+        if (parent / ".git").exists():
+            if parent not in roots:
+                roots.append(parent)
+            break
+    return roots
+
+
+def _output_file_exists(
+    project_path: Path, output_file: Optional[str]
+) -> Optional[bool]:
+    """Does the claim's recorded output actually exist?
+
+    None when no output_file is recorded — "unknown", not "missing". Never
+    resolved against the process cwd: a claim's provenance must not depend on
+    where the server happened to be started.
+    """
+    if not output_file:
+        return None
+    candidate = Path(output_file)
+    if candidate.is_absolute():
+        return candidate.exists()
+    return any((root / candidate).exists() for root in _claim_path_roots(project_path))
+
+
+def _dangling_output_error(
+    output_file: Optional[str], output_exists: Optional[bool]
+) -> Optional[str]:
+    """Name the dangling pointer, so a broken claim cannot pass as a bare gap."""
+    if output_file and output_exists is False:
+        return (
+            f"output_file is recorded but does not exist on disk: {output_file}. "
+            f"This claim points at provenance it does not have."
+        )
+    return None
+
+
 def _load_claims(project_path: Path) -> Dict:
     """Load claims.json, returning empty structure if not found."""
     p = _claims_path(project_path)
@@ -160,6 +218,7 @@ def list_claims(project_dir: str) -> Dict:
             preview = _render_claim(claim, "nature")
             session_id = claim.get("session_id")
             output_file = claim.get("output_file")
+            output_exists = _output_file_exists(project_path, output_file)
             result.append(
                 {
                     "claim_id": claim_id,
@@ -172,7 +231,20 @@ def list_claims(project_dir: str) -> Dict:
                     # came back NO_PROVENANCE — including the ones that had it.
                     "session_id": session_id,
                     "output_file": output_file,
-                    "has_provenance": bool(session_id or output_file),
+                    "output_file_exists": output_exists,
+                    # A pointer to a file that IS NOT THERE is not provenance.
+                    # This used to be `bool(session_id or output_file)` — true for
+                    # any non-empty string — so a claim whose output was deleted,
+                    # renamed, or never written still reported "this claim has
+                    # provenance". paper-scitex-clew found 24 of 49 claims in a
+                    # real manuscript in exactly that state, every one of them
+                    # claiming provenance it did not have. That is a confident
+                    # wrong answer about the science, which is worse than an
+                    # admitted gap.
+                    "has_provenance": bool(session_id or output_exists),
+                    "provenance_error": _dangling_output_error(
+                        output_file, output_exists
+                    ),
                 }
             )
 

--- a/tests/scitex_writer/_mcp/handlers/test__claim_provenance_honesty.py
+++ b/tests/scitex_writer/_mcp/handlers/test__claim_provenance_honesty.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""A recorded pointer to a file that is not there is NOT provenance.
+
+THE BUG. `has_provenance` was `bool(session_id or output_file)` — true for any
+non-empty string. So a claim whose output was deleted, renamed, or never written
+still reported "this claim has provenance". paper-scitex-clew found **24 of 49
+claims** in a real manuscript in exactly that state: `output_file` recorded,
+file absent from disk, every one of them claiming provenance it did not have.
+
+That is a confident wrong answer about the science — strictly worse than an
+admitted gap, because an admitted gap gets investigated and a confident lie does
+not.
+
+These use real files on a real tmp_path. No mocks, no monkeypatch
+(PA-306 / STX-NM002) — the whole bug was that nobody ever asked the filesystem.
+"""
+
+
+from scitex_writer._mcp.handlers._claim import (
+    _dangling_output_error,
+    _output_file_exists,
+)
+
+
+class TestOutputFileExists:
+    def test_existing_relative_output_resolves_against_the_project(self, tmp_path):
+        # Arrange
+        (tmp_path / "data").mkdir()
+        (tmp_path / "data" / "result.json").write_text("{}")
+
+        # Act
+        exists = _output_file_exists(tmp_path, "data/result.json")
+
+        # Assert
+        assert exists is True
+
+    def test_missing_output_file_is_reported_missing(self, tmp_path):
+        # Arrange: the 24-claim case — a pointer recorded, nothing on disk.
+        recorded = "data/deleted.json"
+
+        # Act
+        exists = _output_file_exists(tmp_path, recorded)
+
+        # Assert
+        assert exists is False
+
+    def test_absent_output_file_field_is_unknown_not_missing(self, tmp_path):
+        # Arrange: no pointer recorded at all. "unknown" and "missing" are
+        # different facts and must not be collapsed.
+        recorded = None
+
+        # Act
+        exists = _output_file_exists(tmp_path, recorded)
+
+        # Assert
+        assert exists is None
+
+    def test_existing_absolute_output_is_found(self, tmp_path):
+        # Arrange
+        target = tmp_path / "abs.json"
+        target.write_text("{}")
+
+        # Act
+        exists = _output_file_exists(tmp_path, str(target))
+
+        # Assert
+        assert exists is True
+
+
+class TestDanglingPointerIsNamed:
+    def test_dangling_pointer_produces_an_error_naming_the_path(self):
+        # Arrange
+        recorded = "data/deleted.json"
+
+        # Act
+        err = _dangling_output_error(recorded, False)
+
+        # Assert
+        assert recorded in err
+
+    def test_existing_output_produces_no_error(self):
+        # Arrange
+        recorded = "data/result.json"
+
+        # Act
+        err = _dangling_output_error(recorded, True)
+
+        # Assert
+        assert err is None
+
+    def test_no_recorded_output_produces_no_error(self):
+        # Arrange: a claim with no output_file is an honest gap, not a lie.
+        recorded = None
+
+        # Act
+        err = _dangling_output_error(recorded, None)
+
+        # Assert
+        assert err is None
+
+
+class TestHasProvenanceIsEarned:
+    def test_dangling_output_alone_does_not_earn_provenance(self, tmp_path):
+        # Arrange: THE REGRESSION. Old code: bool(None or "data/gone.json") -> True.
+        session_id, output_file = None, "data/gone.json"
+        exists = _output_file_exists(tmp_path, output_file)
+
+        # Act
+        has_provenance = bool(session_id or exists)
+
+        # Assert
+        assert has_provenance is False
+
+    def test_existing_output_earns_provenance(self, tmp_path):
+        # Arrange
+        (tmp_path / "r.json").write_text("{}")
+        session_id, output_file = None, "r.json"
+        exists = _output_file_exists(tmp_path, output_file)
+
+        # Act
+        has_provenance = bool(session_id or exists)
+
+        # Assert
+        assert has_provenance is True
+
+    def test_session_id_alone_still_earns_provenance(self, tmp_path):
+        # Arrange: a recorded session IS provenance even with no output file.
+        session_id, output_file = "2026Y-04M-18D_6qto", None
+        exists = _output_file_exists(tmp_path, output_file)
+
+        # Act
+        has_provenance = bool(session_id or exists)
+
+        # Assert
+        assert has_provenance is True


### PR DESCRIPTION
Ships 2.34.0.

**A pointer to a file that is not there is NOT provenance.** `has_provenance` was `bool(session_id or output_file)` — true for any non-empty string. paper-scitex-clew found **24 of 49 claims** in a real manuscript recording an `output_file` that does not exist on disk, every one reporting `has_provenance=True`. A confident wrong answer about the science.

The pane claimed provenance for 49/49; the truth is 27, with 24 dangling — independently matching their count.

Also corrects ADR 0001 §4, which named a `GroundingVerdict` type scitex-clew does not export.