### PR TITLE
fix(annotations): notify rail imports scitex_cards, not the deleted scitex_todo

### DIFF
--- a/src/scitex_writer/_annotations/_emit.py
+++ b/src/scitex_writer/_annotations/_emit.py
@@ -2,12 +2,12 @@
 # -*- coding: utf-8 -*-
 """The emit seam (§4) — annotation → channel notification.
 
-PROVISIONAL RAIL. The design doc (§4) recommends scitex-todo card events
+PROVISIONAL RAIL. The design doc (§4) recommends scitex-cards card events
 as the durable notification rail, but the exact contract (card model,
 body schema, resolve/close semantics) is pending **scitex-agentic-journal
 ratification** (§5.4). This module keeps the whole mechanism behind a
 single ``emit()`` function so the rail is a swappable impl detail, not an
-API change. Do NOT hard-couple callers to scitex-todo.
+API change. Do NOT hard-couple callers to scitex-cards.
 
 Spike 0 behaviour: ``emit()`` PERSISTS the record (SQLite, ``_db``) and
 POSTS a one-line ``comment_task`` to the manuscript's owning card. Both
@@ -54,19 +54,19 @@ def _notify(
     card_id: str,
     store: Optional[PathLike] = None,
 ) -> Tuple[bool, Optional[str]]:
-    """PROVISIONAL: post the annotation summary to a scitex-todo card.
+    """PROVISIONAL: post the annotation summary to a scitex-cards card.
 
-    Returns ``(notified, notify_error)``. The scitex-todo import is LAZY so
-    the module still imports where scitex-todo is absent (e.g. CI). This is
+    Returns ``(notified, notify_error)``. The scitex-cards import is LAZY so
+    the module still imports where scitex-cards is absent (e.g. CI). This is
     fail-soft for PERSISTENCE (a failed notify never rolls back the row)
     but NOT silent: the reason is surfaced to the caller as ``notify_error``
     (no swallowed exception). ``store`` lets tests point at a tmp
-    ``tasks.yaml`` so the real shared store is never written.
+    store so the real shared one is never written.
     """
     try:
-        from scitex_todo import comment_task
+        from scitex_cards import comment_task
     except ImportError:
-        return False, "scitex-todo not installed — notification rail unavailable"
+        return False, "scitex-cards not installed — notification rail unavailable"
 
     try:
         comment_task(

--- a/tests/integration/test_cross_package_imports.py
+++ b/tests/integration/test_cross_package_imports.py
@@ -30,8 +30,8 @@ CROSS_PACKAGE_IMPORTS = [
     "scitex_dev.skills",
     "scitex_dev.system_deps",
     "scitex_dev.types",
+    "scitex_cards",
     "scitex_scholar",
-    "scitex_todo",
     "scitex_ui",
 ]
 # ===== END AUTO-GENERATED =====

--- a/tests/scitex_writer/_annotations/test__emit.py
+++ b/tests/scitex_writer/_annotations/test__emit.py
@@ -2,9 +2,9 @@
 # -*- coding: utf-8 -*-
 """Tests for scitex_writer._annotations._emit (the emit seam).
 
-The scitex-todo rail is OPTIONAL — tests that assert a comment was posted
-``pytest.importorskip("scitex_todo")`` so they skip where the dep is
-absent (e.g. CI) and run where present. NO mock of scitex_todo
+The scitex-cards rail is OPTIONAL — tests that assert a comment was posted
+``pytest.importorskip("scitex_cards")`` so they skip where the dep is
+absent (e.g. CI) and run where present. NO mock of scitex_cards
 (STX-NM002). Real tmp store isolates the shared ``tasks.yaml``. One assert
 per test (STX-TQ007); no monkeypatch (PA-306).
 """
@@ -25,9 +25,9 @@ def _annotation(text: str = "fix this claim") -> Annotation:
 
 @pytest.fixture
 def todo_store(tmp_path):
-    """A real tmp scitex-todo store seeded with the owning card."""
-    pytest.importorskip("scitex_todo")
-    from scitex_todo import add_task
+    """A real tmp scitex-cards store seeded with the owning card."""
+    pytest.importorskip("scitex_cards")
+    from scitex_cards import add_task
 
     store = tmp_path / "tasks.yaml"
     add_task(
@@ -92,7 +92,7 @@ def test_emit_reports_notified_true_with_seeded_card(tmp_path, todo_store):
 
 def test_emit_posts_comment_to_owning_card(tmp_path, todo_store):
     # Arrange
-    from scitex_todo import get_task
+    from scitex_cards import get_task
 
     db = tmp_path / "writer.db"
     emit(

--- a/tests/scitex_writer/_annotations/test__service.py
+++ b/tests/scitex_writer/_annotations/test__service.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 """Tests for scitex_writer._annotations._service (POST orchestration).
 
-Real SQLite in ``tmp_path``; the scitex-todo rail is optional so the
-notified-True path ``pytest.importorskip("scitex_todo")``. No mocks
+Real SQLite in ``tmp_path``; the scitex-cards rail is optional so the
+notified-True path ``pytest.importorskip("scitex_cards")``. No mocks
 (STX-NM002); one assert per test (STX-TQ007); no monkeypatch (PA-306).
 """
 
@@ -21,9 +21,9 @@ def _body(text: str = "please clarify") -> dict:
 
 @pytest.fixture
 def todo_store(tmp_path):
-    """A real tmp scitex-todo store seeded with the owning card."""
-    pytest.importorskip("scitex_todo")
-    from scitex_todo import add_task
+    """A real tmp scitex-cards store seeded with the owning card."""
+    pytest.importorskip("scitex_cards")
+    from scitex_cards import add_task
 
     store = tmp_path / "tasks.yaml"
     add_task(


### PR DESCRIPTION
## Why this comes from the scitex-cards maintainer

I released the change that stranded this import. scitex-cards **v0.41.0** (on PyPI 2026-08-16 05:29Z) deleted the `scitex_todo` compatibility shim, and this package's annotation notify rail still imported it. Fixing it is mine, not yours.

## Nothing was crashing — the guard held

Worth stating precisely, because the first report of this (mine included) said "breaks production", and that was wrong.

`_emit.py:66-69` is a **lazy, function-scoped import guarded by `except ImportError`** that returns `(False, reason)`. That reason is then propagated rather than dropped:

- `_emit.py:99` captures `notified, notify_error`
- `_emit.py:104-105` puts both in the returned record
- `_service.py:62-63` surfaces both in the service response

So the module imports fine, the annotation row still persists, and the caller is told. Whoever wrote that guard was right, and its docstring says the laziness is deliberate "so the module still imports where the package is absent (e.g. CI)".

## What was actually broken: the message

It said `"scitex-todo not installed — notification rail unavailable"` — naming a package that exists on **no index**. Anyone following that hint hits a dead end. Constitution §2 asks an error to name the next step; it now names `scitex-cards`, which can actually be installed.

The second real effect: the notification rail goes dark on upgrade. Cards stop receiving annotation comments. Fail-soft, reported — but silent to anyone not reading `notify_error`.

## Verified, not assumed

`scitex_cards` exports all three callables this package uses, checked against the installed package rather than inferred from the shim's old surface:

| callable | present | note |
|---|---|---|
| `comment_task` | yes | signature `(store, task_id, text, by, kind, entry_points)` — compatible with the existing call |
| `add_task` | yes | used by test fixtures |
| `get_task` | yes | used by test assertions |

## One file deliberately NOT changed — please read this part

`tests/scitex_writer/_django/handlers/test_annotation.py` is untouched, on purpose.

Its `isolated_shared_store` fixture is **autouse** and isolates via the environment:

```python
os.environ["SCITEX_TODO_TASKS_YAML_SHARED"] = str(store)
```

**`scitex_cards` does not read that variable.** Its equivalent is `SCITEX_CARDS_TASKS_YAML_SHARED`, and the sole store-identity axis is now `SCITEX_CARDS_DB`.

So flipping that file's import would *activate* tests whose isolation is inert, and the store they fall back to is **resolved, not tmp**. That is a plausible path to writing test cards into the live shared board. It needs the isolation re-pointed and a run to prove it — not a rename. Left skipping, which is the status quo and harmless.

The two test files that **are** flipped isolate by passing `store` as an explicit positional argument with no environment involvement. I checked that rather than assuming it.

## Note on the auto-generated file

`tests/integration/test_cross_package_imports.py` is generated by `scitex-dev ecosystem write-integration-tests` from the source tree. Its entry is updated to what regeneration now produces, so the next regeneration is a no-op rather than a conflict.

## A related defect this surfaced, in your tree and several others

`pytest.importorskip("scitex_todo")` **skips on `ModuleNotFoundError`**, which is an `ImportError` subclass. So the exact deletion these tests exist to notice is converted into a SKIP and the suite reports green — a gate that cannot fail, arriving through the door that looks like caution.

The same shape was found tonight in `sac` (2 call sites) and in `scitex-cards` itself. The fix that distinguishes the two cases:

```python
pytest.importorskip("scitex_cards")          # genuinely-optional package → skip
module = importlib.import_module("scitex_cards.some.submodule")  # renamed/deleted → FAIL
```

I have not applied that here — it is a separate change and this PR is deliberately narrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
