### PR TITLE
chore(release): 2.35.0 — clew owns its own manuscript hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.35.0] - 2026-07-14
+
+### Changed
+- **Clew owns its own manuscript hints; writer stops synthesising them.** scitex-clew 0.18.0 ships `export_manuscript_hints` (verified from the published wheel, and confirmed installable on the PyPI simple index — the JSON API lags). Writer used to read clew's ledger directly and emit `scitex-clew`-labelled hints as an interim stand-in. It no longer does: `WRITER_SOURCES` drops `"scitex-clew"`, because merge-by-source *replaces* the sources a producer claims — so writer continuing to claim it would clobber clew's real entries on every compile.
+
+  **The dangerous half is the silent one.** Dropping the interim producer would make projects pinned to an *older* clew simply lose their provenance hints — the pane goes quiet, with nothing to say why. That silent disappearance is exactly the failure this feed exists to surface. So writer now emits a **warning under its own `scitex-writer` source** when clew is installed but predates 0.18.0, naming the version and handing back `uv pip install -U scitex-clew`. Clew being *absent* stays silent — an optional peer with nothing to say is an honest nothing, not a missing something.
+
+  `hints_from_claims` is retired (its docstring now says so, loudly — re-wiring it would clobber clew's entries) but not yet deleted; its tests still document the severity mapping. Removal is tracked separately.
+
 ## [2.34.0] - 2026-07-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.34.0"
+version = "2.35.0"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Ships #341.

scitex-clew 0.18.0 ships `export_manuscript_hints` (verified from the **published wheel**, confirmed installable on the **simple index**). So `WRITER_SOURCES` drops `"scitex-clew"` — merge-by-source *replaces* what a producer claims, so writer continuing to claim it would clobber clew's real entries every compile.

**The dangerous half is silent:** dropping the interim producer would make projects on an *older* clew lose provenance hints, pane going quiet with no explanation. So writer now warns under its own source when clew is too old, naming the version and the upgrade command. Clew *absent* stays silent — an honest nothing.

Verified against the real clew 0.17.0 in-container: the warning fires. `hints_from_claims` retired (docstring says so) but not deleted; its tests document the severity map.