### PR TITLE
release: scitex-writer 2.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.39.0] - 2026-07-17
+
+### Fixed
+- **The vendored engine tree carried a second, lying answer to "what version is this?".** A project is scaffolded by copying the template repo, which brings the engine's `CHANGELOG.md` along. That file is in no sync list (`_constants.py` refreshes only `scripts/`, `compile.sh`, and a few named engine paths), so it freezes at the version the project was created on while everything around it keeps updating — and the gap widens with every release.
+
+  Harmless debris, except that it **names a version**, so it reads as authoritative. Measured in a real consumer's tree: `00_shared/.scitex-writer-vendored-version` said **2.24.7** while `CHANGELOG.md`'s top entry said **2.9.0** — fifteen minor versions apart, in the same directory. On 2026-07-14 that fossil convinced a reader to report the engine four months stale to the whole fleet. Same family as 2.38.0's provenance stamp: a marker describing an *install event*, not the code.
+
+  The vendored copy is now replaced by a pointer to the engine's real changelog and to the vendored-version stamp, rather than synced — the engine's changelog already has an authoritative home, and copying it into every paper repo would give one fact two places to live.
+
+  Identification is by **content, never path**: `project_path` is normally the vendored engine tree, but in a directly-scaffolded layout a `CHANGELOG.md` there could be the author's own, and `PRESERVED_PATHS` does not cover it. Only a file positively recognisable as the engine's changelog is touched; anything else is left byte-identical. `dry_run` touches nothing, and the outcome is reported (`fossil_changelog_neutralised`), never silent.
+
 ## [2.38.0] - 2026-07-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.38.0"
+version = "2.39.0"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_writer/_mcp/handlers/_update/_fossil.py
+++ b/src/scitex_writer/_mcp/handlers/_update/_fossil.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# File: src/scitex_writer/_mcp/handlers/_update/_fossil.py
+
+"""Neutralise scaffolding debris that impersonates a version marker.
+
+A project is scaffolded by copying the template repo, which brings the ENGINE's
+``CHANGELOG.md`` along. That file is in no sync list (see ``_constants.py``:
+only ``scripts/``, ``compile.sh`` and a few named engine paths refresh), so it
+freezes at the version the project was created on while everything around it
+keeps updating. The gap widens with every release.
+
+That would be harmless debris except for one thing: **it names a version**, so
+it reads as authoritative. A real tree stamped 2.24.7 carried a changelog whose
+top entry said 2.9.0, and a reader (me, 2026-07-14) reported the engine four
+months stale to the whole fleet on its authority.
+
+The fix is not to refresh it -- the engine's changelog already has an
+authoritative home on GitHub, and copying it into every paper repo would give
+one fact two places to live (constitution SSoT). Instead the vendored copy is
+replaced by a pointer to the real one, so the tree stops carrying a second,
+lying answer to "what version is this?".
+
+Identification is by CONTENT, never by path: ``project_path`` is normally the
+vendored engine tree (``<repo>/.scitex/writer/``), but in a directly-scaffolded
+layout a ``CHANGELOG.md`` at that path could be the AUTHOR's own. We only touch
+a file we can positively recognise as the engine's, and leave anything else
+alone.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+CHANGELOG_PATH = "CHANGELOG.md"
+CHANGELOG_URL = "https://github.com/ywatanabe1989/scitex-writer/blob/main/CHANGELOG.md"
+VENDOR_STAMP_NAME = "00_shared/.scitex-writer-vendored-version"
+
+
+def is_engine_changelog(text: str) -> bool:
+    """True only for a file we can positively identify as the engine's changelog.
+
+    Deliberately strict. A false positive here overwrites an author's own
+    CHANGELOG.md, so anything we cannot recognise is left untouched.
+    """
+    head = text[:400]
+    if not head.lstrip().startswith("# Changelog"):
+        return False
+    return "SciTeX Writer" in head
+
+
+def pointer_text(pkg_version: str) -> str:
+    """The replacement: says what this tree is, and where the real log lives."""
+    return (
+        f"# Changelog — not here\n"
+        f"\n"
+        f"This is a **vendored scitex-writer engine tree**, not the engine's\n"
+        f"repository. It used to carry a copy of the engine's CHANGELOG.md that\n"
+        f"was written once when this project was scaffolded and never refreshed\n"
+        f"again — so it kept naming the version you started on, long after the\n"
+        f"engine had moved on. It read as authoritative and was not.\n"
+        f"\n"
+        f"The engine's changelog lives at:\n"
+        f"\n"
+        f"    {CHANGELOG_URL}\n"
+        f"\n"
+        f"The version THIS tree was vendored from is recorded in:\n"
+        f"\n"
+        f"    {VENDOR_STAMP_NAME}\n"
+        f"\n"
+        f"which `scitex-writer update-project` rewrites on every vendor, and\n"
+        f"which the compile-time freshness gate reads. That file is the single\n"
+        f'answer to "what engine is this project on?" — at the time of writing,\n'
+        f"{pkg_version}.\n"
+    )
+
+
+def neutralise_fossil_changelog(
+    project_path: Path, pkg_version: str, dry_run: bool = False
+) -> bool:
+    """Replace a recognisable engine CHANGELOG fossil with a pointer.
+
+    Returns True when the file was (or would be) replaced. Does nothing and
+    returns False when the file is absent, already a pointer, or not
+    recognisable as the engine's changelog -- the last case matters, because in
+    a directly-scaffolded layout this path could be the AUTHOR's own changelog,
+    and overwriting that would be far worse than the fossil.
+
+    Not best-effort-silent: an OSError here is a real failure to fix a known
+    lying marker, and the caller reports the outcome either way.
+    """
+    target = project_path / CHANGELOG_PATH
+    if not target.is_file():
+        return False
+    text = target.read_text(encoding="utf-8", errors="replace")
+    if not is_engine_changelog(text):
+        return False
+    if not dry_run:
+        target.write_text(pointer_text(pkg_version), encoding="utf-8")
+    return True

--- a/src/scitex_writer/_mcp/handlers/_update/_handler.py
+++ b/src/scitex_writer/_mcp/handlers/_update/_handler.py
@@ -11,6 +11,7 @@ from typing import Optional
 from ...utils import resolve_project_path
 from ._constants import PRESERVED_PATHS
 from ._diff import backup_files, collect_sync_files, compare_files
+from ._fossil import neutralise_fossil_changelog
 from ._git_safety import (
     git_status_summary,
     has_uncommitted_changes,
@@ -172,6 +173,15 @@ def update_project(
         # (which the compile rewrites from the installed version for PDF
         # metadata) -- this stamp is written ONLY here and reflects the version
         # update-project vendored from. Absent => a pre-feature vendor (stale).
+        # The scaffolded engine CHANGELOG.md is in no sync list, so it freezes at
+        # the version the project was created on and then keeps NAMING it -- a
+        # second, lying answer to "what engine is this?" (a tree stamped 2.24.7
+        # carried a changelog saying 2.9.0, and it was believed). Replace it with
+        # a pointer to the real one; reported, never silent.
+        fossil_neutralised = neutralise_fossil_changelog(
+            project_path, pkg_version, dry_run=dry_run
+        )
+
         if not dry_run:
             _write_vendor_stamp(project_path, pkg_version)
             # Also refresh the visible colophon / PDF-Creator stamp so it shows
@@ -181,6 +191,7 @@ def update_project(
         return {
             "success": True,
             "dry_run": dry_run,
+            "fossil_changelog_neutralised": fossil_neutralised,
             "git_safe": git_safe,
             "warnings": warnings,
             "source": str(source_dir),

--- a/tests/scitex_writer/_mcp/handlers/_update/test__fossil.py
+++ b/tests/scitex_writer/_mcp/handlers/_update/test__fossil.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""The vendored tree must not carry a second, lying answer to "what version?".
+
+THE BUG. A project is scaffolded by copying the template repo, which brings the
+ENGINE's CHANGELOG.md along. It is in no sync list (_constants.py syncs only
+`scripts/`, `compile.sh` and a few named engine paths), so it freezes at the
+version the project was created on while everything around it keeps refreshing.
+
+That would be harmless debris except it NAMES A VERSION, so it reads as
+authoritative. Measured in a real consumer on 2026-07-17:
+
+    .scitex/writer/00_shared/.scitex-writer-vendored-version -> 2.24.7  (honest)
+    .scitex/writer/CHANGELOG.md top entry                    -> 2.9.0   (fossil)
+
+Fifteen minor versions apart. On 2026-07-14 that fossil convinced a reader (me)
+to tell the fleet the engine was "2.9.0, four months behind". Same family as the
+PDF provenance stamp fixed in 2.38.0: a marker describing an INSTALL EVENT
+rather than the code.
+
+The safety property is the important one. `project_path` is normally the
+vendored engine tree, but in a directly-scaffolded layout a CHANGELOG.md there
+could be the AUTHOR's own — and silently overwriting an author's file would be
+far worse than the fossil we are fixing. Identification is therefore by content,
+and anything unrecognised is left alone.
+
+Pure decision functions + a tmp_path for the one I/O function, so these run with
+no mock and no monkeypatch (PA-306 / STX-NM002).
+"""
+
+from scitex_writer._mcp.handlers._update._fossil import (
+    is_engine_changelog,
+    neutralise_fossil_changelog,
+    pointer_text,
+)
+
+# The real shape of the fossil, as found in a consumer's vendored tree.
+ENGINE_CHANGELOG = (
+    "# Changelog\n"
+    "\n"
+    "All notable changes to SciTeX Writer will be documented in this file.\n"
+    "\n"
+    "## [Unreleased]\n"
+    "\n"
+    "## [2.9.0] - 2026-03-14\n"
+)
+
+AUTHORS_OWN_CHANGELOG = (
+    "# Changelog\n"
+    "\n"
+    "Revisions to our manuscript, tracked for the co-authors.\n"
+    "\n"
+    "## 2026-03-01 — reviewer 2 response\n"
+)
+
+
+class TestEngineChangelogIsRecognised:
+    def test_the_engine_changelog_is_recognised(self):
+        # Arrange
+        text = ENGINE_CHANGELOG
+
+        # Act
+        recognised = is_engine_changelog(text)
+
+        # Assert
+        assert recognised is True
+
+
+class TestAuthorContentIsNeverTouched:
+    def test_an_authors_own_changelog_is_not_recognised(self):
+        # Arrange: same "# Changelog" heading, different owner.
+        text = AUTHORS_OWN_CHANGELOG
+
+        # Act
+        recognised = is_engine_changelog(text)
+
+        # Assert
+        assert recognised is False
+
+    def test_an_authors_changelog_is_left_byte_identical(self, tmp_path):
+        # Arrange
+        (tmp_path / "CHANGELOG.md").write_text(AUTHORS_OWN_CHANGELOG)
+
+        # Act
+        neutralise_fossil_changelog(tmp_path, "2.38.0")
+
+        # Assert
+        assert (tmp_path / "CHANGELOG.md").read_text() == AUTHORS_OWN_CHANGELOG
+
+    def test_an_authors_changelog_reports_no_neutralisation(self, tmp_path):
+        # Arrange
+        (tmp_path / "CHANGELOG.md").write_text(AUTHORS_OWN_CHANGELOG)
+
+        # Act
+        neutralised = neutralise_fossil_changelog(tmp_path, "2.38.0")
+
+        # Assert
+        assert neutralised is False
+
+    def test_unrelated_prose_is_not_recognised(self):
+        # Arrange
+        text = "# Notes\n\nSciTeX Writer is used to build this paper.\n"
+
+        # Act
+        recognised = is_engine_changelog(text)
+
+        # Assert
+        assert recognised is False
+
+
+class TestFossilIsNeutralised:
+    def test_the_fossil_is_reported_as_neutralised(self, tmp_path):
+        # Arrange
+        (tmp_path / "CHANGELOG.md").write_text(ENGINE_CHANGELOG)
+
+        # Act
+        neutralised = neutralise_fossil_changelog(tmp_path, "2.38.0")
+
+        # Assert
+        assert neutralised is True
+
+    def test_the_stale_version_no_longer_appears(self, tmp_path):
+        # Arrange: 2.9.0 is the lie that fooled the fleet.
+        (tmp_path / "CHANGELOG.md").write_text(ENGINE_CHANGELOG)
+
+        # Act
+        neutralise_fossil_changelog(tmp_path, "2.38.0")
+
+        # Assert
+        assert "2.9.0" not in (tmp_path / "CHANGELOG.md").read_text()
+
+    def test_the_replacement_points_at_the_honest_stamp(self, tmp_path):
+        # Arrange
+        (tmp_path / "CHANGELOG.md").write_text(ENGINE_CHANGELOG)
+
+        # Act
+        neutralise_fossil_changelog(tmp_path, "2.38.0")
+
+        # Assert
+        assert (
+            ".scitex-writer-vendored-version" in (tmp_path / "CHANGELOG.md").read_text()
+        )
+
+    def test_a_second_run_is_a_no_op(self, tmp_path):
+        # Arrange: the pointer must not be mistaken for a fossil.
+        (tmp_path / "CHANGELOG.md").write_text(pointer_text("2.38.0"))
+
+        # Act
+        neutralised = neutralise_fossil_changelog(tmp_path, "2.38.0")
+
+        # Assert
+        assert neutralised is False
+
+
+class TestDryRunTouchesNothing:
+    def test_dry_run_leaves_the_fossil_byte_identical(self, tmp_path):
+        # Arrange
+        (tmp_path / "CHANGELOG.md").write_text(ENGINE_CHANGELOG)
+
+        # Act
+        neutralise_fossil_changelog(tmp_path, "2.38.0", dry_run=True)
+
+        # Assert
+        assert (tmp_path / "CHANGELOG.md").read_text() == ENGINE_CHANGELOG
+
+    def test_dry_run_still_reports_what_it_would_do(self, tmp_path):
+        # Arrange
+        (tmp_path / "CHANGELOG.md").write_text(ENGINE_CHANGELOG)
+
+        # Act
+        neutralised = neutralise_fossil_changelog(tmp_path, "2.38.0", dry_run=True)
+
+        # Assert
+        assert neutralised is True
+
+
+class TestAbsentFileIsNotAFailure:
+    def test_no_changelog_reports_nothing_neutralised(self, tmp_path):
+        # Arrange: a tree with no CHANGELOG.md at all.
+        project = tmp_path
+
+        # Act
+        neutralised = neutralise_fossil_changelog(project, "2.38.0")
+
+        # Assert
+        assert neutralised is False


### PR DESCRIPTION
## 2.39.0 — the vendored tree stops carrying a lying version marker

A project is scaffolded by copying the template repo, which brings the engine's `CHANGELOG.md` along. It is in **no sync list**, so it freezes at the version the project was created on while everything around it refreshes.

It **names a version**, so it reads as authoritative. Measured in a real consumer:

```
00_shared/.scitex-writer-vendored-version  ->  2.24.7   (honest)
CHANGELOG.md  top entry                    ->  2.9.0    (fossil, ~4 months stale)
```

Fifteen minor versions apart, same directory. That fossil convinced a reader to report the engine four months stale to the whole fleet. Same family as 2.38.0's provenance stamp: **a marker describing an install event, not the code.**

The vendored copy now points at the engine's real changelog and at the honest stamp, rather than being synced — the changelog already has an authoritative home, and copying it into every paper repo would give one fact two places to live.

**Safety:** identification is by content, never path. In a directly-scaffolded layout a `CHANGELOG.md` could be the author's own, and `PRESERVED_PATHS` doesn't cover it — so only a positively-recognisable engine changelog is touched, `dry_run` touches nothing, and the outcome is reported rather than silent.

**Verified:** 12 tests green; mutation-tested (dropping the content check kills exactly the author-safety tests); driven against a copy of a real consumer's actual fossil. All 8 CI checks green on #352 and #353.