### PR TITLE
release: scitex-writer 2.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.38.0] - 2026-07-17
+
+### Fixed
+- **The compile stamped a version it could not establish into the PDF's provenance metadata.** `_inject_version_stamp` wrote `scitex_writer.__version__` into `\ScitexWriterVersion` and `pdfcreator`, and `__version__` resolves through `importlib.metadata.version()`. When an environment holds more than one scitex-writer distribution, that call picks one by directory scan order and returns it with no sign the question was ambiguous — a confident answer to an unanswerable question.
+
+  Measured in a live container: a `2.26.1` and a `2.37.0` dist-info side by side, `version()` answering **2.26.1** while **2.37.0** code was actually running (confirmed by probing for `_source_check`, a 2.33.0+ symbol). Every PDF compiled there would have asserted it was built by v2.26.1. Unlike a wrong log line, that falsehood is **durable**: it ships inside the published manuscript, survives the environment being repaired, and no later reader can detect it from the PDF alone.
+
+  The stamp was also wrapped in `except Exception: pass` ("never block compilation due to version stamp"), so a stamp that never got written was indistinguishable from a clean compile — two silent failures stacked, one writing the wrong version and one hiding writing nothing.
+
+  New `_version_truth.py` refuses rather than guesses: when two or more installed distributions claim the name, it raises, naming every candidate and the repair command. Duplicate dist-info that *agree* are not ambiguous and do not block; an empty install set is legitimate (source-tree runs fall back to `pyproject.toml`). `_inject_version_stamp` now fails loud, matching `_render_claims` directly above it, which already refuses for the same reason ("compiling now would ship a stale claims_rendered.tex"). Import origin deliberately does **not** enter the stamp — it would bake local filesystem paths into published PDF metadata; it verifies the version, it does not appear in the artifact.
+
 ## [2.37.0] - 2026-07-14
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.37.0"
+version = "2.38.0"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_writer/_mcp/handlers/_compile.py
+++ b/src/scitex_writer/_mcp/handlers/_compile.py
@@ -32,17 +32,25 @@ def _auto_render_claims(project_path) -> None:
 
 
 def _inject_version_stamp(project_path) -> None:
-    """Write 00_shared/scitex_writer_version.tex for PDF metadata (best-effort)."""
-    try:
-        from scitex_writer import __version__
+    """Write 00_shared/scitex_writer_version.tex for PDF metadata.
 
-        version_tex = project_path / "00_shared" / "scitex_writer_version.tex"
-        version_tex.write_text(
-            f"\\def\\ScitexWriterVersion{{{__version__}}}\n"
-            f"\\hypersetup{{pdfcreator={{Compiled by SciTeX Writer v{__version__}}}}}\n"
-        )
-    except Exception:
-        pass  # Never block compilation due to version stamp
+    Fails loud, like _render_claims above: this stamp is the manuscript's
+    provenance claim about the engine that built it. Stamping a version we
+    cannot establish would ship a paper asserting it was built by something
+    that did not build it, and swallowing a write failure would make a stamp
+    that never happened indistinguishable from a clean compile.
+    """
+    from scitex_writer import __version__
+
+    from ._version_truth import (
+        installed_versions,
+        resolve_stamp_version,
+        version_stamp_tex,
+    )
+
+    version = resolve_stamp_version(installed_versions(), __version__)
+    version_tex = project_path / "00_shared" / "scitex_writer_version.tex"
+    version_tex.write_text(version_stamp_tex(version))
 
 
 def compile_manuscript(

--- a/src/scitex_writer/_mcp/handlers/_version_truth.py
+++ b/src/scitex_writer/_mcp/handlers/_version_truth.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Establish the engine's own version truthfully, or refuse to state one.
+
+A package's version lives in metadata *adjacent* to its code, not in the code.
+When an environment holds more than one scitex-writer distribution,
+``importlib.metadata.version()`` resolves one of them by scan order and returns
+it with no indication that the question was ambiguous -- a confident answer to
+an unanswerable question.
+
+That matters here more than it would elsewhere: the compile stamps this version
+into the manuscript's PDF provenance metadata. A guessed version becomes a
+durable falsehood in a published scientific artifact -- one that survives in the
+file long after the environment is repaired, and which no later reader can
+detect from the PDF alone.
+
+So when the version cannot be established, we refuse to stamp rather than stamp
+a guess. The decision logic is pure: callers pass in the facts, so it can be
+tested against real inputs instead of a patched interpreter.
+"""
+
+from __future__ import annotations
+
+REMEDY = (
+    "Remove the stale distribution so the version is unambiguous:\n"
+    "    pip uninstall -y scitex-writer && pip install 'scitex-writer[all]'"
+)
+
+
+def describe_ambiguous_metadata(versions: list[str]) -> str:
+    """Explain why no version can be stated, naming every candidate."""
+    shown = ", ".join(sorted(versions))
+    return (
+        f"scitex-writer cannot determine its own version: {len(versions)} "
+        f"installed distributions claim the name scitex-writer ({shown}). "
+        f"importlib.metadata resolves one of them by directory scan order, so "
+        f"any version reported now is a coin-flip.\n\n"
+        f"Refusing to stamp a guessed engine version into the PDF's provenance "
+        f"metadata: the manuscript would assert it was built by a version that "
+        f"did not build it, and would keep asserting it after this environment "
+        f"is fixed.\n\n" + REMEDY
+    )
+
+
+def resolve_stamp_version(installed: list[str], declared: str) -> str:
+    """Return the version safe to stamp, or raise naming the ambiguity.
+
+    ``installed`` are the versions of every installed distribution claiming the
+    scitex-writer name; ``declared`` is what the package reports as its own
+    version. This function's job is to *veto* ``declared`` when the metadata it
+    came from was ambiguous -- not to re-derive it. An empty ``installed`` is
+    not ambiguous: running from a source tree with nothing installed is a
+    legitimate state, and ``declared`` falls back to pyproject.toml there.
+    """
+    distinct = sorted(set(installed))
+    if len(distinct) > 1:
+        raise RuntimeError(describe_ambiguous_metadata(distinct))
+    return declared
+
+
+def version_stamp_tex(version: str) -> str:
+    """Render the LaTeX provenance stamp for a version known to be truthful."""
+    return (
+        f"\\def\\ScitexWriterVersion{{{version}}}\n"
+        f"\\hypersetup{{pdfcreator={{Compiled by SciTeX Writer v{version}}}}}\n"
+    )
+
+
+def installed_versions(name: str = "scitex-writer") -> list[str]:
+    """Every version claimed by an installed distribution with this name."""
+    import importlib.metadata as md
+
+    want = name.lower().replace("_", "-")
+    return [
+        d.version
+        for d in md.distributions()
+        if (d.metadata["Name"] or "").lower().replace("_", "-") == want
+    ]

--- a/tests/scitex_writer/_mcp/handlers/test__version_truth.py
+++ b/tests/scitex_writer/_mcp/handlers/test__version_truth.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""The compile must never stamp a version it cannot establish.
+
+THE BUG. `_inject_version_stamp` wrote `scitex_writer.__version__` into the
+manuscript's PDF provenance metadata (\\ScitexWriterVersion + pdfcreator), and
+`__version__` comes from `importlib.metadata.version()`. When an environment
+holds more than one scitex-writer distribution, that call resolves one by
+directory scan order and returns it with no sign the question was ambiguous.
+The whole thing was wrapped in `except Exception: pass`, so a stamp that never
+got written looked exactly like a clean compile.
+
+Real incident (2026-07-17): this container carried both a 2.26.1 and a 2.37.0
+dist-info. `version()` answered 2.26.1 while 2.37.0 code was actually running --
+verified by probing for a 2.33.0+ symbol. Every PDF compiled here would have
+asserted it was built by v2.26.1. Unlike a bad log line, that falsehood is
+durable: it survives in the published file after the environment is repaired,
+and no later reader can detect it from the PDF alone.
+
+Two silent failures stacked: one wrote the wrong version, the other hid writing
+nothing.
+
+The decision functions are pure -- they take the facts as arguments -- so these
+run against real values with no mock and no monkeypatch (PA-306 / STX-NM002).
+"""
+
+import functools
+
+import pytest
+
+from scitex_writer._mcp.handlers._version_truth import (
+    describe_ambiguous_metadata,
+    resolve_stamp_version,
+    version_stamp_tex,
+)
+
+# The exact state measured in the container that surfaced this bug.
+AMBIGUOUS = ["2.26.1", "2.37.0"]
+
+
+def _refusal_message(installed, declared) -> str:
+    """Return the refusal message, or "" when the call is allowed through."""
+    try:
+        resolve_stamp_version(installed, declared)
+    except RuntimeError as exc:
+        return str(exc)
+    return ""
+
+
+class TestAmbiguousMetadataIsRefused:
+    def test_two_distinct_versions_are_refused(self):
+        # Arrange
+        installed = AMBIGUOUS
+
+        # Act
+        message = _refusal_message(installed, "2.26.1")
+
+        # Assert
+        assert message != ""
+
+    def test_refusal_raises_rather_than_returning_a_guess(self):
+        # Arrange
+        installed = AMBIGUOUS
+
+        # Act
+        act = functools.partial(resolve_stamp_version, installed, "2.26.1")
+
+        # Assert
+        with pytest.raises(RuntimeError):
+            act()
+
+
+class TestRefusalMessage:
+    def test_message_names_the_stale_candidate(self):
+        # Arrange
+        installed = AMBIGUOUS
+
+        # Act
+        message = _refusal_message(installed, "2.26.1")
+
+        # Assert
+        assert "2.26.1" in message
+
+    def test_message_names_the_current_candidate(self):
+        # Arrange
+        installed = AMBIGUOUS
+
+        # Act
+        message = _refusal_message(installed, "2.26.1")
+
+        # Assert
+        assert "2.37.0" in message
+
+    def test_message_hands_back_a_working_repair_command(self):
+        # Arrange
+        installed = AMBIGUOUS
+
+        # Act
+        message = _refusal_message(installed, "2.26.1")
+
+        # Assert
+        assert "pip uninstall -y scitex-writer" in message
+
+    def test_message_explains_the_provenance_stake(self):
+        # Arrange: the message must say WHY, or a reader will force past it.
+        versions = AMBIGUOUS
+
+        # Act
+        message = describe_ambiguous_metadata(versions)
+
+        # Assert
+        assert "provenance" in message
+
+
+class TestUnambiguousMetadataIsStamped:
+    def test_single_installed_version_is_returned(self):
+        # Arrange
+        installed = ["2.37.0"]
+
+        # Act
+        version = resolve_stamp_version(installed, "2.37.0")
+
+        # Assert
+        assert version == "2.37.0"
+
+    def test_same_version_declared_twice_is_not_ambiguous(self):
+        # Arrange: duplicate dist-info that AGREE answer the question, so they
+        # must not block a compile.
+        installed = ["2.37.0", "2.37.0"]
+
+        # Act
+        version = resolve_stamp_version(installed, "2.37.0")
+
+        # Assert
+        assert version == "2.37.0"
+
+    def test_nothing_installed_defers_to_the_declared_version(self):
+        # Arrange: a source tree with nothing installed is legitimate;
+        # __version__ falls back to pyproject.toml there.
+        installed = []
+
+        # Act
+        version = resolve_stamp_version(installed, "0.0.0+local")
+
+        # Assert
+        assert version == "0.0.0+local"
+
+
+class TestStampRendersTheVersion:
+    def test_stamp_defines_the_latex_version_macro(self):
+        # Arrange
+        version = "2.37.0"
+
+        # Act
+        tex = version_stamp_tex(version)
+
+        # Assert
+        assert "\\def\\ScitexWriterVersion{2.37.0}" in tex
+
+    def test_stamp_sets_the_pdf_creator_metadata(self):
+        # Arrange
+        version = "2.37.0"
+
+        # Act
+        tex = version_stamp_tex(version)
+
+        # Assert
+        assert "pdfcreator={Compiled by SciTeX Writer v2.37.0}" in tex


### PR DESCRIPTION
## 2.38.0 — the compile refuses to stamp a version it cannot establish

### Fixed

The compile wrote `scitex_writer.__version__` into the manuscript's PDF provenance metadata (`\ScitexWriterVersion` + `pdfcreator`). `__version__` resolves through `importlib.metadata.version()`, which — when two distributions claim the name — picks one by directory scan order and returns it with no sign the question was ambiguous.

Measured in a live container:

```
site-packages/scitex_writer-2.26.1.dist-info    <- editable
site-packages/scitex_writer-2.37.0.dist-info    <- wheel payload

importlib.metadata.version("scitex-writer") -> 2.26.1
_source_check.py (a 2.33.0+ symbol)         -> PRESENT   # 2.37.0 is what runs
```

Every PDF compiled there asserted it was built by **v2.26.1** when **2.37.0** built it. Unlike a wrong log line, that falsehood is **durable** — it ships inside the published manuscript, survives the environment being repaired, and no later reader can detect it from the PDF alone.

The stamp was also wrapped in `except Exception: pass`, so a stamp that never got written was indistinguishable from a clean compile. Two silent failures stacked: one wrote the wrong version, the other hid writing nothing.

`_version_truth.resolve_stamp_version` now **vetoes** an untrustworthy version rather than guessing — raising with every candidate named and the repair command. Duplicate dist-info that *agree* are not ambiguous and do not block; an empty install set is legitimate (source-tree runs fall back to `pyproject.toml`). `_inject_version_stamp` fails loud, matching `_render_claims` directly above it, which already refuses for the same reason.

Import origin is deliberately kept **out** of the stamp: it would bake local filesystem paths into published PDF metadata. It verifies the version; it does not appear in the artifact.

### Verification

- 11 tests green.
- **Mutation-tested**: reverting to the old `return declared` kills exactly the 5 tests that encode the fix; the other 6 survive.
- **Real entry point driven**: `_inject_version_stamp` refuses in the actually-ambiguous container rather than stamping — a unit-only pass would not have proven the wiring.
- PS-108b: the new module lives beside its only consumer in `_mcp/handlers/`, keeping the package root at threshold.

All 8 CI checks green on #350.