### PR TITLE
fix(claims): refuse claim IDs that collide into one LaTeX macro (2.40.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.40.0] - 2026-07-17
+
+### Fixed
+- **Two claim IDs differing only in punctuation silently rendered the WRONG VALUE into the manuscript.** LaTeX macro names are built by stripping every non-alphanumeric character from the claim ID, so `group-a-effect` and `group_a_effect` both become `groupaeffect` — the same macro. The renderer emits one `\@namedef` per claim, and `\@namedef` is `\def`: the second definition silently replaces the first, and *both* `\vclaim` calls then expand to the last claim's value.
+
+  Reproduced against the real renderer:
+
+  ```
+  render_claims success: True
+  \@namedef for v@claim@groupaeffect@nature: 2 definitions
+      defines value -> 111
+      defines value -> 999
+  ```
+
+  So `\vclaim{group-a-effect}` printed **999** — the other claim's value — into the PDF, with no warning, from a renderer reporting success. This is the most severe member of the silent-wrong-answer family the last two releases addressed: not a wrong version string in metadata, but **a wrong number in a published scientific paper**.
+
+  `render_claims` now refuses before writing anything, naming every colliding ID, the shared macro, what is at stake, and the remedy. Two distinct claims sharing a macro is always a defect — there is no legitimate collision — so it is a hard refusal rather than a warning. The compile already fails loud on a failed claim render, so a collision now blocks the build and no `claims_rendered.tex` is emitted (verified at the real entry point, not just in a unit test).
+
 ## [2.39.0] - 2026-07-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.39.0"
+version = "2.40.0"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/scitex_writer/_mcp/handlers/_claim.py
+++ b/src/scitex_writer/_mcp/handlers/_claim.py
@@ -23,6 +23,8 @@ from ._claim_format import (
     FORMAT_STYLES,
     _render_claim,
     _sanitize_id,
+    describe_sanitize_collisions,
+    find_sanitize_collisions,
 )
 
 CLAIMS_FILE = "00_shared/claims.json"
@@ -431,6 +433,18 @@ def render_claims(project_dir: str) -> Dict:
             "}",
             "",
         ]
+
+        # Two claim IDs differing only in punctuation sanitise to the SAME macro
+        # name, and \@namedef is \def -- the second definition silently replaces
+        # the first, so both \vclaim calls render the LAST claim's value. That is
+        # a wrong number in the manuscript, emitted by a renderer reporting
+        # success. Refuse before writing rather than ship it.
+        collisions = find_sanitize_collisions(claims.keys())
+        if collisions:
+            return {
+                "success": False,
+                "error": describe_sanitize_collisions(collisions),
+            }
 
         if claims:
             lines.append("%% Rendered claims")

--- a/src/scitex_writer/_mcp/handlers/_claim_format.py
+++ b/src/scitex_writer/_mcp/handlers/_claim_format.py
@@ -22,6 +22,47 @@ def _sanitize_id(claim_id: str) -> str:
     return re.sub(r"[^a-zA-Z0-9]", "", claim_id)
 
 
+def find_sanitize_collisions(claim_ids) -> Dict[str, list]:
+    """Map each colliding macro name to the >1 claim_ids that collapse onto it.
+
+    ``_sanitize_id`` strips every non-alphanumeric character, so ``group-a-effect``
+    and ``group_a_effect`` both become ``groupaeffect`` -- the same LaTeX macro
+    name. The renderer emits one ``\\@namedef`` per claim, and ``\\@namedef`` is
+    ``\\def``: the second definition silently replaces the first. Both
+    ``\\vclaim`` calls then expand to the LAST claim's value.
+
+    That is a wrong NUMBER in a published manuscript, produced with no warning
+    by a renderer reporting success. Two distinct claims must never share a
+    macro, so any collision is a hard error -- there is no legitimate case.
+    """
+    groups: Dict[str, list] = {}
+    for claim_id in claim_ids:
+        groups.setdefault(_sanitize_id(claim_id), []).append(claim_id)
+    return {safe: ids for safe, ids in groups.items() if len(ids) > 1}
+
+
+def describe_sanitize_collisions(collisions: Dict[str, list]) -> str:
+    """Name every colliding group, the value at stake, and the remedy."""
+    lines = [
+        "Claim IDs collide into the same LaTeX macro name.",
+        "",
+        "Macro names are built by stripping every non-alphanumeric character "
+        "from the claim ID, so IDs differing only in punctuation produce the "
+        "SAME macro. The later definition silently overwrites the earlier one, "
+        "and every \\vclaim for the group then renders the LAST claim's value "
+        "-- a wrong number in the manuscript, with no warning.",
+        "",
+    ]
+    for safe, ids in sorted(collisions.items()):
+        lines.append(f"  \\v@claim@{safe}@* <- {', '.join(sorted(ids))}")
+    lines += [
+        "",
+        "Rename the claim IDs in 00_shared/claims.json so they differ by more "
+        "than punctuation (letters and digits are what survive sanitisation).",
+    ]
+    return "\n".join(lines)
+
+
 def _format_p(p: float, style: str) -> str:
     """Format a p-value according to style."""
     if p < 0.001:
@@ -217,6 +258,8 @@ __all__ = [
     "CLAIM_TYPES",
     "FORMAT_STYLES",
     "_sanitize_id",
+    "find_sanitize_collisions",
+    "describe_sanitize_collisions",
     "_format_p",
     "_format_statistic",
     "_format_value",

--- a/tests/scitex_writer/_mcp/handlers/test__claim_collision.py
+++ b/tests/scitex_writer/_mcp/handlers/test__claim_collision.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Two claim IDs must never collapse onto one LaTeX macro.
+
+THE BUG. Macro names are built by `_sanitize_id`, which strips every
+non-alphanumeric character: `group-a-effect` and `group_a_effect` both become
+`groupaeffect`. The renderer emits one `\\@namedef` per claim, and `\\@namedef`
+is `\\def` — the second definition silently replaces the first. Both `\\vclaim`
+calls then expand to the LAST claim's value.
+
+Reproduced against the real renderer before this guard existed (2026-07-17):
+
+    render_claims success: True
+    \\@namedef for v@claim@groupaeffect@nature: 2 definitions
+        defines value -> 111
+        defines value -> 999
+
+So `\\vclaim{group-a-effect}` printed 999 — the OTHER claim's value — into the
+manuscript, with no warning, from a renderer reporting success. That is the most
+severe form of this family: not a wrong version string in metadata, but a wrong
+NUMBER in a published scientific paper.
+
+There is no legitimate collision: two distinct claims sharing a macro is always
+a defect, so it is a hard refusal rather than a warning.
+
+The decision functions are pure, so these run on real values with no mock and no
+monkeypatch (PA-306 / STX-NM002).
+"""
+
+from scitex_writer._mcp.handlers._claim_format import (
+    _sanitize_id,
+    describe_sanitize_collisions,
+    find_sanitize_collisions,
+)
+
+# The exact pair that reproduced the bug.
+COLLIDING = ["group-a-effect", "group_a_effect"]
+
+
+class TestCollisionIsDetected:
+    def test_ids_differing_only_in_punctuation_collide(self):
+        # Arrange
+        ids = COLLIDING
+
+        # Act
+        collisions = find_sanitize_collisions(ids)
+
+        # Assert
+        assert collisions == {"groupaeffect": COLLIDING}
+
+    def test_the_collision_is_real_not_hypothetical(self):
+        # Arrange: both really do sanitise to one macro name.
+        ids = COLLIDING
+
+        # Act
+        sanitised = {_sanitize_id(i) for i in ids}
+
+        # Assert
+        assert len(sanitised) == 1
+
+    def test_three_way_collision_is_reported_as_one_group(self):
+        # Arrange
+        ids = ["a-b", "a_b", "a.b"]
+
+        # Act
+        collisions = find_sanitize_collisions(ids)
+
+        # Assert
+        assert collisions == {"ab": ids}
+
+
+class TestDistinctIdsAreNotFlagged:
+    def test_genuinely_distinct_ids_do_not_collide(self):
+        # Arrange
+        ids = ["group-a-effect", "group-b-effect"]
+
+        # Act
+        collisions = find_sanitize_collisions(ids)
+
+        # Assert
+        assert collisions == {}
+
+    def test_a_single_claim_never_collides_with_itself(self):
+        # Arrange
+        ids = ["group-a-effect"]
+
+        # Act
+        collisions = find_sanitize_collisions(ids)
+
+        # Assert
+        assert collisions == {}
+
+    def test_no_claims_is_not_a_collision(self):
+        # Arrange
+        ids = []
+
+        # Act
+        collisions = find_sanitize_collisions(ids)
+
+        # Assert
+        assert collisions == {}
+
+
+class TestRefusalMessage:
+    def test_message_names_every_colliding_id(self):
+        # Arrange
+        collisions = {"groupaeffect": COLLIDING}
+
+        # Act
+        message = describe_sanitize_collisions(collisions)
+
+        # Assert
+        assert "group-a-effect, group_a_effect" in message
+
+    def test_message_names_the_shared_macro(self):
+        # Arrange
+        collisions = {"groupaeffect": COLLIDING}
+
+        # Act
+        message = describe_sanitize_collisions(collisions)
+
+        # Assert
+        assert "\\v@claim@groupaeffect@*" in message
+
+    def test_message_states_the_stake_a_wrong_number(self):
+        # Arrange: a reader must know a VALUE is at risk, not just a name.
+        collisions = {"groupaeffect": COLLIDING}
+
+        # Act
+        message = describe_sanitize_collisions(collisions)
+
+        # Assert
+        assert "wrong number" in message
+
+    def test_message_hands_back_an_actionable_remedy(self):
+        # Arrange
+        collisions = {"groupaeffect": COLLIDING}
+
+        # Act
+        message = describe_sanitize_collisions(collisions)
+
+        # Assert
+        assert "Rename the claim IDs" in message


### PR DESCRIPTION
## The bug — a wrong *number* in a published paper

LaTeX macro names are built by `_sanitize_id`, which strips every non-alphanumeric character. So `group-a-effect` and `group_a_effect` both become **`groupaeffect`** — the same macro. The renderer emits one `\@namedef` per claim, and `\@namedef` is `\def`: the second definition **silently replaces** the first.

Reproduced against the real renderer, before the guard:

```
render_claims success: True
\@namedef for v@claim@groupaeffect@nature: 2 definitions
    defines value -> 111
    defines value -> 999
```

`\vclaim{group-a-effect}` printed **999** — the *other* claim's value — into the PDF, with no warning, from a renderer reporting success.

This is the most severe member of the family 2.38.0 and 2.39.0 addressed. Those were wrong *version strings* in metadata. This is **a wrong number in a scientific manuscript**, in a toolchain whose entire purpose is that every value is traceable.

## The fix

`render_claims` refuses before writing anything, naming every colliding ID, the shared macro, what is at stake, and the remedy:

```
Claim IDs collide into the same LaTeX macro name.
...the second definition silently overwrites the earlier one, and every \vclaim
for the group then renders the LAST claim's value -- a wrong number in the
manuscript, with no warning.

  \v@claim@groupaeffect@* <- group-a-effect, group_a_effect

Rename the claim IDs in 00_shared/claims.json so they differ by more than
punctuation...
```

Two distinct claims sharing a macro is **always** a defect — there is no legitimate collision — so it is a hard refusal, not a warning.

## Verification

- 10 tests green.
- **Reproduced the bug first**, against the real renderer, rather than assuming it from reading the code.
- **Wiring verified at the real entry point**, not just the unit: `_auto_render_claims` now raises and **no `claims_rendered.tex` is written**, so wrong values cannot ship. The compile already fails loud on a failed claim render — this reuses that existing gate rather than inventing one.

```
COMPILE BLOCKED at the real entry point:
    Failed to render claims_rendered.tex from .../claims.json: C
    claims_rendered.tex written: False
```