### PR TITLE
chore(release): promote develop → main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.41.0] - 2026-07-22
+
+### Added
+- **The post-compile gate now verifies that the signature footer and claim marks actually rendered** — the last two deficiency classes from the 2026-06-30 incident (a PDF shipped with no figures, no signature, no clew marks; exit 0, one stdout WARN). The gate had covered figures only. Both new checks read the OUTPUT (`pdftotext`) rather than trusting the input or the log:
+  - *Signature*: the injector marks its work with a sentinel comment in the compiled `.tex`; sentinel present + "Compiled by SciTeX Writer" absent from the PDF text fails the build — the colophon was inlined but never rendered. Sentinel absent means the opt-in feature is off, and there is nothing to verify.
+  - *Claim marks*: a literal `[claim:<id>]` in the rendered text (an undefined `\vclaim`'s typeset fallback) fails the build, naming the ids — the output-level backstop behind the `.tex`-level reconciliation (#344), which holds even when that check was skipped or wrong.
+
+  Poppler-absent degrades to a WARN-skip on both, matching the existing `pdfimages` contract: never a silent pass claim, never a false fail on a bare container. A page-count assertion was deliberately NOT added: there is no source of truth for the expectation, and a gate that fails on correct input trains people to ignore it. (#359)
+
+### Fixed
+- **`pip install scitex-writer[all]` silently under-installed the public `dev`/`docs` extras** (PS-221 §3, enforced by scitex-dev v0.34.0's upgraded audit). `[all]` now self-references `scitex-writer[dev]` + `scitex-writer[docs]` — the spec's canonical shape — keeping each extra the single source of truth. An underscore rename (`_dev`/`_docs`) was tried first and reverted: PS-210 §2 requires a public `[dev]` whose install runs the full test suite, so the two rules together pin the self-reference shape. (#359)
+- **Every PR into `develop` was permanently unmergeable**: branch protection required status contexts named `pytest-matrix / pytest-matrix-on-ubuntu-py3.<N>` — names no check run ever produces (verified against the check-runs API; real names carry no workflow prefix). The protection now names the real contexts, so merges go through the front door instead of needing `--admin`. (repo settings, no code change)
+
 ## [2.40.0] - 2026-07-17
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,23 @@ dependencies = [
     # ModuleNotFoundError — a runtime failure that should have been an
     # install-time resolution failure. Raise this floor whenever settings.py
     # starts consuming a newer scitex-ui symbol.
-    "scitex-ui>=0.5.1",
+    # Floor raised to 0.7.1 alongside the favicon_href wiring in
+    # _django/views.py. The shell's favicon behaviour changed three times, and
+    # this floor is what makes writer's templates correct under all of them:
+    #   <= 0.6.0  no favicon markup in the shell AT ALL (verified against the
+    #             installed 0.6.0 tree: zero matches for `icon` in its
+    #             templates). favicon_href is not consulted; nothing is emitted.
+    #      0.6.4  conditional -- `{% if favicon_href %}` -- so passing it works,
+    #             and omitting it emits nothing.
+    #   >= 0.7.0  UNCONDITIONAL, falling back to the shared SciTeX mark when no
+    #             favicon_href is given. This is what produced writer's
+    #             duplicate icon links before this change.
+    # Writer now always passes favicon_href, so 0.6.4 would also behave. The
+    # floor is 0.7.1 rather than 0.6.4 because on <= 0.6.0 the bare rel="icon"
+    # would silently vanish (we deleted it from extra_css), and because 0.7.1
+    # drops two render-blocking head requests that 0.7.0 introduced -- so 0.7.0
+    # is never the version we want to resolve onto.
+    "scitex-ui>=0.7.1",
     # Pillow powers the thumbnail service for figure/table previews in the
     # editor's insert panel. Core — removing it breaks `api/thumbnail` and
     # the fig/table grid renders empty rectangles.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-writer"
-version = "2.40.0"
+version = "2.41.0"
 description = "LaTeX manuscript compilation system for scientific documents with MCP server"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,15 @@ dependencies = [
 # feature. No menu of half-states to get wrong. `dev` / `docs` remain, because
 # those are for people building writer, not using it.
 all = [
+    # PS-221 §3: every public extra must be a subset of `all`, so the
+    # documented "give me everything" install can never silently
+    # under-install. The canonical shape (spec's own example:
+    # `all = ["figrecipe[scitex]", "figrecipe[dev]"]`) is SELF-REFERENCE, not
+    # duplicated pins — `dev`/`docs` stay the single source of truth for
+    # their contents. (An underscore rename was tried first and rejected:
+    # PS-210 §2 requires a PUBLIC `[dev]` that runs the full suite.)
+    "scitex-writer[dev]",
+    "scitex-writer[docs]",
     # Desktop window for `gui open --desktop`.
     "pywebview>=4.0.0",
     # The workspace shell the editor server runs inside

--- a/scripts/python/check_compile_artifacts.py
+++ b/scripts/python/check_compile_artifacts.py
@@ -91,6 +91,28 @@ _UNDEF_AGG_RE = re.compile(r"There were undefined references")
 # Cap names listed in one report line.
 _MAX_NAMES = 25
 
+# TERTIARY (PDF-text) checks. Both verify the OUTPUT, not the input: the
+# motivating incident (2026-06-30) shipped a PDF whose signature was silently
+# dropped and whose claim marks never materialized, with exit 0 and only a
+# stdout WARN. The compiled .tex says what SHOULD be in the PDF; pdftotext
+# says what IS.
+#
+# Signature: _inline_signature_footer marks its injection with this sentinel
+# comment in the compiled .tex, and the footer typesets a fixed prefix
+# ("Compiled by SciTeX Writer v<version>"). Sentinel present + prefix absent
+# from the PDF text = the colophon was inlined but did not render. The
+# sentinel must be searched in the RAW .tex -- it IS a comment, so the
+# comment-stripped text used for \includegraphics counting never contains it.
+_SIGNATURE_SENTINEL = "% SciTeX signature footer (inlined at compile time)"
+_SIGNATURE_PDF_TEXT = "Compiled by SciTeX Writer"
+
+# Claim placeholders: an undefined \vclaim falls back to typesetting a literal
+# "[claim:<id>]" into the PDF (the silent-failure path check_claim_citations
+# guards at the .tex level). This is the PDF-level backstop: if any literal
+# placeholder made it into the rendered text, the manuscript is citing a claim
+# that resolved to nothing, whatever the .tex-level checks believed.
+_CLAIM_PLACEHOLDER_RE = re.compile(r"\[claim:[^\]\s]{1,80}\]")
+
 
 def log_pass(msg):
     global PASS_COUNT
@@ -150,9 +172,7 @@ def count_pdf_images(pdf_path):
     if proc.returncode != 0:
         return None
     # Data rows start with "<page> <num> ...", e.g. "   1   0 image ...".
-    rows = [
-        ln for ln in proc.stdout.splitlines() if re.match(r"\s*\d+\s+\d+\s", ln)
-    ]
+    rows = [ln for ln in proc.stdout.splitlines() if re.match(r"\s*\d+\s+\d+\s", ln)]
     return len(rows)
 
 
@@ -210,15 +230,110 @@ def _scan_log(log_path, report):
         report("log: there were undefined references (unresolved \\ref/\\cite)")
 
 
+def extract_pdf_text(pdf_path):
+    """PDF text via `pdftotext` (poppler), or None when unavailable/failed.
+
+    Same availability contract as count_pdf_images: poppler lives on the env
+    that actually compiles; a bare container may lack it, and every consumer
+    of this helper must degrade to a WARN-skip, never a silent pass."""
+    if shutil.which("pdftotext") is None:
+        return None
+    try:
+        proc = subprocess.run(
+            ["pdftotext", str(pdf_path), "-"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def _read_raw_tex(compiled_tex):
+    """Raw compiled-.tex text (comments INTACT -- the signature sentinel is a
+    comment), or None when unreadable."""
+    if not compiled_tex:
+        return None
+    try:
+        return Path(compiled_tex).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def check_signature_rendered(raw_tex, pdf_text, report):
+    """TERTIARY: the inlined signature footer must actually render.
+
+    Applicability comes from the compiled .tex itself: the injector marks its
+    work with _SIGNATURE_SENTINEL, so sentinel-absent means the opt-in feature
+    is off and there is nothing to verify (pass). Sentinel-present demands the
+    footer's fixed text in the PDF."""
+    if raw_tex is None:
+        log_warn("could not read compiled .tex -- skipping signature check")
+        return
+    if _SIGNATURE_SENTINEL not in raw_tex:
+        log_pass("signature footer not enabled (opt-in) -- nothing to verify")
+        return
+    if pdf_text is None:
+        log_warn(
+            "signature footer inlined; cannot verify it rendered "
+            "(pdftotext/poppler unavailable or PDF unreadable)"
+        )
+        return
+    if _SIGNATURE_PDF_TEXT in pdf_text:
+        log_pass("signature footer rendered in the PDF")
+    else:
+        report(
+            f"signature footer was inlined into the compiled .tex but "
+            f"'{_SIGNATURE_PDF_TEXT}' is absent from the PDF text -- the "
+            f"colophon did not render (silent drop)."
+        )
+        log_detail(
+            "2026-06-30 incident signature drop: the compile logged only a "
+            "stdout WARN and exited 0."
+        )
+
+
+def check_claim_placeholders(pdf_text, report):
+    """TERTIARY: no literal '[claim:<id>]' may reach the rendered PDF.
+
+    An undefined \\vclaim typesets that placeholder instead of a value. The
+    .tex-level reconciliation (check_claim_citations) should catch it first;
+    this is the output-level backstop that holds even if the .tex checks were
+    skipped or wrong."""
+    if pdf_text is None:
+        # Poppler-absent skip is already reported by the signature check when
+        # applicable; a second WARN here would be noise without new signal.
+        return
+    hits = _dedupe(_CLAIM_PLACEHOLDER_RE.findall(pdf_text))
+    if hits:
+        report(
+            f"{len(hits)} claim placeholder(s) rendered literally in the PDF "
+            f"(undefined \\vclaim): {_fmt_names(hits)}"
+        )
+        log_detail(
+            "fix: register the claim id(s) in claims.json / re-run "
+            "render_claims so the macro resolves to a value."
+        )
+    else:
+        log_pass("no literal [claim:...] placeholders in the PDF text")
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Post-compile verification gate: fail loud on a deficient "
         "PDF (figures referenced but not embedded; log deficiency signals)."
     )
     parser.add_argument("project_dir", nargs="?", default=".")
-    parser.add_argument("--compiled-tex", default=os.environ.get("SCITEX_WRITER_COMPILED_TEX"))
+    parser.add_argument(
+        "--compiled-tex", default=os.environ.get("SCITEX_WRITER_COMPILED_TEX")
+    )
     parser.add_argument("--pdf", default=os.environ.get("SCITEX_WRITER_COMPILED_PDF"))
-    parser.add_argument("--log", default=os.environ.get("SCITEX_WRITER_GLOBAL_LOG_FILE"))
+    parser.add_argument(
+        "--log", default=os.environ.get("SCITEX_WRITER_GLOBAL_LOG_FILE")
+    )
     parser.add_argument("--level", choices=list(_LEVELS), default=None)
     args = parser.parse_args()
 
@@ -275,6 +390,11 @@ def main():
 
     # --- SECONDARY: log deficiency scan ---
     _scan_log(args.log, report)
+
+    # --- TERTIARY: PDF-text completeness (signature, claim placeholders) ---
+    pdf_text = extract_pdf_text(args.pdf) if args.pdf else None
+    check_signature_rendered(_read_raw_tex(args.compiled_tex), pdf_text, report)
+    check_claim_placeholders(pdf_text, report)
 
     print()
     print(

--- a/src/scitex_writer/_annotations/_emit.py
+++ b/src/scitex_writer/_annotations/_emit.py
@@ -2,12 +2,12 @@
 # -*- coding: utf-8 -*-
 """The emit seam (§4) — annotation → channel notification.
 
-PROVISIONAL RAIL. The design doc (§4) recommends scitex-todo card events
+PROVISIONAL RAIL. The design doc (§4) recommends scitex-cards card events
 as the durable notification rail, but the exact contract (card model,
 body schema, resolve/close semantics) is pending **scitex-agentic-journal
 ratification** (§5.4). This module keeps the whole mechanism behind a
 single ``emit()`` function so the rail is a swappable impl detail, not an
-API change. Do NOT hard-couple callers to scitex-todo.
+API change. Do NOT hard-couple callers to scitex-cards.
 
 Spike 0 behaviour: ``emit()`` PERSISTS the record (SQLite, ``_db``) and
 POSTS a one-line ``comment_task`` to the manuscript's owning card. Both
@@ -54,19 +54,19 @@ def _notify(
     card_id: str,
     store: Optional[PathLike] = None,
 ) -> Tuple[bool, Optional[str]]:
-    """PROVISIONAL: post the annotation summary to a scitex-todo card.
+    """PROVISIONAL: post the annotation summary to a scitex-cards card.
 
-    Returns ``(notified, notify_error)``. The scitex-todo import is LAZY so
-    the module still imports where scitex-todo is absent (e.g. CI). This is
+    Returns ``(notified, notify_error)``. The scitex-cards import is LAZY so
+    the module still imports where scitex-cards is absent (e.g. CI). This is
     fail-soft for PERSISTENCE (a failed notify never rolls back the row)
     but NOT silent: the reason is surfaced to the caller as ``notify_error``
     (no swallowed exception). ``store`` lets tests point at a tmp
-    ``tasks.yaml`` so the real shared store is never written.
+    store so the real shared one is never written.
     """
     try:
-        from scitex_todo import comment_task
+        from scitex_cards import comment_task
     except ImportError:
-        return False, "scitex-todo not installed — notification rail unavailable"
+        return False, "scitex-cards not installed — notification rail unavailable"
 
     try:
         comment_task(

--- a/src/scitex_writer/_django/templates/writer/editor.html
+++ b/src/scitex_writer/_django/templates/writer/editor.html
@@ -1,9 +1,11 @@
 {% extends "scitex_ui/standalone_shell.html" %}
 {% load static %}
 {% block extra_css %}
-    <link rel="icon"
-          type="image/svg+xml"
-          href="{% static 'writer/favicon.svg' %}">
+    {# The bare SVG icon link is NOT here: the scitex-ui shell emits it from
+       `favicon_href`, which views.py sets to writer/favicon.svg. Declaring it
+       here too would produce two identical rel="icon" links (scitex-ui 0.7.0
+       made the shell's link unconditional). Only the variants the shell cannot
+       express -- sizes= and apple-touch-icon -- belong in this block. #}
     <link rel="icon"
           type="image/png"
           sizes="16x16"

--- a/src/scitex_writer/_django/templates/writer/viewer.html
+++ b/src/scitex_writer/_django/templates/writer/viewer.html
@@ -1,9 +1,11 @@
 {% extends "scitex_ui/standalone_shell.html" %}
 {% load static %}
 {% block extra_css %}
-    <link rel="icon"
-          type="image/svg+xml"
-          href="{% static 'writer/favicon.svg' %}">
+    {# The bare SVG icon link is NOT here: the scitex-ui shell emits it from
+       `favicon_href`, which views.py sets to writer/favicon.svg. Declaring it
+       here too would produce two identical rel="icon" links (scitex-ui 0.7.0
+       made the shell's link unconditional). Only the variants the shell cannot
+       express -- sizes= and apple-touch-icon -- belong in this block. #}
     <link rel="icon"
           type="image/png"
           sizes="16x16"

--- a/src/scitex_writer/_django/views.py
+++ b/src/scitex_writer/_django/views.py
@@ -67,6 +67,27 @@ def _app_label(base: str) -> str:
     return f"{base} (standalone)" if mode == "standalone" else base
 
 
+def _favicon_href() -> str:
+    """Writer's own brand mark, for the scitex-ui shell's icon link.
+
+    scitex-ui 0.7.0 made the shell's ``<link rel="icon">`` UNCONDITIONAL,
+    falling back to the shared SciTeX mark when a view supplies no
+    ``favicon_href`` (scitex_ui/templates/scitex_ui/_branding_head.html).
+    Writer supplied none, so every page emitted the shared mark ON TOP OF
+    writer's own links -- untidy rather than broken, since the shell's link
+    precedes ``extra_css`` and ours won.
+
+    Passing this makes the shell emit WRITER's mark, so there is exactly one
+    bare ``rel="icon"``. The sized PNG variants and the apple-touch-icon stay
+    in each template's ``extra_css``: the shell has no way to express
+    ``sizes=`` or ``apple-touch-icon``, and a single shared SVG is not a
+    substitute for a 180x180 home-screen icon.
+    """
+    from django.templatetags.static import static
+
+    return static("writer/favicon.svg")
+
+
 def editor_page(request):
     """Serve the editor shell page."""
     project = _get_project(request)
@@ -78,6 +99,7 @@ def editor_page(request):
             "app_label": _app_label("SciTeX Writer"),
             "project_dir": project_dir,
             "dark_mode": project.dark_mode if project else False,
+            "favicon_href": _favicon_href(),
         },
         request=request,
     )
@@ -168,6 +190,7 @@ def viewer_page(request):
             "app_name": "writer",
             "app_label": _app_label("SciTeX Writer — Viewer"),
             "project_dir": project_dir,
+            "favicon_href": _favicon_href(),
         },
         request=request,
     )

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -30,8 +30,8 @@ CROSS_PACKAGE_IMPORTS = [
     "scitex_dev.skills",
     "scitex_dev.system_deps",
     "scitex_dev.types",
+    "scitex_cards",
     "scitex_scholar",
-    "scitex_todo",
     "scitex_ui",
 ]
 # ===== END AUTO-GENERATED =====

--- a/tests/scitex_writer/_annotations/test__emit.py
+++ b/tests/scitex_writer/_annotations/test__emit.py
@@ -2,9 +2,9 @@
 # -*- coding: utf-8 -*-
 """Tests for scitex_writer._annotations._emit (the emit seam).
 
-The scitex-todo rail is OPTIONAL — tests that assert a comment was posted
-``pytest.importorskip("scitex_todo")`` so they skip where the dep is
-absent (e.g. CI) and run where present. NO mock of scitex_todo
+The scitex-cards rail is OPTIONAL — tests that assert a comment was posted
+``pytest.importorskip("scitex_cards")`` so they skip where the dep is
+absent (e.g. CI) and run where present. NO mock of scitex_cards
 (STX-NM002). Real tmp store isolates the shared ``tasks.yaml``. One assert
 per test (STX-TQ007); no monkeypatch (PA-306).
 """
@@ -25,9 +25,9 @@ def _annotation(text: str = "fix this claim") -> Annotation:
 
 @pytest.fixture
 def todo_store(tmp_path):
-    """A real tmp scitex-todo store seeded with the owning card."""
-    pytest.importorskip("scitex_todo")
-    from scitex_todo import add_task
+    """A real tmp scitex-cards store seeded with the owning card."""
+    pytest.importorskip("scitex_cards")
+    from scitex_cards import add_task
 
     store = tmp_path / "tasks.yaml"
     add_task(
@@ -92,7 +92,7 @@ def test_emit_reports_notified_true_with_seeded_card(tmp_path, todo_store):
 
 def test_emit_posts_comment_to_owning_card(tmp_path, todo_store):
     # Arrange
-    from scitex_todo import get_task
+    from scitex_cards import get_task
 
     db = tmp_path / "writer.db"
     emit(

--- a/tests/scitex_writer/_annotations/test__service.py
+++ b/tests/scitex_writer/_annotations/test__service.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for scitex_writer._annotations._service (POST orchestration).
 
-Real SQLite in ``tmp_path``; the scitex-todo rail is optional so the
-notified-True path ``pytest.importorskip("scitex_todo")``. No mocks
+Real SQLite in ``tmp_path``; the scitex-cards rail is optional so the
+notified-True path ``pytest.importorskip("scitex_cards")``. No mocks
 (STX-NM002); one assert per test (STX-TQ007); no monkeypatch (PA-306).
 """
 
@@ -21,9 +21,9 @@ def _body(text: str = "please clarify") -> dict:
 
 @pytest.fixture
 def todo_store(tmp_path):
-    """A real tmp scitex-todo store seeded with the owning card."""
-    pytest.importorskip("scitex_todo")
-    from scitex_todo import add_task
+    """A real tmp scitex-cards store seeded with the owning card."""
+    pytest.importorskip("scitex_cards")
+    from scitex_cards import add_task
 
     store = tmp_path / "tasks.yaml"
     add_task(

--- a/tests/scripts/python/test_check_compile_artifacts.py
+++ b/tests/scripts/python/test_check_compile_artifacts.py
@@ -19,7 +19,6 @@ sys.path.insert(0, str(ROOT_DIR / "scripts" / "python"))
 
 from check_compile_artifacts import (  # noqa: E402
     count_includegraphics,
-    count_pdf_images,
     extract_undefined,
 )
 
@@ -54,29 +53,50 @@ def _write(tmp_path, rel, content):
     return p
 
 
+_FAKE_PDFTOTEXT = """#!/usr/bin/env python3
+import os
+print(os.environ.get("FAKE_PDFTOTEXT_TEXT", ""))
+"""
+
+
 def _fake_bin(tmp_path):
-    """Create a fake `pdfimages` in tmp_path/bin and return that bin dir."""
+    """Create fake `pdfimages` + `pdftotext` in tmp_path/bin; return the dir.
+
+    pdftotext's stdout is driven by $FAKE_PDFTOTEXT_TEXT (default empty), so
+    the PDF-text checks (signature, claim placeholders) run hermetically."""
     binp = tmp_path / "bin"
     binp.mkdir(exist_ok=True)
-    exe = binp / "pdfimages"
-    exe.write_text(_FAKE_PDFIMAGES, encoding="utf-8")
-    exe.chmod(exe.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    for name, body in (
+        ("pdfimages", _FAKE_PDFIMAGES),
+        ("pdftotext", _FAKE_PDFTOTEXT),
+    ):
+        exe = binp / name
+        exe.write_text(body, encoding="utf-8")
+        exe.chmod(exe.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
     return binp
 
 
-def _run(tmp_path, *extra, rows=None, use_fake=True):
+def _run(tmp_path, *extra, rows=None, use_fake=True, pdf_text=None):
     env = dict(os.environ)
-    for k in ("SCITEX_WRITER_COMPILE_ARTIFACTS", "SCITEX_WRITER_COMPILED_TEX",
-              "SCITEX_WRITER_COMPILED_PDF", "SCITEX_WRITER_GLOBAL_LOG_FILE"):
+    for k in (
+        "SCITEX_WRITER_COMPILE_ARTIFACTS",
+        "SCITEX_WRITER_COMPILED_TEX",
+        "SCITEX_WRITER_COMPILED_PDF",
+        "SCITEX_WRITER_GLOBAL_LOG_FILE",
+    ):
         env.pop(k, None)
     env["HOME"] = str(tmp_path / "_home")
     if use_fake:
         env["PATH"] = str(_fake_bin(tmp_path)) + os.pathsep + env.get("PATH", "")
     if rows is not None:
         env["FAKE_PDFIMAGES_ROWS"] = str(rows)
+    if pdf_text is not None:
+        env["FAKE_PDFTOTEXT_TEXT"] = pdf_text
     return subprocess.run(
         [sys.executable, str(_SCRIPT), str(tmp_path), *extra],
-        capture_output=True, text=True, env=env,
+        capture_output=True,
+        text=True,
+        env=env,
     )
 
 
@@ -111,11 +131,16 @@ def test_count_pdf_images_uses_pdfimages(tmp_path):
     pdf = _write(tmp_path, "x.pdf", "%PDF-1.5\n")
     # Act
     out = subprocess.run(
-        [sys.executable, "-c",
-         "import sys;sys.path.insert(0,%r);"
-         "from check_compile_artifacts import count_pdf_images;"
-         "print(count_pdf_images(%r))" % (str(ROOT_DIR / "scripts" / "python"), str(pdf))],
-        capture_output=True, text=True,
+        [
+            sys.executable,
+            "-c",
+            "import sys;sys.path.insert(0,%r);"
+            "from check_compile_artifacts import count_pdf_images;"
+            "print(count_pdf_images(%r))"
+            % (str(ROOT_DIR / "scripts" / "python"), str(pdf)),
+        ],
+        capture_output=True,
+        text=True,
         env={**os.environ, "PATH": env_path, "FAKE_PDFIMAGES_ROWS": "4"},
     )
     # Assert
@@ -133,8 +158,14 @@ def test_fail_when_referenced_but_zero_embedded(tmp_path):
     _write(tmp_path, "compiled.tex", _TEX_5)
     _write(tmp_path, "out.pdf", "%PDF-1.5\n")
     # Act
-    proc = _run(tmp_path, "--compiled-tex", str(tmp_path / "compiled.tex"),
-                "--pdf", str(tmp_path / "out.pdf"), rows=0)
+    proc = _run(
+        tmp_path,
+        "--compiled-tex",
+        str(tmp_path / "compiled.tex"),
+        "--pdf",
+        str(tmp_path / "out.pdf"),
+        rows=0,
+    )
     # Assert
     assert proc.returncode == 1
 
@@ -145,8 +176,14 @@ def test_warn_when_partial_embedding(tmp_path):
     _write(tmp_path, "compiled.tex", _TEX_5)
     _write(tmp_path, "out.pdf", "%PDF-1.5\n")
     # Act
-    proc = _run(tmp_path, "--compiled-tex", str(tmp_path / "compiled.tex"),
-                "--pdf", str(tmp_path / "out.pdf"), rows=3)
+    proc = _run(
+        tmp_path,
+        "--compiled-tex",
+        str(tmp_path / "compiled.tex"),
+        "--pdf",
+        str(tmp_path / "out.pdf"),
+        rows=3,
+    )
     # Assert
     assert proc.returncode == 0
 
@@ -157,8 +194,14 @@ def test_pass_when_all_embedded(tmp_path):
     _write(tmp_path, "compiled.tex", _TEX_5)
     _write(tmp_path, "out.pdf", "%PDF-1.5\n")
     # Act
-    proc = _run(tmp_path, "--compiled-tex", str(tmp_path / "compiled.tex"),
-                "--pdf", str(tmp_path / "out.pdf"), rows=5)
+    proc = _run(
+        tmp_path,
+        "--compiled-tex",
+        str(tmp_path / "compiled.tex"),
+        "--pdf",
+        str(tmp_path / "out.pdf"),
+        rows=5,
+    )
     # Assert
     assert proc.returncode == 0
 
@@ -169,8 +212,16 @@ def test_off_level_skips_failure(tmp_path):
     _write(tmp_path, "compiled.tex", _TEX_5)
     _write(tmp_path, "out.pdf", "%PDF-1.5\n")
     # Act
-    proc = _run(tmp_path, "--compiled-tex", str(tmp_path / "compiled.tex"),
-                "--pdf", str(tmp_path / "out.pdf"), "--level", "off", rows=0)
+    proc = _run(
+        tmp_path,
+        "--compiled-tex",
+        str(tmp_path / "compiled.tex"),
+        "--pdf",
+        str(tmp_path / "out.pdf"),
+        "--level",
+        "off",
+        rows=0,
+    )
     # Assert
     assert proc.returncode == 0
 
@@ -181,8 +232,14 @@ def test_no_figures_passes(tmp_path):
     _write(tmp_path, "compiled.tex", _TEX_0)
     _write(tmp_path, "out.pdf", "%PDF-1.5\n")
     # Act
-    proc = _run(tmp_path, "--compiled-tex", str(tmp_path / "compiled.tex"),
-                "--pdf", str(tmp_path / "out.pdf"), rows=0)
+    proc = _run(
+        tmp_path,
+        "--compiled-tex",
+        str(tmp_path / "compiled.tex"),
+        "--pdf",
+        str(tmp_path / "out.pdf"),
+        rows=0,
+    )
     # Assert
     assert proc.returncode == 0
 
@@ -195,8 +252,14 @@ def test_no_poppler_warns_not_fails(tmp_path):
     # Act (use_fake=False: PATH has no pdfimages dir; the script's
     # shutil.which("pdfimages") may still find a real one, so this asserts the
     # non-fatal contract regardless: referenced+unverifiable must NOT fail.)
-    proc = _run(tmp_path, "--compiled-tex", str(tmp_path / "compiled.tex"),
-                "--pdf", str(tmp_path / "out.pdf"), use_fake=False)
+    proc = _run(
+        tmp_path,
+        "--compiled-tex",
+        str(tmp_path / "compiled.tex"),
+        "--pdf",
+        str(tmp_path / "out.pdf"),
+        use_fake=False,
+    )
     # Assert
     assert proc.returncode in (0, 1)
 
@@ -208,9 +271,16 @@ def test_log_scan_flags_missing_file(tmp_path):
     _write(tmp_path, "out.pdf", "%PDF-1.5\n")
     _write(tmp_path, "c.log", "Package pdftex.def Error: File `fig.jpg' not found\n")
     # Act
-    proc = _run(tmp_path, "--compiled-tex", str(tmp_path / "compiled.tex"),
-                "--pdf", str(tmp_path / "out.pdf"),
-                "--log", str(tmp_path / "c.log"), rows=0)
+    proc = _run(
+        tmp_path,
+        "--compiled-tex",
+        str(tmp_path / "compiled.tex"),
+        "--pdf",
+        str(tmp_path / "out.pdf"),
+        "--log",
+        str(tmp_path / "c.log"),
+        rows=0,
+    )
     # Assert
     assert proc.returncode == 1
 
@@ -222,9 +292,16 @@ def test_log_scan_ignores_scitex_citation_nudge(tmp_path):
     _write(tmp_path, "out.pdf", "%PDF-1.5\n")
     _write(tmp_path, "c.log", "WARN: SciTeX Writer citation not found!\n")
     # Act
-    proc = _run(tmp_path, "--compiled-tex", str(tmp_path / "compiled.tex"),
-                "--pdf", str(tmp_path / "out.pdf"),
-                "--log", str(tmp_path / "c.log"), rows=0)
+    proc = _run(
+        tmp_path,
+        "--compiled-tex",
+        str(tmp_path / "compiled.tex"),
+        "--pdf",
+        str(tmp_path / "out.pdf"),
+        "--log",
+        str(tmp_path / "c.log"),
+        rows=0,
+    )
     # Assert
     assert proc.returncode == 0
 
@@ -245,7 +322,9 @@ def test_extract_undefined_returns_reference_keys():
 
 def test_extract_undefined_returns_citation_keys():
     # Arrange
-    log = "LaTeX Warning: Citation `Kuhlmann2018' on page 2 undefined on input line 9.\n"
+    log = (
+        "LaTeX Warning: Citation `Kuhlmann2018' on page 2 undefined on input line 9.\n"
+    )
     # Act
     refs, cites = extract_undefined(log)
     # Assert
@@ -284,8 +363,92 @@ def test_undefined_reference_log_fails_and_lists_the_key(tmp_path):
         "LaTeX Warning: There were undefined references.\n",
     )
     # Act
-    proc = _run(tmp_path, "--compiled-tex", str(tmp_path / "compiled.tex"),
-                "--pdf", str(tmp_path / "out.pdf"),
-                "--log", str(tmp_path / "c.log"), rows=0)
+    proc = _run(
+        tmp_path,
+        "--compiled-tex",
+        str(tmp_path / "compiled.tex"),
+        "--pdf",
+        str(tmp_path / "out.pdf"),
+        "--log",
+        str(tmp_path / "c.log"),
+        rows=0,
+    )
     # Assert
     assert (proc.returncode == 1) and ("tab:2_scorecard" in proc.stdout)
+
+
+# ============================================================================
+# tertiary PDF-text checks: signature footer + claim placeholders
+# ============================================================================
+
+_SENTINEL = "% SciTeX signature footer (inlined at compile time)"
+_TEX_SIGNED = _TEX_0.replace(
+    "\\end{document}", _SENTINEL + "\n\\end{document}"
+)
+
+
+def test_signature_inlined_but_absent_from_pdf_fails(tmp_path):
+    """Sentinel in the compiled .tex + no colophon text in the PDF -> FAIL
+    (the 2026-06-30 silent signature drop)."""
+    # Arrange
+    _write(tmp_path, "compiled.tex", _TEX_SIGNED)
+    _write(tmp_path, "out.pdf", "%PDF-1.5\n")
+    # Act
+    proc = _run(tmp_path, "--compiled-tex", str(tmp_path / "compiled.tex"),
+                "--pdf", str(tmp_path / "out.pdf"), rows=0,
+                pdf_text="Body text only, no colophon here.")
+    # Assert
+    assert (proc.returncode == 1) and ("colophon did not render" in proc.stdout)
+
+
+def test_signature_inlined_and_rendered_passes(tmp_path):
+    """Sentinel present + 'Compiled by SciTeX Writer' in the PDF text -> pass."""
+    # Arrange
+    _write(tmp_path, "compiled.tex", _TEX_SIGNED)
+    _write(tmp_path, "out.pdf", "%PDF-1.5\n")
+    # Act
+    proc = _run(tmp_path, "--compiled-tex", str(tmp_path / "compiled.tex"),
+                "--pdf", str(tmp_path / "out.pdf"), rows=0,
+                pdf_text="Compiled by SciTeX Writer v2.41.0")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_signature_not_enabled_skips_check(tmp_path):
+    """No sentinel (opt-in off) -> nothing to verify, exit 0 even with an
+    empty PDF text."""
+    # Arrange
+    _write(tmp_path, "compiled.tex", _TEX_0)
+    _write(tmp_path, "out.pdf", "%PDF-1.5\n")
+    # Act
+    proc = _run(tmp_path, "--compiled-tex", str(tmp_path / "compiled.tex"),
+                "--pdf", str(tmp_path / "out.pdf"), rows=0, pdf_text="")
+    # Assert
+    assert proc.returncode == 0
+
+
+def test_claim_placeholder_in_pdf_text_fails(tmp_path):
+    """A literal [claim:<id>] in the rendered PDF -> FAIL, naming the id
+    (undefined \\vclaim backstop at the OUTPUT level)."""
+    # Arrange
+    _write(tmp_path, "compiled.tex", _TEX_0)
+    _write(tmp_path, "out.pdf", "%PDF-1.5\n")
+    # Act
+    proc = _run(tmp_path, "--compiled-tex", str(tmp_path / "compiled.tex"),
+                "--pdf", str(tmp_path / "out.pdf"), rows=0,
+                pdf_text="value [claim:cohorta_inter_ncaps] more text")
+    # Assert
+    assert (proc.returncode == 1) and ("cohorta_inter_ncaps" in proc.stdout)
+
+
+def test_signature_unverifiable_without_pdftotext_warns_not_fails(tmp_path):
+    """Sentinel present but poppler absent -> WARN-skip (exit 0), never a
+    silent pass claim and never a false fail."""
+    # Arrange
+    _write(tmp_path, "compiled.tex", _TEX_SIGNED)
+    _write(tmp_path, "out.pdf", "%PDF-1.5\n")
+    # Act
+    proc = _run(tmp_path, "--compiled-tex", str(tmp_path / "compiled.tex"),
+                "--pdf", str(tmp_path / "out.pdf"), use_fake=False)
+    # Assert
+    assert (proc.returncode == 0) and ("cannot verify it rendered" in proc.stdout)


### PR DESCRIPTION
## What this is

A **develop → main promotion** PR, opened by `scitex-dev` as part of a fleet-wide sweep. Your default branch is behind your own `develop`, which means `main` no longer reflects what has been released.

**You decide whether to merge it.** I do not merge other packages' default branches — opening a PR is reversible and CI-gated; merging is neither. If this is wrong for your repo, close it and nothing is lost.

## Why it was opened

Measured across the fleet: 22 repos had `main` behind their newest tag. That gap is not cosmetic — it means:

1. Anyone reading your default branch sees stale code.
2. A published release on PyPI can have no corresponding commit on `main`.
3. The next promotion accumulates, so the diff only gets harder to review.

## On the "behind" count

If the compare view says `main` is also *behind* `develop` by a few commits, that is expected and not divergence: merge-based promotion makes `main` accumulate merge commits that `develop` never sees. It is the normal steady state for this workflow.

## Authorisation

Operator ruling, 2026-08-04: PRs against repos `scitex-dev` does not own are explicitly authorized. This sweep was held for six days waiting on exactly that word, and it applies here.

Tracked on card `default-branch-behind-published-release-promotion-gap-20260729`.
