### PR TITLE
fix(gui): supply favicon_href so the shell stops emitting a duplicate icon link

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,23 @@ dependencies = [
     # ModuleNotFoundError — a runtime failure that should have been an
     # install-time resolution failure. Raise this floor whenever settings.py
     # starts consuming a newer scitex-ui symbol.
-    "scitex-ui>=0.5.1",
+    # Floor raised to 0.7.1 alongside the favicon_href wiring in
+    # _django/views.py. The shell's favicon behaviour changed three times, and
+    # this floor is what makes writer's templates correct under all of them:
+    #   <= 0.6.0  no favicon markup in the shell AT ALL (verified against the
+    #             installed 0.6.0 tree: zero matches for `icon` in its
+    #             templates). favicon_href is not consulted; nothing is emitted.
+    #      0.6.4  conditional -- `{% if favicon_href %}` -- so passing it works,
+    #             and omitting it emits nothing.
+    #   >= 0.7.0  UNCONDITIONAL, falling back to the shared SciTeX mark when no
+    #             favicon_href is given. This is what produced writer's
+    #             duplicate icon links before this change.
+    # Writer now always passes favicon_href, so 0.6.4 would also behave. The
+    # floor is 0.7.1 rather than 0.6.4 because on <= 0.6.0 the bare rel="icon"
+    # would silently vanish (we deleted it from extra_css), and because 0.7.1
+    # drops two render-blocking head requests that 0.7.0 introduced -- so 0.7.0
+    # is never the version we want to resolve onto.
+    "scitex-ui>=0.7.1",
     # Pillow powers the thumbnail service for figure/table previews in the
     # editor's insert panel. Core — removing it breaks `api/thumbnail` and
     # the fig/table grid renders empty rectangles.

--- a/src/scitex_writer/_django/templates/writer/editor.html
+++ b/src/scitex_writer/_django/templates/writer/editor.html
@@ -1,9 +1,11 @@
 {% extends "scitex_ui/standalone_shell.html" %}
 {% load static %}
 {% block extra_css %}
-    <link rel="icon"
-          type="image/svg+xml"
-          href="{% static 'writer/favicon.svg' %}">
+    {# The bare SVG icon link is NOT here: the scitex-ui shell emits it from
+       `favicon_href`, which views.py sets to writer/favicon.svg. Declaring it
+       here too would produce two identical rel="icon" links (scitex-ui 0.7.0
+       made the shell's link unconditional). Only the variants the shell cannot
+       express -- sizes= and apple-touch-icon -- belong in this block. #}
     <link rel="icon"
           type="image/png"
           sizes="16x16"

--- a/src/scitex_writer/_django/templates/writer/viewer.html
+++ b/src/scitex_writer/_django/templates/writer/viewer.html
@@ -1,9 +1,11 @@
 {% extends "scitex_ui/standalone_shell.html" %}
 {% load static %}
 {% block extra_css %}
-    <link rel="icon"
-          type="image/svg+xml"
-          href="{% static 'writer/favicon.svg' %}">
+    {# The bare SVG icon link is NOT here: the scitex-ui shell emits it from
+       `favicon_href`, which views.py sets to writer/favicon.svg. Declaring it
+       here too would produce two identical rel="icon" links (scitex-ui 0.7.0
+       made the shell's link unconditional). Only the variants the shell cannot
+       express -- sizes= and apple-touch-icon -- belong in this block. #}
     <link rel="icon"
           type="image/png"
           sizes="16x16"

--- a/src/scitex_writer/_django/views.py
+++ b/src/scitex_writer/_django/views.py
@@ -67,6 +67,27 @@ def _app_label(base: str) -> str:
     return f"{base} (standalone)" if mode == "standalone" else base
 
 
+def _favicon_href() -> str:
+    """Writer's own brand mark, for the scitex-ui shell's icon link.
+
+    scitex-ui 0.7.0 made the shell's ``<link rel="icon">`` UNCONDITIONAL,
+    falling back to the shared SciTeX mark when a view supplies no
+    ``favicon_href`` (scitex_ui/templates/scitex_ui/_branding_head.html).
+    Writer supplied none, so every page emitted the shared mark ON TOP OF
+    writer's own links -- untidy rather than broken, since the shell's link
+    precedes ``extra_css`` and ours won.
+
+    Passing this makes the shell emit WRITER's mark, so there is exactly one
+    bare ``rel="icon"``. The sized PNG variants and the apple-touch-icon stay
+    in each template's ``extra_css``: the shell has no way to express
+    ``sizes=`` or ``apple-touch-icon``, and a single shared SVG is not a
+    substitute for a 180x180 home-screen icon.
+    """
+    from django.templatetags.static import static
+
+    return static("writer/favicon.svg")
+
+
 def editor_page(request):
     """Serve the editor shell page."""
     project = _get_project(request)
@@ -78,6 +99,7 @@ def editor_page(request):
             "app_label": _app_label("SciTeX Writer"),
             "project_dir": project_dir,
             "dark_mode": project.dark_mode if project else False,
+            "favicon_href": _favicon_href(),
         },
         request=request,
     )
@@ -168,6 +190,7 @@ def viewer_page(request):
             "app_name": "writer",
             "app_label": _app_label("SciTeX Writer — Viewer"),
             "project_dir": project_dir,
+            "favicon_href": _favicon_href(),
         },
         request=request,
     )


### PR DESCRIPTION
## What

scitex-ui 0.7.0 made the shell's `<link rel="icon">` **unconditional**, falling back to the shared SciTeX mark when a view supplies no `favicon_href`. Writer supplied none and declares five icon links of its own in `extra_css`, so on 0.7.x every editor and viewer page emitted **six**.

Reported by scitex-ui before it bit us.

## Not a visible regression

The shell includes the branding partial at line 12; `extra_css` is at line 48. Writer's links come later and win in every browser. This is untidy markup, not a broken icon — fixed as tidiness.

## Why setting favicon_href alone was not the fix

It would have **moved** the duplicate, not removed it: the shell emits exactly one bare `rel="icon"`, and writer declared one too. The bare SVG link was always the redundant one — the shell can express it, but cannot express `sizes=` or `apple-touch-icon`.

| | |
|---|---|
| `views.py` | `_favicon_href()` + `favicon_href` in `editor_page` **and** `viewer_page` |
| `{editor,viewer}.html` | drop the bare `rel="icon"` svg link (comment says why) |
| kept in `extra_css` | 16x16, 32x32, 192x192, apple-touch-icon 180x180 |

Net **five** links, as before 0.7.0. A single shared SVG is not a substitute for a 180x180 home-screen icon.

## Verified by rendering, not by reading the diff

The installed `scitex_ui` in the agent container is 0.6.0 and has **no favicon markup at all**, so nothing local could exercise 0.7.1's behaviour. Rendered the real partial in a scratch venv on `scitex-ui==0.7.1`:

```
no favicon_href   -> <link rel="icon" href="/static/scitex_ui/img/scitex-favicon.svg" />
with favicon_href -> <link rel="icon" href="/static/writer/favicon.svg" />
```

## Pin

Raised to `scitex-ui>=0.7.1`. The shell's favicon behaviour has three stages — `<=0.6.0` emits no favicon markup at all, `0.6.4` honours `favicon_href` conditionally, `>=0.7.0` is unconditional with the shared fallback — so 0.6.4 would also work now that writer always passes it. The floor is 0.7.1 because on `<=0.6.0` the bare icon link would silently **vanish** (we just deleted it from `extra_css`), and because 0.7.1 drops two render-blocking head requests that 0.7.0 introduced.

An earlier draft of that pin comment claimed pre-0.7.0 "ignores favicon_href entirely". That was wrong and is corrected in the committed version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)