### PR TITLE
feat(compile): clew COVERAGE gate — the manuscript's claims must be clew's grounded claims

### DIFF
--- a/scripts/python/check_clew_completeness.py
+++ b/scripts/python/check_clew_completeness.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ROLE: engine-vendored — DO NOT edit here. `scitex-writer update-project`
+# overwrites this file on every re-vendor; fix it upstream in the
+# scitex-writer package instead (local edits are lost, and update-project
+# may set it read-only in the consumer workspace after vendoring).
+# File: scripts/python/check_clew_completeness.py
+# Purpose: Pre-compile COVERAGE gate — assert that the claims the MANUSCRIPT
+#          renders are the claims clew has GROUNDED. Its sibling
+#          check_clew_verify.py asks "are the grounded claims still valid
+#          against their sources?"; this asks the question that one cannot:
+#          "did the gate look at the manuscript AT ALL?".
+#
+# WHY THIS EXISTS. check_clew_verify delegates to `clew verify`, which reports
+# a verdict over CLEW'S STORE. So it can pass having checked a claim set that is
+# DISJOINT from what the PDF renders — a green gate certifying a paper it never
+# looked at. Measured on a real manuscript (paper-scitex-clew): clew's store had
+# 1 claim; the manuscript rendered 83; the intersection was 0. "0/1 verified"
+# reads like one near-miss; it MEANS "I have never seen your manuscript". A
+# verdict without a denominator taken from the manuscript is not a verdict.
+# (Reported as writer-clew-gate-verifies-disjoint-claimset, Defect A.)
+#
+# HOW. The manuscript claim set = the raw \vclaim{...} arguments the paper cites
+# + the 00_shared/claims.json keys. The join key is the RAW claim_id, no
+# transform on either side (confirmed with scitex-clew: claim_id is clew's
+# identity; the sanitized macro name is writer's rendering plumbing, not the
+# join key). We hand that set to `clew gate-completeness --submission <identity
+# mapping> --json`, which checks it against clew's grounded claim_ids and returns
+# {ok, grounded, missing, orphan}. `missing` = manuscript claims clew has NOT
+# grounded = uncertified values in the PDF = the coverage gap we hard-fail on.
+#
+# `orphan` (grounded but never cited) does NOT reduce coverage and is reported
+# as advisory, not fatal — a registered claim the paper does not use is
+# housekeeping, not a wrong value in the manuscript.
+#
+# CLI-only, like check_clew_verify: shells the clew binary, never imports
+# scitex_clew, so it works with just "clew on PATH".
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _severity import resolve_level  # noqa: E402
+
+# Reuse the sibling gate's helpers so research-default, clew discovery, and the
+# require_claims knob can never drift between the two provenance gates.
+from check_clew_verify import (  # noqa: E402
+    _find_clew,
+    _is_research_project,
+    resolve_require_claims,
+)
+
+GREEN = "\033[0;32m"
+YELLOW = "\033[1;33m"
+RED = "\033[0;31m"
+DIM = "\033[0;90m"
+BOLD = "\033[1m"
+NC = "\033[0m"
+
+PASS_COUNT = 0
+WARN_COUNT = 0
+FAIL_COUNT = 0
+
+_VCLAIM = re.compile(r"\\vclaim(?:\[[^\]]*\])?\{([^}]+)\}")
+
+
+def log_pass(msg):
+    global PASS_COUNT
+    print(f"  {GREEN}[PASS]{NC} {msg}")
+    PASS_COUNT += 1
+
+
+def log_warn(msg):
+    global WARN_COUNT
+    print(f"  {YELLOW}[WARN]{NC} {msg}")
+    WARN_COUNT += 1
+
+
+def log_fail(msg):
+    global FAIL_COUNT
+    print(f"  {RED}[FAIL]{NC} {msg}")
+    FAIL_COUNT += 1
+
+
+def log_detail(msg):
+    print(f"    {DIM}{msg}{NC}")
+
+
+def _collect_tex_files(doc_dir):
+    skip = re.compile(r"_v\d+\.tex$|_diff\.tex$")
+    files = []
+    content_dir = doc_dir / "contents"
+    if content_dir.exists():
+        for f in content_dir.glob("*.tex"):
+            if not skip.search(f.name):
+                files.append(f)
+        for subdir in ["figures/caption_and_media", "tables/caption_and_media"]:
+            d = content_dir / subdir
+            if d.exists():
+                files.extend(d.glob("*.tex"))
+    base = doc_dir / "base.tex"
+    if base.exists():
+        files.append(base)
+    return list(set(files))
+
+
+def manuscript_claim_set(project_dir):
+    """Every claim the manuscript RENDERS: raw \\vclaim{...} args + claims.json
+    keys. Raw, no sanitize — this is the join key clew reconciles on."""
+    ids = set()
+    for doc in ("01_manuscript", "02_supplementary", "03_revision"):
+        d = project_dir / doc
+        if not d.exists():
+            continue
+        for f in _collect_tex_files(d):
+            text = f.read_text(encoding="utf-8", errors="replace")
+            for line in text.splitlines():
+                stripped = line.split("%")[0] if "%" in line else line
+                for m in _VCLAIM.finditer(stripped):
+                    k = m.group(1).strip()
+                    if k and not k.startswith("#"):
+                        ids.add(k)
+    claims_json = project_dir / "00_shared" / "claims.json"
+    if claims_json.exists():
+        try:
+            data = json.loads(claims_json.read_text(encoding="utf-8"))
+            claims = data.get("claims", {})
+            if isinstance(claims, dict):
+                ids.update(claims.keys())
+            else:
+                ids.update(
+                    c.get("claim_id") or c.get("id")
+                    for c in claims
+                    if isinstance(c, dict) and (c.get("claim_id") or c.get("id"))
+                )
+        except Exception:
+            pass
+    return {i for i in ids if i}
+
+
+def _resolve_clew_workdir(project_dir):
+    """Where clew's CANONICAL DB lives, which is NOT always project_dir.
+
+    A vendored project keeps the manuscript at <repo>/.scitex/writer while clew's
+    canonical store is <repo>/.scitex/clew/runtime/clew.db (the fleet
+    runtime-state-DB layout). Pointing `clew gate-completeness --workdir` at the
+    writer subdir resolves a DIFFERENT (or nested, stale) clew DB and reports a
+    WRONG coverage denominator — measured on a real project that carried two
+    clew DBs of different contents (0 vs ~30 grounded). A coverage gate that
+    reconciles against the wrong DB is the same silent-wrong-answer it exists to
+    catch, so resolve the canonical store deterministically: walk up from
+    project_dir to the nearest ancestor that has `.scitex/clew`, else fall back
+    to project_dir.
+    """
+    for d in (project_dir, *project_dir.parents):
+        if (d / ".scitex" / "clew").is_dir():
+            return d
+    return project_dir
+
+
+def _run_gate_completeness(clew_bin, project_dir, claim_ids):
+    """Shell `clew gate-completeness` with an IDENTITY submission over the
+    manuscript claim set. Returns (exit_code, parsed_json_or_None, raw_output)."""
+    submission = {cid: cid for cid in claim_ids}
+    tmp = Path(tempfile.mkstemp(suffix=".json", prefix="writer-coverage-")[1])
+    tmp.write_text(json.dumps(submission))
+    try:
+        proc = subprocess.run(
+            [
+                clew_bin,
+                "gate-completeness",
+                "--submission",
+                str(tmp),
+                "--workdir",
+                str(_resolve_clew_workdir(project_dir)),
+                "--json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        return 124, None, "clew gate-completeness timed out after 120s"
+    except OSError as exc:
+        return 125, None, f"could not execute clew: {exc}"
+    finally:
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+    raw = (proc.stdout or "") + (proc.stderr or "")
+    try:
+        parsed = json.loads(proc.stdout)
+    except Exception:
+        parsed = None
+    return proc.returncode, parsed, raw.strip()
+
+
+def main():
+    global FAIL_COUNT
+
+    parser = argparse.ArgumentParser(
+        description="Pre-compile clew COVERAGE gate: assert the manuscript's "
+        "rendered claims are the claims clew has grounded. Defaults ON (error) "
+        "for research projects, off otherwise."
+    )
+    parser.add_argument("project_dir", nargs="?", default=".")
+    parser.add_argument(
+        "--level",
+        choices=["off", "warn", "error"],
+        default=None,
+        help="Severity: off, warn, or error. Overrides env and config.",
+    )
+    parser.add_argument(
+        "--require-claims",
+        action="store_true",
+        help="Reclassify a missing clew CLI as a real failure (ADR-0021).",
+    )
+    args = parser.parse_args()
+
+    project_dir = Path(args.project_dir).resolve()
+    research = _is_research_project(project_dir)
+    default = "error" if research else "off"
+    level = resolve_level(
+        "clew_completeness",
+        args.level,
+        project_dir,
+        default=default,
+        env_var="SCITEX_WRITER_CLEW_COMPLETENESS",
+    )
+    require_claims = resolve_require_claims(args.require_claims, project_dir)
+    soft_report = (
+        (log_fail if level == "error" else log_warn) if require_claims else log_warn
+    )
+    kind = "research" if research else "non-research"
+    print(f"\n{BOLD}=== Clew Coverage Gate (level={level}, {kind}) ==={NC}\n")
+
+    if level == "off":
+        print(
+            f"  {DIM}[INFO]{NC} clew coverage gate is disabled (level=off). "
+            f"Set clew_completeness.level or --level to enable."
+        )
+        _summary()
+        return 0
+
+    manuscript = manuscript_claim_set(project_dir)
+    if not manuscript:
+        log_pass("no manuscript claims to reconcile (\\vclaim / claims.json empty)")
+        _summary()
+        return 0
+
+    clew_bin = _find_clew()
+    if clew_bin is None:
+        soft_report(
+            "clew CLI not found -- manuscript coverage is UNVERIFIED for this build."
+        )
+        log_detail(
+            "install scitex-clew to enable, or set clew_completeness.level: off."
+        )
+        _summary()
+        return 1 if FAIL_COUNT > 0 else 0
+
+    code, parsed, raw = _run_gate_completeness(clew_bin, project_dir, manuscript)
+
+    if parsed is None:
+        # A gate that cannot get an answer must not pass silently.
+        report = log_fail if level == "error" else log_warn
+        report(f"clew gate-completeness gave no parseable verdict (exit {code}).")
+        for line in raw.splitlines()[:20]:
+            log_detail(line)
+        _summary()
+        return 1 if FAIL_COUNT > 0 else 0
+
+    missing = parsed.get("missing") or {}
+    orphan = parsed.get("orphan") or {}
+    total = len(manuscript)
+    covered = total - len(missing)
+    pct = (covered * 100 // total) if total else 100
+
+    if missing:
+        report = log_fail if level == "error" else log_warn
+        report(
+            f"coverage {covered}/{total} ({pct}%): {len(missing)} manuscript "
+            f"claim(s) are RENDERED but NOT clew-grounded -- their values are "
+            f"uncertified in the PDF"
+        )
+        for cid in sorted(missing)[:40]:
+            log_detail(f"ungrounded: {cid}")
+        if len(missing) > 40:
+            log_detail(f"... and {len(missing) - 40} more")
+        log_detail(
+            "fix: register + ground these claims in clew (they must trace to a "
+            "signed source), or remove the \\vclaim citation. Override with "
+            "clew_completeness.level if intended."
+        )
+    else:
+        log_pass(
+            f"coverage {total}/{total} (100%): every manuscript claim is clew-grounded"
+        )
+
+    # Orphans do not reduce coverage; report advisory so a registered-but-uncited
+    # claim is visible without blocking the compile.
+    if orphan:
+        log_warn(
+            f"{len(orphan)} grounded claim(s) are never cited in the manuscript "
+            f"(orphan -- housekeeping, not a wrong value)"
+        )
+        for cid in sorted(orphan)[:20]:
+            log_detail(f"orphan: {cid}")
+
+    _summary()
+    return 1 if FAIL_COUNT > 0 else 0
+
+
+def _summary():
+    print()
+    print(
+        f"{BOLD}Summary:{NC} {GREEN}{PASS_COUNT} passed{NC}, "
+        f"{YELLOW}{WARN_COUNT} warnings{NC}, {RED}{FAIL_COUNT} errors{NC}"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+
+# EOF

--- a/scripts/shell/modules/run_provenance_checks.sh
+++ b/scripts/shell/modules/run_provenance_checks.sh
@@ -68,7 +68,7 @@ PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$THIS_DIR/../../.." && pwd)}"
 PY="${SCITEX_WRITER_PYTHON:-python3}"
 
 rc=0
-for chk in check_paper_symlink check_media_provenance check_figure_media check_ref_integrity check_caption_footnote check_table_decimals check_clew_verify check_citations check_citation_trust check_version_freshness; do
+for chk in check_paper_symlink check_media_provenance check_figure_media check_ref_integrity check_caption_footnote check_table_decimals check_clew_verify check_clew_completeness check_citations check_citation_trust check_version_freshness; do
     script="$THIS_DIR/../../python/${chk}.py"
     [ -f "$script" ] || continue
     "$PY" "$script" "$PROJECT_ROOT" || rc=$?

--- a/tests/scripts/python/test_check_clew_completeness.py
+++ b/tests/scripts/python/test_check_clew_completeness.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Test file for: check_clew_completeness.py (Defect A — the coverage gate)
+#
+# THE BUG THIS PINS. check_clew_verify delegates to `clew verify`, which reports
+# a verdict over CLEW'S STORE — so it can pass having checked a claim set
+# DISJOINT from what the manuscript renders. Measured on a real manuscript: 83
+# rendered claims, 0 grounded, and the old gate said "0/1 verified". This gate
+# reconciles the MANUSCRIPT set against clew's grounded set and reports coverage.
+#
+# The CLI reconciliation (`clew gate-completeness`) is validated by hand against
+# the real manuscript (0/83, exit 1); these tests pin the PURE logic where the
+# subtle bugs live — the manuscript set (raw claim_id, no sanitize) and the
+# canonical-DB workdir resolution that made the denominator wrong until fixed.
+# No mocks.
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
+
+_SCRIPT = ROOT_DIR / "scripts" / "python" / "check_clew_completeness.py"
+
+from check_clew_completeness import (  # noqa: E402
+    _resolve_clew_workdir,
+    manuscript_claim_set,
+)
+
+
+class TestManuscriptClaimSet:
+    def test_collects_vclaim_arguments(self, tmp_path):
+        # Arrange
+        c = tmp_path / "01_manuscript" / "contents"
+        c.mkdir(parents=True)
+        (c / "s.tex").write_text("Value: \\vclaim{group_effect}.\n")
+
+        # Act
+        ids = manuscript_claim_set(tmp_path)
+
+        # Assert
+        assert "group_effect" in ids
+
+    def test_collects_claims_json_keys(self, tmp_path):
+        # Arrange
+        sh = tmp_path / "00_shared"
+        sh.mkdir(parents=True)
+        (sh / "claims.json").write_text(
+            json.dumps({"claims": {"registered_one": {"type": "value"}}})
+        )
+
+        # Act
+        ids = manuscript_claim_set(tmp_path)
+
+        # Assert
+        assert "registered_one" in ids
+
+    def test_keeps_the_id_raw_without_sanitizing(self, tmp_path):
+        # Arrange: the join key is the RAW claim_id (clew's identity). An
+        # underscored id must survive verbatim — sanitizing it here would join
+        # on the wrong string against clew's grounded set.
+        c = tmp_path / "01_manuscript" / "contents"
+        c.mkdir(parents=True)
+        (c / "s.tex").write_text("\\vclaim{cohorta_inter_ncaps}\n")
+
+        # Act
+        ids = manuscript_claim_set(tmp_path)
+
+        # Assert
+        assert "cohorta_inter_ncaps" in ids
+
+
+class TestResolveClewWorkdir:
+    def test_walks_up_to_the_canonical_clew_dir(self, tmp_path):
+        # Arrange: the vendored layout — manuscript at <repo>/.scitex/writer,
+        # clew's canonical DB at <repo>/.scitex/clew. The workdir must resolve to
+        # the repo root, or the gate reconciles against the wrong DB.
+        repo = tmp_path
+        (repo / ".scitex" / "clew").mkdir(parents=True)
+        writer = repo / ".scitex" / "writer"
+        writer.mkdir(parents=True)
+
+        # Act
+        resolved = _resolve_clew_workdir(writer)
+
+        # Assert
+        assert resolved == repo
+
+    def test_falls_back_to_project_dir_when_no_clew_dir_exists(self, tmp_path):
+        # Arrange: no .scitex/clew anywhere above — nothing to walk up to.
+        proj = tmp_path / "plain"
+        proj.mkdir()
+
+        # Act
+        resolved = _resolve_clew_workdir(proj)
+
+        # Assert
+        assert resolved == proj
+
+    def test_prefers_the_nearest_clew_dir_not_a_higher_one(self, tmp_path):
+        # Arrange: if both a nested and an ancestor .scitex/clew exist, the
+        # NEAREST wins (the project's own store, not a grandparent's).
+        outer = tmp_path
+        (outer / ".scitex" / "clew").mkdir(parents=True)
+        inner = outer / "sub" / "project"
+        (inner / ".scitex" / "clew").mkdir(parents=True)
+
+        # Act
+        resolved = _resolve_clew_workdir(inner)
+
+        # Assert
+        assert resolved == inner
+
+
+def _run(project_dir, *extra):
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), str(project_dir), *extra],
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestEndToEnd:
+    def test_off_level_disables_the_gate(self, tmp_path):
+        # Arrange
+        c = tmp_path / "01_manuscript" / "contents"
+        c.mkdir(parents=True)
+        (c / "s.tex").write_text("\\vclaim{anything}\n")
+
+        # Act
+        result = _run(tmp_path, "--level", "off")
+
+        # Assert
+        assert result.returncode == 0
+
+    def test_no_manuscript_claims_passes(self, tmp_path):
+        # Arrange: nothing rendered, nothing to reconcile — an honest pass, and
+        # it must not even reach clew.
+        c = tmp_path / "01_manuscript" / "contents"
+        c.mkdir(parents=True)
+        (c / "s.tex").write_text("Plain prose.\n")
+
+        # Act
+        result = _run(tmp_path, "--level", "error")
+
+        # Assert
+        assert result.returncode == 0


### PR DESCRIPTION
Addresses **Defect A** of `writer-clew-gate-verifies-disjoint-claimset` (P1). Together with #344 (Defect B), this closes the gap that let a green provenance gate certify a paper it never inspected.

`check_clew_verify` delegates to `clew verify`, which reports a verdict over **clew’s store** — so it can pass having checked a claim set **disjoint** from what the PDF renders. On a real manuscript: clew’s store had 1 claim, the manuscript rendered 83, the intersection was 0, and the gate said `"0/1 verified"`. That reads like one near-miss; it *means* "I have never seen your manuscript."

## The fix

`check_clew_completeness.py` computes the manuscript claim set (raw `\vclaim` args + `claims.json` keys — **raw `claim_id`**, clew’s identity key, no transform, per agreement with scitex-clew) and hands it to `clew gate-completeness` as an identity submission. `missing` = manuscript claims clew has not grounded = the coverage gap it **hard-fails** on. Orphans (grounded but uncited) are advisory. CLI-only like `check_clew_verify`, reusing its severity/research helpers so the two gates can’t drift.

**Validated on paper-scitex-clew:** `coverage 0/83 (0%)` — 83 rendered claims, 0 grounded, exit 1. The old gate said `"0/1 verified"`.

## A denominator bug I caught in my own first version

It passed `--workdir=project_dir`, but a vendored project keeps the manuscript at `<repo>/.scitex/writer` while clew’s canonical DB is at `<repo>/.scitex/clew`. That resolved a **different (nested, stale) clew DB** and reported 53 missing instead of the authoritative 83 — a coverage gate reconciling against the wrong DB is the same silent-wrong-answer it exists to catch. `_resolve_clew_workdir` now walks up to the canonical `.scitex/clew`. (This also surfaced that the consumer project carries **two clew DBs of different contents** — flagged to them separately.)