### PR TITLE
ci(sif-shim): make exec-in-sif.sh adapt to the host instead of assuming Spartan

### DIFF
--- a/.github/ci/exec-in-sif.sh
+++ b/.github/ci/exec-in-sif.sh
@@ -1,51 +1,111 @@
 #!/usr/bin/env bash
-# Outer apptainer-exec wrapper for scitex-tex's self-hosted (Spartan) CI.
+# Outer apptainer-exec wrapper for scitex-writer's self-hosted CI.
 #
-# Runs ON THE RUNNER (outside the SIF). Resolves the apptainer shim + SIF image
-# from the repo Actions Variables, then `apptainer exec`s the SIF and hands off
-# to an INNER script (run inside the container). Keeps every workflow job's YAML
-# down to one line — `bash .github/ci/exec-in-sif.sh <inner-script> [args...]` —
-# and concentrates all the HPC/SIF plumbing (shim PATH, ~-expansion, scratch,
-# binds) in one version-controlled place.
+# Runs ON THE RUNNER (outside the SIF). Resolves apptainer + the SIF image, then
+# `apptainer exec`s the SIF and hands off to an INNER script (run inside the
+# container). Keeps every workflow job's YAML down to one line —
+# `bash .github/ci/exec-in-sif.sh <inner-script> [args...]` — and concentrates
+# all the SIF plumbing (apptainer resolution, ~-expansion, scratch, binds) in
+# one version-controlled place.
 #
-# Required env (set by the workflow from repo Actions Variables):
-#   SCITEX_CI_APPTAINER   path to the apptainer shim   (e.g. ~/.env-3.11/bin/apptainer)
-#   SCITEX_CI_SIF         path to the CI SIF image     (e.g. ~/.scitex/dev/containers/ci-cpu.sif)
+# HOST-AGNOSTIC. This script is NOT Spartan-only: it auto-adapts to whichever
+# self-hosted runner picks the job up, keyed off what actually exists on the box.
+#
+#   * Spartan HPC — the GPFS project dir /data/gpfs/projects/punim0264 EXISTS:
+#     apptainer comes from the ~/.env-3.11 shim named by SCITEX_CI_APPTAINER,
+#     apptainer scratch lives on the GPFS project, and punim0264 is bound into
+#     the container ($HOME/.scitex there is a symlink into it, so without the
+#     bind the symlink dangles inside the SIF).
+#
+#   * Local compute nodes (scitex-compute-01..04) — NO /data/gpfs at all:
+#     apptainer is the distro package on PATH (/usr/bin/apptainer), scratch is
+#     host-local under $HOME/.cache/scitex-ci, and the GPFS bind is OMITTED
+#     (apptainer refuses a bind whose source does not exist, and `mkdir -p` on a
+#     GPFS scratch path would hard-fail here under `set -e`).
+#
+# Each of those three decisions (interpreter, scratch, bind) is made
+# INDEPENDENTLY from a probe of this host, so a runner that matches neither
+# profile exactly still gets a coherent command line.
+#
+# Env (set by the workflow from repo Actions Variables):
+#   SCITEX_CI_APPTAINER   OPTIONAL path to an apptainer shim
+#                         (e.g. ~/.env-3.11/bin/apptainer). Honoured when it
+#                         points at an executable; otherwise apptainer is taken
+#                         from PATH.
+#   SCITEX_CI_SIF         REQUIRED path to the CI SIF image
+#                         (e.g. ~/.scitex/dev/containers/ci-cpu.sif)
 #
 # Usage:
 #   bash .github/ci/exec-in-sif.sh run-in-sif.sh 3.12
 #
-# Fail-loud (operator directive): a missing shim or SIF is a HARD error — never
-# a silent fallback to a bare-runner install.
+# Fail-loud (operator directive): if NEITHER the shim nor PATH yields an
+# apptainer, or the SIF is missing, that is a HARD error naming what was tried
+# — never a silent fallback to a bare-runner install.
 set -euo pipefail
 
 INNER="${1:?inner script name required (relative to .github/ci/)}"
 shift || true
 
-# The runner's job shell is --noprofile --norc (no Lmod), so the apptainer shim
-# must be put on PATH explicitly; it execs the real Apptainer binary directly.
-# ~-expand the Actions-Variable paths: a quoted "~/…" is NOT tilde-expanded by
-# the shell, so substitute a leading ~ with $HOME ourselves.
-APPTAINER="${SCITEX_CI_APPTAINER:?SCITEX_CI_APPTAINER not set (repo Actions Variable)}"
-SIF="${SCITEX_CI_SIF:?SCITEX_CI_SIF not set (repo Actions Variable)}"
-APPTAINER="${APPTAINER/#\~/$HOME}"
-SIF="${SIF/#\~/$HOME}"
+# Spartan's job shell is --noprofile --norc (no Lmod), so its apptainer shim dir
+# must be put on PATH explicitly; the shim execs the real Apptainer binary.
+# Harmless where that directory is absent — a non-existent PATH entry is simply
+# never matched — which is the case on the local compute nodes.
 export PATH="$HOME/.env-3.11/bin:$PATH"
 
-[ -x "$APPTAINER" ] || {
-    echo "::error::apptainer shim not executable at $APPTAINER"
+# ~-expand the Actions-Variable paths: a quoted "~/…" is NOT tilde-expanded by
+# the shell, so substitute a leading ~ with $HOME ourselves.
+APPTAINER_VAR="${SCITEX_CI_APPTAINER:-}"
+APPTAINER_VAR="${APPTAINER_VAR/#\~/$HOME}"
+SIF="${SCITEX_CI_SIF:?SCITEX_CI_SIF not set (repo Actions Variable)}"
+SIF="${SIF/#\~/$HOME}"
+
+# Apptainer resolution, in order:
+#   1. SCITEX_CI_APPTAINER when it names an executable  (Spartan's shim)
+#   2. `apptainer` on PATH                              (local compute nodes)
+# Only when NEITHER resolves is this an error — and the message names BOTH
+# attempts, because "which one did you even try" is the whole diagnosis.
+if [ -n "$APPTAINER_VAR" ] && [ -x "$APPTAINER_VAR" ]; then
+    APPTAINER="$APPTAINER_VAR"
+    APPTAINER_FROM="SCITEX_CI_APPTAINER"
+elif APPTAINER="$(command -v apptainer 2>/dev/null)"; then
+    APPTAINER_FROM="PATH"
+else
+    echo "::error::no apptainer on this runner. Tried (1) SCITEX_CI_APPTAINER=${SCITEX_CI_APPTAINER:-<unset>} (expanded to '${APPTAINER_VAR:-<empty>}') — not an executable; (2) 'apptainer' on PATH ($PATH) — not found. Install apptainer on this runner, or point SCITEX_CI_APPTAINER at a working shim. Running the job outside the SIF on a bare-runner install is NOT an acceptable fallback."
     exit 1
-}
+fi
+
 [ -f "$SIF" ] || {
     echo "::error::CI SIF missing at $SIF — rebuild it: scitex-container apptainer build ci-cpu"
     exit 1
 }
 
-# apptainer scratch on the shared FS — keeps HOME clean.
-export APPTAINER_TMPDIR="/data/gpfs/projects/punim0264/ywatanabe/ci/apptainer-tmp"
+# Apptainer scratch. On Spartan the GPFS project scratch (shared FS) keeps HOME
+# clean; everywhere else that path does not exist, and `mkdir -p` under it would
+# be a hard failure, so fall back to host-local scratch under $HOME.
+GPFS_PROJECT="/data/gpfs/projects/punim0264"
+if [ -d "$GPFS_PROJECT" ]; then
+    export APPTAINER_TMPDIR="$GPFS_PROJECT/ywatanabe/ci/apptainer-tmp"
+else
+    export APPTAINER_TMPDIR="$HOME/.cache/scitex-ci/apptainer-tmp"
+fi
 mkdir -p "$APPTAINER_TMPDIR"
 
-# --bind punim0264: $HOME/.scitex is a symlink into punim0264; bind it so the
-# symlink resolves inside the container. --pwd "$PWD" keeps the checkout as cwd.
-exec "$APPTAINER" exec --pwd "$PWD" --bind /data/gpfs/projects/punim0264 \
-    "$SIF" bash ".github/ci/$INNER" "$@"
+# Build the argv as an ARRAY so the GPFS bind can be dropped cleanly rather than
+# passed as an empty string. --pwd "$PWD" keeps the checkout as cwd.
+APPTAINER_ARGV=(exec --pwd "$PWD")
+if [ -d "$GPFS_PROJECT" ]; then
+    APPTAINER_ARGV+=(--bind "$GPFS_PROJECT")
+    GPFS_STATE="present (scratch on GPFS, punim0264 bound)"
+else
+    GPFS_STATE="absent (scratch under \$HOME, no GPFS bind)"
+fi
+
+# Echo the resolved plan: when a run fails on an unfamiliar node, the FIRST
+# question is which of the two profiles it took.
+echo "exec-in-sif: apptainer=$APPTAINER (via $APPTAINER_FROM)"
+echo "exec-in-sif: sif=$SIF"
+echo "exec-in-sif: $GPFS_PROJECT $GPFS_STATE"
+echo "exec-in-sif: APPTAINER_TMPDIR=$APPTAINER_TMPDIR"
+echo "exec-in-sif: + $APPTAINER ${APPTAINER_ARGV[*]} $SIF bash .github/ci/$INNER $*"
+
+exec "$APPTAINER" "${APPTAINER_ARGV[@]}" "$SIF" bash ".github/ci/$INNER" "$@"


### PR DESCRIPTION
ci(sif-shim): make exec-in-sif.sh adapt to the host instead of assuming Spartan

The fleet's CI has moved off Spartan onto local compute nodes
(scitex-compute-01..04). There /data/gpfs does not exist and
~/.env-3.11/bin/apptainer does not exist, so this script -- which runs
under `set -euo pipefail` -- had two hard failures waiting in it:

  * `[ -x "$APPTAINER" ]` errored out because SCITEX_CI_APPTAINER named a
    shim that is not on the box;
  * `mkdir -p /data/gpfs/projects/punim0264/ywatanabe/ci/apptainer-tmp`
    failed on a filesystem that does not exist.

Everyday CI in this repo does not go through this shim, so the repo looks
healthy -- the breakage would only have surfaced at RELEASE time.

Three decisions are now probed INDEPENDENTLY from the host rather than
assumed:

  1. apptainer -- SCITEX_CI_APPTAINER when it points at an executable,
     otherwise `command -v apptainer`. Only when NEITHER resolves is that
     an error, and the message names both attempts. Never a silent
     fallback to a bare-runner install.
  2. scratch -- the GPFS project scratch when that directory exists,
     otherwise host-local $HOME/.cache/scitex-ci/apptainer-tmp.
  3. --bind /data/gpfs/projects/punim0264 -- passed only when the
     directory exists; the argv is built as an array so the flag is
     dropped cleanly instead of being passed as an empty string.

Spartan, where all three of those paths still exist, takes exactly the
same code path it did before and is unchanged.

The resolved plan (apptainer + where it came from, SIF, GPFS present or
absent, scratch dir, and the full command line) is echoed before exec, so
a failure on an unfamiliar runner says which profile it took.

Ported from the reference implementation in scitex-ai/scitex-dev PR #572
(branch ci/sif-shim-host-agnostic), which was executed end to end against
the real 1.2G ci-cpu.sif on a real compute node.
